### PR TITLE
docs: canonical deployment guide, runbooks, and release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # Sentinel Trading Platform
 
-Evidence-based systematic trading platform built as a Turborepo monorepo with a Next.js dashboard, a Python quant engine, a TypeScript agent orchestrator, and shared contracts.
+Systematic trading control plane built as a Turborepo monorepo: Next.js dashboard, Python quant engine, TypeScript agent orchestrator, and Supabase-backed state.
 
-## What this repo is today
+## Production Topology
 
-Sentinel already contains:
-- a runnable Next.js dashboard in `apps/web`
-- a FastAPI quant engine in `apps/engine`
-- an Express-based agent orchestration service in `apps/agents`
-- shared TypeScript contracts in `packages/shared`
-- Supabase schema and seed data in `supabase`
+```text
+browser -> Vercel (apps/web)
+              |
+              +-- /api/engine/* --> Railway (apps/engine)
+              +-- /api/agents/* --> Railway (apps/agents)
+              |
+              +-- Supabase (client-side, anon key)
 
-Sentinel is **not yet a finished production trading system**. Some flows still rely on fallback or staged behavior, and deployment guidance should be read together with `docs/deployment.md` before treating the system as production-ready.
+engine  -> Supabase / Polygon / Alpaca
+agents  -> engine / Supabase / Anthropic
+```
 
-## Repository map
+- `apps/web` runs on **Vercel** and is the only public origin.
+- `apps/engine` runs on **Railway** as the quant backend.
+- `apps/agents` runs on **Railway** and is **required** in production.
+- The browser never calls backend services directly. All backend traffic flows through same-origin Next.js route handlers (`/api/engine/*`, `/api/agents/*`).
+- Docker Compose is for **local development only**.
+
+## Repository Map
 
 ```text
 apps/web/        Next.js 16 dashboard (TypeScript, port 3000)
@@ -21,141 +30,90 @@ apps/engine/     Python FastAPI quant engine (port 8000)
 apps/agents/     TypeScript agent orchestrator (port 3001)
 packages/shared/ Shared TypeScript contracts (@sentinel/shared)
 supabase/        PostgreSQL migrations and seed data
-docs/            AI guidance, plans, analysis, and deployment docs
+docs/            Deployment guides, runbooks, and AI collaboration docs
 ```
 
-## Architecture at a glance
-
-```text
-browser -> apps/web (Next.js)
-              |\
-              | server-side service calls
-              v
-          apps/engine (FastAPI) <--- apps/agents (Express)
-              |
-              v
-           Supabase
-```
-
-### Current app boundaries
-- `apps/web` talks to `apps/engine` over HTTP.
-- `apps/agents` talks to `apps/engine` through its server-side `EngineClient`.
-- `apps/web` and `apps/agents` share contracts from `packages/shared`.
-- Supabase is the persistence boundary for application data. See `docs/ai/architecture.md` for the more detailed version used in implementation work.
-
-## Recommended deployment model
-
-The simplest deployment target for Sentinel is:
-- **public:** `apps/web`
-- **private/internal:** `apps/engine`
-- **optional for first production:** `apps/agents`, unless the human owner chooses to make it required
-
-The repo currently includes:
-- `docker-compose.yml` for local multi-service development
-- `vercel.json` for web deployment behavior
-- `apps/engine/railway.toml` for engine deployment on Railway
-
-Read `docs/deployment.md` for the canonical deployment guide, current platform assumptions, environment ownership, and rollout guidance.
-
-## Quick start
+## Quick Start
 
 ### Prerequisites
-- Node 22+
-- pnpm 10.32.1
-- Python 3.12+
-- an engine virtualenv at `apps/engine/.venv`
-- a populated `.env` created from `.env.example`
+
+- Node 22+ and pnpm 10.32.1
+- Python 3.12+ and uv
+- A populated `.env` (copy from `.env.example`)
 
 ### Setup
+
 ```bash
-cp .env.example .env
+cp .env.example .env    # fill in credentials
 pnpm install
 ```
 
-Then populate required Supabase, Polygon, Alpaca, Anthropic, engine, and agents values in `.env`.
+### Local Development
 
-### Start local services
+**Node workspaces only** (web + agents):
+
 ```bash
 pnpm dev
 ```
 
-For a full local multi-service container stack, use:
+**Engine separately** (Python, not managed by Turborepo):
+
+```bash
+cd apps/engine
+uv run python -m uvicorn src.api.main:app --reload --port 8000
+```
+
+**Full local stack** (all three services via Docker):
+
 ```bash
 docker compose up --build
 ```
 
-## Validation commands
+## Validation
 
-### Canonical root commands
 ```bash
-pnpm dev
-pnpm lint
-pnpm test
-pnpm build
-pnpm test:web
-pnpm test:web:e2e
-pnpm test:agents
-pnpm lint:engine
-pnpm format:check:engine
-pnpm test:engine
+pnpm lint               # Node workspaces
+pnpm test               # Node workspaces
+pnpm build              # Node workspaces
+pnpm test:web           # web unit tests
+pnpm test:agents        # agents unit tests
+pnpm lint:engine        # ruff lint
+pnpm format:check:engine # ruff format check
+pnpm test:engine        # pytest
 ```
 
-### Important validation note
-`pnpm lint`, `pnpm test`, and `pnpm build` cover the Node/Turborepo workspaces only. The Python engine must be validated separately with the engine commands above.
+`pnpm lint`, `pnpm test`, and `pnpm build` cover Node workspaces only. The engine must be validated separately.
 
-## Environment model
+## Deployment
 
-Use `.env.example` as the source list of variables.
+| Service | Host    | Entry Point                       |
+| ------- | ------- | --------------------------------- |
+| Web     | Vercel  | Public (browser)                  |
+| Engine  | Railway | Private (Vercel server-side only) |
+| Agents  | Railway | Private (Vercel server-side only) |
 
-Broadly:
-- `NEXT_PUBLIC_*` values are browser-exposed and should be treated as public configuration
-- `ENGINE_URL`, `AGENTS_URL`, API keys, service-role keys, and broker credentials are server-side values
-- production deployments should prefer internal URLs between `web`, `engine`, and `agents` whenever possible
+See [docs/deployment.md](docs/deployment.md) for the full deployment guide, environment ownership, cutover order, and smoke tests.
 
-The full environment ownership and deployment matrix lives in `docs/deployment.md`.
+## Runbooks
 
-## Deployment assets in this repo
+- [Local Development](docs/runbooks/local.md)
+- [Preview Deployment](docs/runbooks/preview.md)
+- [Production Deployment](docs/runbooks/production.md)
+- [Troubleshooting](docs/runbooks/troubleshooting.md)
+- [Release Checklist](docs/runbooks/release-checklist.md)
 
-- `docker-compose.yml` — local development stack for `web`, `engine`, and `agents`
-- `apps/web/Dockerfile` — web container build
-- `apps/agents/Dockerfile` — agents container build
-- `apps/engine/Dockerfile` — engine container build
-- `vercel.json` — Vercel deployment behavior for the web app
-- `apps/engine/railway.toml` — Railway deployment config for the engine
-
-## Contributor guardrails
+## Contributor Guardrails
 
 Before changing code, read:
+
 1. `AGENTS.md`
 2. `docs/ai/working-agreement.md`
 3. `docs/ai/architecture.md`
 4. `docs/ai/commands.md`
-5. `docs/ai/review-checklist.md`
-6. `docs/ai/state/project-state.md`
-7. `docs/ai/agent-ops.md`
 
 Key rules:
-- do not casually modify migrations, shared contracts, package manager files, or deployment-critical config
-- web-to-engine requests must follow the approved fetch path
-- preserve `OfflineBanner` and `SimulatedBadge` behavior
-- prefer minimal diffs and explicit validation reporting
 
-## Known gaps / maturity notes
-
-Sentinel is still in an implementation phase. Known categories of incomplete or evolving work include:
-- deployment simplification and runbooks
-- centralization of service URL and health-check behavior
-- README and operator documentation expansion
-- decisions on whether `apps/agents` is mandatory for first production
-
-Track current work in `docs/ai/state/project-state.md` and the deployment/readme roadmap in `docs/ai/roadmaps/2026-03-20-deployment-readme-roadmap.md`.
-
-## Additional docs
-
-- `docs/deployment.md` — canonical deployment guide
-- `docs/ai/working-agreement.md` — collaboration rules
-- `docs/ai/architecture.md` — system boundaries and sensitive paths
-- `docs/ai/commands.md` — canonical validation commands
-- `docs/ai/review-checklist.md` — handoff/review checklist
-- `docs/ai/agent-ops.md` — Claude Code + Codex operating rules
-- `docs/ai/state/project-state.md` — live project state ledger
+- Do not modify migrations, shared contracts, or deployment config without review.
+- Web-to-engine requests must go through `/api/engine/*` proxy routes.
+- Preserve `OfflineBanner` and `SimulatedBadge` outage UX.
+- Prefer minimal diffs and explicit validation reporting.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,196 +1,177 @@
 # Sentinel Deployment Guide
 
-This is the canonical deployment reference for the Sentinel Trading Platform.
+Canonical deployment reference. One supported production topology. No ambiguity.
 
-## Goal
-
-Make deployment easy to explain and safe to operate by defining:
-- the supported runtime topology
-- which services are public vs internal
-- the current deployment assets in the repo
-- environment-variable ownership by runtime
-- first-production recommendations and open decisions
-
-## Current runtime topology
-
-Sentinel currently consists of three application services plus Supabase:
+## Production Topology
 
 ```text
-browser -> web (Next.js, port 3000)
-web -> engine (FastAPI, port 8000)
-web -> agents (Express, port 3001)  [current code path exists]
-agents -> engine
-engine -> Supabase / external providers
-agents -> Supabase / Anthropic / engine
+browser -> Vercel (apps/web)
+              |
+              +-- /api/engine/* --> Railway engine
+              +-- /api/agents/* --> Railway agents
+
+engine  -> Supabase, Polygon, Alpaca
+agents  -> engine, Supabase, Anthropic
 ```
 
-## Current deployment assets
+- **Web** runs on Vercel. It is the only public origin.
+- **Engine** runs on Railway. Internal only.
+- **Agents** runs on Railway. Internal only. **Required in production.**
+- **Docker Compose** is local development only. Not a production path.
+- The browser never calls backend services directly. All backend traffic flows through same-origin `/api/engine/*` and `/api/agents/*` route handlers.
 
-### Local multi-service stack
-- `docker-compose.yml`
-  - runs `engine`, `agents`, and `web`
-  - wires internal service URLs between containers
-  - exposes ports 8000, 3001, and 3000 locally
+## Environment Ownership by Runtime
 
-### Web deployment
-- `vercel.json`
-  - currently configures an `ignoreCommand` for web/shared changes
-  - implies Vercel is expected to host the web app
+### Vercel (apps/web) -- Browser-Safe
 
-### Engine deployment
-- `apps/engine/railway.toml`
-  - provides a Railway deployment definition for the engine
+| Variable                        | Purpose               |
+| ------------------------------- | --------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase API endpoint |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase public auth  |
 
-### Container assets
-- `apps/web/Dockerfile`
-- `apps/agents/Dockerfile`
-- `apps/engine/Dockerfile`
+### Vercel (apps/web) -- Server-Side Only
 
-These assets should be treated as one deployment system, not three unrelated deployment stories.
+| Variable                    | Purpose                                                   |
+| --------------------------- | --------------------------------------------------------- |
+| `ENGINE_URL`                | Railway engine URL (e.g. `https://engine.up.railway.app`) |
+| `ENGINE_API_KEY`            | Engine authentication key                                 |
+| `AGENTS_URL`                | Railway agents URL (e.g. `https://agents.up.railway.app`) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Privileged Supabase access                                |
 
-## Recommended deployment model
+### Railway Engine (apps/engine)
 
-### First production recommendation
+| Variable                    | Purpose                         |
+| --------------------------- | ------------------------------- |
+| `POLYGON_API_KEY`           | Market data provider            |
+| `ALPACA_API_KEY`            | Broker authentication           |
+| `ALPACA_SECRET_KEY`         | Broker secret                   |
+| `ALPACA_BASE_URL`           | Paper vs live endpoint          |
+| `BROKER_MODE`               | `paper` or `live`               |
+| `SUPABASE_SERVICE_ROLE_KEY` | Database access                 |
+| `NEXT_PUBLIC_SUPABASE_URL`  | Database endpoint               |
+| `ENGINE_API_KEY`            | Validates inbound auth          |
+| `CORS_ORIGINS`              | Allowed origins (Vercel domain) |
+| `PORT`                      | Railway-assigned port (auto)    |
 
-Use a split deployment model:
-- **Public:** `web`
-- **Private/internal:** `engine`
-- **Optional for first production:** `agents` unless the human owner decides otherwise
+### Railway Agents (apps/agents)
 
-### Why this is the easiest model
+| Variable                    | Purpose                      |
+| --------------------------- | ---------------------------- |
+| `ENGINE_URL`                | Engine service URL           |
+| `ANTHROPIC_API_KEY`         | LLM provider                 |
+| `SUPABASE_SERVICE_ROLE_KEY` | Database access              |
+| `SUPABASE_URL`              | Database endpoint            |
+| `PORT`                      | Railway-assigned port (auto) |
 
-It minimizes:
-- cross-origin browser configuration
-- the number of public endpoints
-- duplicated health-check and auth complexity
-- the amount of deployment coordination required across providers
+### Deprecated (Remove After Cutover)
 
-### Recommended target shape
+| Variable                     | Replacement                    |
+| ---------------------------- | ------------------------------ |
+| `NEXT_PUBLIC_ENGINE_URL`     | `ENGINE_URL` (server-side)     |
+| `NEXT_PUBLIC_ENGINE_API_KEY` | `ENGINE_API_KEY` (server-side) |
+| `NEXT_PUBLIC_AGENTS_URL`     | `AGENTS_URL` (server-side)     |
 
-```text
-Public internet
-  -> web (Vercel or equivalent)
-       -> engine over internal/private URL
-       -> agents over internal/private URL if enabled
+These exist only during migration. The browser must not depend on them in production.
 
-Private services
-  -> engine (Railway or container host)
-  -> agents (same backend host class as engine, if enabled)
-```
+## Service Configuration
 
-## Current reality vs recommended target
+All upstream URL resolution, auth headers, timeouts, and retries are centralized in `apps/web/src/lib/server/service-config.ts`. No other file should duplicate this logic.
 
-### Already present in the repo
-- local Compose supports all three services
-- web build/deploy behavior exists
-- engine deploy behavior exists
-- service configuration logic already supports internal server-side URLs through `ENGINE_URL` and `AGENTS_URL`
+### Timeout Policy
 
-### Still to be completed
-- browser-facing data access is not fully normalized behind same-origin web routes
-- agents posture for first production remains a human decision
-- a complete env ownership table is not yet reflected in `.env.example`
-- runbooks for deploy/smoke-test/rollback still need to be added
+| Route Pattern             | Timeout | Retries |
+| ------------------------- | ------- | ------- |
+| `/health`                 | 4s      | 1       |
+| `/api/v1/strategies/scan` | 70s     | 2 (GET) |
+| `/api/v1/backtest/run`    | 45s     | 2 (GET) |
+| `/api/v1/data/quotes`     | 15s     | 2 (GET) |
+| Engine GET (default)      | 10s     | 2       |
+| Engine POST (default)     | 15s     | 1       |
+| Agents GET (default)      | 6s      | 2       |
+| Agents POST (default)     | 8s      | 1       |
 
-## Service exposure model
+### Production Safety
 
-### `web`
-- **Audience:** public internet
-- **Purpose:** browser UI and Next.js routes
-- **Should know about:** internal `ENGINE_URL`, internal `AGENTS_URL` if enabled, public Supabase settings
-- **Should expose:** only browser-safe `NEXT_PUBLIC_*` configuration
+- `localhost` and `127.0.0.1` URLs are rejected in production (`NODE_ENV=production` or `VERCEL=1`).
+- Missing `ENGINE_URL` or `AGENTS_URL` returns `not_configured` errors, not silent fallback.
+- `OfflineBanner` and `SimulatedBadge` remain the user-facing outage UX.
 
-### `engine`
-- **Audience:** internal callers and local development
-- **Purpose:** quant engine, data/risk/portfolio APIs
-- **Should know about:** provider credentials, broker credentials, Supabase server-side access, CORS config
-- **Should not be public unless explicitly required**
+## Health Endpoints
 
-### `agents`
-- **Audience:** internal callers and local development
-- **Purpose:** orchestration, alerts, recommendations
-- **Should know about:** Anthropic key, engine URL, Supabase server-side access
-- **Production posture:** pending explicit human decision
+| Service | Endpoint                   | Expected                    |
+| ------- | -------------------------- | --------------------------- |
+| Engine  | `GET /health`              | 200                         |
+| Agents  | `GET /health`              | 200                         |
+| Agents  | `GET /status`              | 200 + orchestrator state    |
+| Web     | `GET /api/health`          | 200                         |
+| Web     | `GET /api/settings/status` | Service connectivity report |
 
-## Environment ownership matrix
+## Deployment Assets
 
-| Variable | Runtime(s) | Visibility | Used for | Notes |
-| --- | --- | --- | --- | --- |
-| `NEXT_PUBLIC_SUPABASE_URL` | web browser, web server | public | browser and server Supabase base URL | Safe for browser exposure. |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | web browser, web server | public | browser Supabase client auth | Safe for browser exposure. |
-| `SUPABASE_SERVICE_ROLE_KEY` | web server, engine, agents | secret | privileged Supabase access | Never expose client-side. |
-| `POLYGON_API_KEY` | engine, possibly web server status checks | secret | market data provider auth | Keep server-side. |
-| `ALPACA_API_KEY` | engine, possibly web server status checks | secret | broker auth | Keep server-side. |
-| `ALPACA_SECRET_KEY` | engine, possibly web server status checks | secret | broker auth | Keep server-side. |
-| `ALPACA_BASE_URL` | engine, web server checks | internal | broker endpoint selection | Paper vs live must be explicit. |
-| `BROKER_MODE` | engine | internal | broker mode selection | Prefer `paper` by default. |
-| `ANTHROPIC_API_KEY` | agents, possibly web server status checks | secret | LLM provider auth | Keep server-side. |
-| `NEXT_PUBLIC_ENGINE_URL` | web browser, web server | public/internal | direct browser engine calls in current implementation | Prefer same-origin web routes over long-term direct browser use. |
-| `ENGINE_URL` | web server, agents | internal | server-to-engine calls | Preferred production path. |
-| `ENGINE_API_KEY` | web server, agents | secret/internal | engine auth | Server-side preferred. |
-| `NEXT_PUBLIC_ENGINE_API_KEY` | web browser | public | current browser engine auth path | Reduce or remove from browser exposure where feasible. |
-| `CORS_ORIGINS` | engine | internal | allowed origins for engine | Must match deployed web origin(s). |
-| `NEXT_PUBLIC_AGENTS_URL` | web browser, web server | public/internal | current browser agents calls | Prefer same-origin web proxy or mark agents optional. |
-| `AGENTS_URL` | web server | internal | server-to-agents calls | Preferred production path. |
-| `AGENTS_PORT` | agents | internal | agents service port | Used by local and container runtime. |
-| `DATA_INGESTION_INTERVAL_MINUTES` | engine | internal | engine scheduling | Operational tuning. |
-| `SIGNAL_GENERATION_INTERVAL_MINUTES` | engine | internal | engine scheduling | Operational tuning. |
-| `RISK_UPDATE_INTERVAL_MINUTES` | engine | internal | engine scheduling | Operational tuning. |
+| File                       | Purpose                         | Environment |
+| -------------------------- | ------------------------------- | ----------- |
+| `docker-compose.yml`       | Full local stack                | Local only  |
+| `apps/web/Dockerfile`      | Web container                   | Local / CI  |
+| `apps/engine/Dockerfile`   | Engine container                | Railway     |
+| `apps/agents/Dockerfile`   | Agents container                | Railway     |
+| `vercel.json`              | Change-detection ignore command | Vercel      |
+| `apps/engine/railway.toml` | Health check + restart policy   | Railway     |
 
-## Supported deployment modes
+## Cutover Order
 
-### Mode 1 — Local development
-Use `docker compose up --build` when you want the full local multi-service stack with service health checks.
+1. Verify local tests pass (all three apps)
+2. Deploy engine to Railway, confirm `/health` returns 200
+3. Deploy agents to Railway, confirm `/health` returns 200
+4. Set `ENGINE_URL`, `ENGINE_API_KEY`, `AGENTS_URL` on Vercel (preview + production)
+5. Deploy Vercel preview
+6. Run preview smoke tests (see [Release Checklist](runbooks/release-checklist.md))
+7. Deploy Vercel production
+8. Run production smoke tests
+9. Remove deprecated `NEXT_PUBLIC_ENGINE_URL`, `NEXT_PUBLIC_ENGINE_API_KEY`, `NEXT_PUBLIC_AGENTS_URL` from Vercel
+10. Decommission stale Railway services
 
-### Mode 2 — Web preview deployment
-Deploy `web` as the public entry point, but only if reachable backend URLs and required env values are configured.
+Do not remove old env vars or stale services until both preview and production pass smoke tests.
 
-### Mode 3 — First production deployment
-Recommended baseline:
-- web deployed publicly
-- engine deployed privately
-- agents either deployed privately or intentionally disabled until the owner confirms it is required
+## Rollback
 
-## Health checks
+### Vercel
 
-### Existing health endpoints
-- engine: `/health`
-- agents: `/health`
-- web: homepage response used in Docker health check
+Redeploy the previous production build from the Vercel dashboard (Deployments > previous READY build > Promote to Production).
 
-### Operational recommendation
-For production smoke tests, verify:
-1. web loads successfully
-2. web server can reach engine health
-3. web server can reach agents health if agents is enabled
-4. required external credentials are present in the correct runtime
+### Railway
 
-## Open decisions
+Each Railway deployment is versioned. Roll back to the previous deployment from the Railway dashboard.
 
-### Decision 1 — Is `agents` required for first production?
-Owner decision required.
+### Config Rollback
 
-Impact:
-- determines whether first production includes a third runtime
-- affects README wording, web behavior, and route proxy requirements
+If the failure is env-related, restore the previous env values in the Vercel/Railway dashboard and redeploy.
 
-### Decision 2 — Preferred backend hosting style
-Owner decision required:
-- Vercel + Railway
-- Vercel + general container host
-- full container-host deployment
+## Smoke Tests
 
-Impact:
-- shapes runbook examples
-- determines recommended internal networking assumptions
+After every deploy, verify:
 
-## Implementation follow-ups
+| Check          | URL                    | Expected                            |
+| -------------- | ---------------------- | ----------------------------------- |
+| Engine health  | `/api/engine/health`   | 200                                 |
+| Agents health  | `/api/agents/health`   | 200                                 |
+| Agents status  | `/api/agents/status`   | 200 + agent states                  |
+| Service status | `/api/settings/status` | engine + agents connected           |
+| Settings page  | `/settings`            | All services show connected         |
+| Agents page    | `/agents`              | Controls enabled, no offline banner |
+| Dashboard      | `/`                    | No localhost fallback in UI         |
 
-The next practical implementation steps are:
-1. inventory browser calls that still hit engine or agents directly
-2. proxy those calls through Next.js routes where appropriate
-3. centralize service URL/auth/timeout logic in the web server layer
-4. add deploy, smoke-test, and rollback runbooks
-5. align `.env.example` comments with the ownership matrix above
+Also verify in Vercel runtime logs:
 
-Track those tasks in `docs/ai/state/project-state.md` and the roadmap in `docs/ai/roadmaps/2026-03-20-deployment-readme-roadmap.md`.
+- No `not_configured` errors
+- No `localhost` in upstream URLs
+- No leaked auth headers
+
+## Port Binding
+
+| Service | Priority                           | Default |
+| ------- | ---------------------------------- | ------- |
+| Engine  | Dockerfile `--port 8000`           | 8000    |
+| Agents  | `PORT` > `AGENTS_PORT` > hardcoded | 3001    |
+| Web     | Next.js default                    | 3000    |
+
+Railway sets `PORT` automatically. Both backend Dockerfiles must respect it.

--- a/docs/runbooks/local.md
+++ b/docs/runbooks/local.md
@@ -1,0 +1,92 @@
+# Local Development Runbook
+
+## Prerequisites
+
+- Node 22+ and pnpm 10.32.1
+- Python 3.12+ and uv
+- Docker (for full-stack mode)
+
+## Environment Setup
+
+```bash
+cp .env.example .env
+pnpm install
+```
+
+Fill in all required values in `.env`. At minimum:
+
+| Variable                        | Where to get it                      |
+| ------------------------------- | ------------------------------------ |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase dashboard > Settings > API  |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Same location                        |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Same location (secret)               |
+| `POLYGON_API_KEY`               | polygon.io dashboard                 |
+| `ALPACA_API_KEY`                | alpaca.markets dashboard (paper)     |
+| `ALPACA_SECRET_KEY`             | Same location                        |
+| `ANTHROPIC_API_KEY`             | console.anthropic.com                |
+| `ENGINE_API_KEY`                | Any string (e.g. `sentinel-dev-key`) |
+
+## Option 1: Node Workspaces Only
+
+```bash
+pnpm dev
+```
+
+Starts `apps/web` (port 3000) and `apps/agents` (port 3001) via Turborepo. Does **not** start the Python engine.
+
+## Option 2: Engine Separately
+
+```bash
+cd apps/engine
+uv venv .venv
+uv pip install -e ".[dev]"
+uv run python -m uvicorn src.api.main:app --reload --port 8000
+```
+
+Run this alongside `pnpm dev` for the full stack without Docker.
+
+## Option 3: Full Stack via Docker Compose
+
+```bash
+docker compose up --build
+```
+
+Starts all three services:
+
+| Service | Port | Internal URL         |
+| ------- | ---- | -------------------- |
+| web     | 3000 | `http://web:3000`    |
+| engine  | 8000 | `http://engine:8000` |
+| agents  | 3001 | `http://agents:3001` |
+
+Compose wires internal URLs between containers automatically. The web app uses the same-origin proxy routes in the browser.
+
+## Smoke Checks
+
+After starting services, verify:
+
+- http://localhost:3000 -- dashboard loads
+- http://localhost:8000/health -- engine responds
+- http://localhost:3001/health -- agents responds
+- http://localhost:3000/api/settings/status -- all services connected
+
+## Validation
+
+```bash
+pnpm lint                 # Node workspaces
+pnpm test                 # Node workspaces
+pnpm build                # Node workspaces (build check)
+pnpm test:web             # web unit tests
+pnpm test:agents          # agents unit tests
+pnpm lint:engine          # ruff lint
+pnpm format:check:engine  # ruff format check
+pnpm test:engine          # pytest
+```
+
+## Gotchas
+
+- `pnpm dev` does not start the engine. Start it separately or use Docker Compose.
+- The browser should use `/api/engine/*` and `/api/agents/*` routes, not direct backend URLs.
+- Never commit `.env`. It is gitignored.
+- Keep `localhost`-based env values out of Vercel preview/production.
+- If agents fail to start, check that `ANTHROPIC_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `ENGINE_URL` are set.

--- a/docs/runbooks/preview.md
+++ b/docs/runbooks/preview.md
@@ -1,0 +1,64 @@
+# Preview Deployment Runbook
+
+Preview should behave identically to production. Same topology, same proxy routes, different URLs.
+
+## Topology
+
+```text
+Vercel preview URL -> Railway engine -> Supabase / Polygon / Alpaca
+                   -> Railway agents -> engine / Supabase / Anthropic
+```
+
+## Pre-Deploy Checklist
+
+- [ ] Railway engine is deployed and `/health` returns 200
+- [ ] Railway agents is deployed and `/health` returns 200
+- [ ] Vercel preview env vars set:
+  - `ENGINE_URL` = Railway engine public URL
+  - `ENGINE_API_KEY` = engine auth key
+  - `AGENTS_URL` = Railway agents public URL
+  - `NEXT_PUBLIC_SUPABASE_URL` = Supabase API URL
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY` = Supabase anon key
+  - `SUPABASE_SERVICE_ROLE_KEY` = Supabase service role key
+
+## Deploy
+
+1. Push to a feature branch or open a PR.
+2. Vercel auto-creates a preview deployment (if `apps/web` or `packages/shared` changed).
+3. Wait for the Vercel build to complete.
+
+If Vercel skips the deployment, it means the commit didn't touch `apps/web` or `packages/shared` (the `ignoreCommand` in `vercel.json`).
+
+## Smoke Tests
+
+Check these on the preview URL:
+
+| Check          | Path                   | Expected                  |
+| -------------- | ---------------------- | ------------------------- |
+| Engine health  | `/api/engine/health`   | 200                       |
+| Agents health  | `/api/agents/health`   | 200                       |
+| Agents status  | `/api/agents/status`   | 200 + orchestrator state  |
+| Service status | `/api/settings/status` | engine + agents connected |
+
+### Page Smoke
+
+- `/` -- dashboard loads, no offline banner
+- `/settings` -- engine and agents show connected
+- `/agents` -- controls enabled, agent states visible
+- `/portfolio` -- loads without errors
+- `/signals` -- loads without errors
+- `/backtest` -- loads without errors
+
+### Verify No Direct Backend Access
+
+Open browser DevTools Network tab. Confirm:
+
+- No requests to Railway URLs from the browser
+- All engine/agents traffic goes through `/api/engine/*` and `/api/agents/*`
+- No `NEXT_PUBLIC_ENGINE_URL` or `NEXT_PUBLIC_AGENTS_URL` in client JS bundle
+
+## Rollback
+
+1. Redeploy the previous Vercel preview build from the dashboard.
+2. If the issue is backend-side, roll Railway back to the previous deployment.
+3. Re-check `/api/settings/status` and `/api/agents/health`.

--- a/docs/runbooks/production.md
+++ b/docs/runbooks/production.md
@@ -1,0 +1,109 @@
+# Production Deployment Runbook
+
+Production runs on one public origin with private backend services. Agents are required.
+
+## Topology
+
+```text
+Public:   Vercel (apps/web)
+Private:  Railway engine, Railway agents
+Database: Supabase (us-east-1)
+```
+
+## Pre-Deploy Checklist
+
+- [ ] All CI checks pass on the branch being deployed
+- [ ] Preview deployment passes all smoke tests (see [preview runbook](preview.md))
+- [ ] Railway engine is healthy (`/health` returns 200)
+- [ ] Railway agents is healthy (`/health` returns 200)
+- [ ] Vercel production env vars are set:
+  - `ENGINE_URL` = Railway engine URL
+  - `ENGINE_API_KEY` = engine auth key
+  - `AGENTS_URL` = Railway agents URL
+  - `NEXT_PUBLIC_SUPABASE_URL` = Supabase URL
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY` = Supabase anon key
+  - `SUPABASE_SERVICE_ROLE_KEY` = Supabase service role key
+
+## Deploy Order
+
+1. Confirm Railway engine and agents are healthy.
+2. Merge the PR to `main` (or push to `main`).
+3. Vercel auto-deploys production (if `apps/web` or `packages/shared` changed).
+4. Wait for the Vercel build to reach `READY` state.
+5. Run production smoke tests.
+
+If you need to force a deploy without a commit:
+
+```bash
+cd apps/web && vercel --prod
+```
+
+## Production Smoke Tests
+
+| Check          | Path                   | Expected                                 |
+| -------------- | ---------------------- | ---------------------------------------- |
+| Engine health  | `/api/engine/health`   | 200                                      |
+| Agents health  | `/api/agents/health`   | 200                                      |
+| Agents status  | `/api/agents/status`   | 200 + orchestrator state                 |
+| Service status | `/api/settings/status` | engine + agents connected                |
+| Settings page  | `/settings`            | All services connected                   |
+| Agents page    | `/agents`              | Controls enabled                         |
+| Dashboard      | `/`                    | No offline banner, no localhost fallback |
+
+### Verify in Logs
+
+Check Vercel runtime logs for:
+
+- No `not_configured` errors
+- No `localhost` in upstream URLs
+- No auth header leakage in responses
+
+Check Railway logs for:
+
+- Clean startup messages
+- Correct port binding (`PORT` env var)
+- Health check responses
+
+## Cutover Rules
+
+- Do not remove deprecated env vars until production passes smoke tests.
+- Keep the previous Vercel deployment available for instant rollback.
+- Keep the previous Railway deployment available until the new backend is confirmed stable.
+
+## Post-Cutover Cleanup
+
+After production is verified stable:
+
+1. Remove deprecated Vercel env vars:
+   - `NEXT_PUBLIC_ENGINE_URL`
+   - `NEXT_PUBLIC_ENGINE_API_KEY`
+   - `NEXT_PUBLIC_AGENTS_URL`
+2. Decommission stale Railway services (placeholder or duplicate services).
+3. Verify that removing deprecated vars doesn't break anything by redeploying.
+
+## Rollback
+
+### Vercel
+
+1. Go to Vercel Dashboard > Deployments.
+2. Find the last `READY` deployment before the broken one.
+3. Click "..." > "Promote to Production."
+
+Or via CLI:
+
+```bash
+vercel rollback <deployment-id>
+```
+
+### Railway
+
+1. Go to Railway Dashboard > Service > Deployments.
+2. Click the previous healthy deployment > "Redeploy."
+
+### Config Rollback
+
+If the failure is env-related:
+
+1. Restore previous env values in Vercel/Railway dashboards.
+2. Trigger a redeploy (env changes require redeployment to take effect).
+3. Re-run smoke tests.

--- a/docs/runbooks/release-checklist.md
+++ b/docs/runbooks/release-checklist.md
@@ -1,0 +1,83 @@
+# Release Checklist
+
+Use this checklist for every production release. Complete each section in order.
+
+## 1. Local Validation
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes (web + agents)
+- [ ] `pnpm build` passes (web build check)
+- [ ] `pnpm test:web` passes
+- [ ] `pnpm test:agents` passes
+- [ ] `pnpm lint:engine` passes
+- [ ] `pnpm format:check:engine` passes
+- [ ] `pnpm test:engine` passes
+- [ ] No untracked files that should be committed (`git status`)
+
+## 2. Code Review Gate
+
+- [ ] PR has been reviewed and approved
+- [ ] CI pipeline passes all jobs (test-web, test-engine, test-agents)
+- [ ] No `NEXT_PUBLIC_ENGINE_URL` or `NEXT_PUBLIC_AGENTS_URL` referenced in new client-side code
+- [ ] No backend URLs or auth keys exposed to the browser
+- [ ] No `localhost` URLs hardcoded in production code paths
+- [ ] If API routes changed: proxy routes still forward correctly
+- [ ] If env vars changed: deployment guide updated
+
+## 3. Railway Backend Deploy
+
+- [ ] Engine deployed to Railway
+- [ ] Engine `/health` returns 200
+- [ ] Engine logs show clean startup and correct port binding
+- [ ] Agents deployed to Railway
+- [ ] Agents `/health` returns 200
+- [ ] Agents `/status` returns orchestrator state
+- [ ] Agents logs show clean startup and correct port binding
+
+## 4. Vercel Preview
+
+- [ ] Vercel preview env vars set (`ENGINE_URL`, `ENGINE_API_KEY`, `AGENTS_URL`)
+- [ ] Preview deployment reaches `READY` state
+- [ ] `/api/engine/health` returns 200
+- [ ] `/api/agents/health` returns 200
+- [ ] `/api/settings/status` reports engine + agents connected
+- [ ] `/settings` page shows all services connected
+- [ ] `/agents` page loads with controls enabled
+- [ ] `/` dashboard loads without offline banner
+- [ ] Browser DevTools Network tab: no direct backend requests
+
+## 5. Vercel Production
+
+- [ ] Merge PR to `main`
+- [ ] Vercel production deployment reaches `READY` state
+- [ ] `/api/engine/health` returns 200
+- [ ] `/api/agents/health` returns 200
+- [ ] `/api/settings/status` reports engine + agents connected
+- [ ] `/settings` page shows all services connected
+- [ ] `/agents` page loads with controls enabled
+- [ ] `/` dashboard loads without offline banner
+
+## 6. Log Verification
+
+- [ ] Vercel runtime logs: no `not_configured` errors
+- [ ] Vercel runtime logs: no `localhost` in upstream URLs
+- [ ] Vercel runtime logs: no auth header leakage
+- [ ] Railway engine logs: clean startup
+- [ ] Railway agents logs: clean startup
+
+## 7. Post-Release Cleanup
+
+Only after production is verified stable:
+
+- [ ] Remove deprecated Vercel env vars (`NEXT_PUBLIC_ENGINE_URL`, `NEXT_PUBLIC_ENGINE_API_KEY`, `NEXT_PUBLIC_AGENTS_URL`)
+- [ ] Decommission stale Railway services
+- [ ] Verify removal doesn't break anything (redeploy and re-check)
+
+## Rollback Trigger
+
+If any production smoke test fails:
+
+1. **Vercel:** Promote the previous `READY` deployment to production.
+2. **Railway:** Redeploy the previous healthy deployment.
+3. **Config:** Restore previous env values and redeploy.
+4. **Investigate:** Only debug after traffic is restored to a working state.

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -1,0 +1,153 @@
+# Troubleshooting Runbook
+
+## First Response
+
+1. Identify the environment: local, preview, or production.
+2. Check `/api/settings/status` for a connectivity report.
+3. Check `/api/engine/health` and `/api/agents/health`.
+4. Read Vercel runtime logs (if Vercel deployment).
+5. Read Railway service logs (if backend issue).
+
+## Common Symptoms
+
+### `not_configured`
+
+The web server cannot find a valid upstream URL for the service.
+
+**Causes:**
+
+- `ENGINE_URL` or `AGENTS_URL` missing from Vercel env vars.
+- URL is set to `localhost` in a production/preview environment.
+- Env var was added but Vercel was not redeployed (env changes require redeployment).
+
+**Fix:**
+
+1. Check Vercel project settings > Environment Variables.
+2. Confirm `ENGINE_URL` and `AGENTS_URL` point to Railway public URLs.
+3. Redeploy after adding/changing env vars.
+
+### `504 Gateway Timeout`
+
+The upstream service is too slow or unreachable.
+
+**Causes:**
+
+- Railway service is down or still starting.
+- Service is not listening on the Railway-assigned `PORT`.
+- Network connectivity between Vercel and Railway is interrupted.
+
+**Fix:**
+
+1. Check Railway dashboard for service status.
+2. Check Railway logs for startup errors or port binding issues.
+3. Verify `PORT` env var is being read by the service entry point.
+4. Try hitting the Railway service URL directly: `curl https://<service>.up.railway.app/health`.
+
+### `401` or `403` from Engine
+
+The engine rejected the request due to auth mismatch.
+
+**Causes:**
+
+- `ENGINE_API_KEY` in Vercel doesn't match `ENGINE_API_KEY` in Railway engine.
+- Auth header format mismatch (expects `Bearer` token or `X-API-Key`).
+
+**Fix:**
+
+1. Confirm the key value matches between Vercel server-side and Railway engine.
+2. Check `service-config.ts` sends both `Authorization: Bearer <key>` and `X-API-Key: <key>`.
+
+### `Offline` Banner in UI
+
+The web app's health polling detected a backend as unreachable.
+
+**Causes (if incorrect):**
+
+- Service is actually up but health probe is timing out (4s timeout).
+- Proxy route is misconfigured.
+- Service URL is localhost in production.
+
+**Fix:**
+
+1. Check `/api/settings/status` for the specific service state.
+2. Check Vercel runtime logs for proxy errors.
+3. Confirm the service responds to `/health` within 4 seconds.
+
+### Vercel Build Failure
+
+**Common causes:**
+
+| Error                                     | Cause                                     | Fix                                         |
+| ----------------------------------------- | ----------------------------------------- | ------------------------------------------- |
+| `Type error: ...`                         | TypeScript error in `apps/web`            | Fix the type error locally, push            |
+| `Cannot find module '@sentinel/shared'`   | Shared package not resolved               | Check `pnpm install` and turbo dependencies |
+| `NEXT_PUBLIC_SUPABASE_URL is not defined` | Missing build-time env var                | Add to Vercel project settings              |
+| Build skipped                             | `ignoreCommand` in `vercel.json` exited 0 | Expected if commit didn't touch `apps/web`  |
+
+### Railway Deployment Failure
+
+**Common causes:**
+
+| Error                          | Cause                           | Fix                                             |
+| ------------------------------ | ------------------------------- | ----------------------------------------------- |
+| `ModuleNotFoundError` (engine) | Missing Python dependency       | Add to `pyproject.toml`, rebuild                |
+| `Cannot find module` (agents)  | Missing Node dependency         | Add to `package.json`, rebuild                  |
+| Port conflict                  | Not using Railway `PORT`        | Ensure entry point reads `process.env.PORT`     |
+| Health check timeout           | App starts slowly or wrong path | Check health endpoint and increase start period |
+
+## Log Inspection
+
+### Vercel Runtime Logs
+
+Via MCP:
+
+```
+Tool: get_runtime_logs
+projectId: prj_IOPutSQDIkXYF1LHfjMQxyMoo5tG
+teamId: team_1jHeAEF8oKm2Z46fqRMdu5uL
+```
+
+Via CLI:
+
+```bash
+vercel logs <deployment-url> --follow
+```
+
+### Railway Logs
+
+Via Railway dashboard: Service > Deployments > View Logs.
+
+### Supabase Logs
+
+Via Supabase dashboard: Project > Logs > Postgres.
+
+Or via MCP:
+
+```
+Tool: get_logs
+project_id: luwyjfwauljwsfsnwiqb
+service: postgres
+```
+
+## Engine Timeout Debugging
+
+1. Verify engine is running: `curl https://<engine>.up.railway.app/health`
+2. Check the specific failing route with the same auth headers.
+3. Look at engine logs for slow query or external API timeout.
+4. Check timeout policy in `service-config.ts` -- some routes have generous timeouts (backtest: 45s, scan: 70s).
+
+## Agents Timeout Debugging
+
+1. Verify agents is running: `curl https://<agents>.up.railway.app/health`
+2. Check `/status` for orchestrator state (is it mid-cycle?).
+3. Confirm `ENGINE_URL` is set in Railway agents env (agents need to reach engine).
+4. Check if `ANTHROPIC_API_KEY` is valid (agents call Claude during cycles).
+
+## Nuclear Option
+
+If everything is broken and you need to get back to a working state:
+
+1. Roll back Vercel to the last known good deployment.
+2. Roll back Railway services to their last known good deployments.
+3. Restore previous env var values if they were changed.
+4. Re-run smoke tests before investigating the root cause.


### PR DESCRIPTION
## Summary

- Rewrite README.md and docs/deployment.md to remove ambiguity: agents required, Vercel+Railway is THE topology
- Add per-runtime environment ownership tables (Vercel browser-safe, Vercel server-side, Railway engine, Railway agents)
- Add release checklist with staged smoke tests and rollback procedures
- Enhance all runbooks with concrete failure patterns, log inspection commands, and Railway-specific troubleshooting

## Files Changed

- `README.md` — definitive topology, no "optional" language
- `docs/deployment.md` — full deployment reference with env ownership, timeout policy, cutover order
- `docs/runbooks/local.md` — env setup, three dev modes, smoke checks
- `docs/runbooks/preview.md` — preview deploy/verify/rollback with DevTools check
- `docs/runbooks/production.md` — production deploy order, log verification, post-cutover cleanup
- `docs/runbooks/troubleshooting.md` — Vercel build failures, Railway deploy failures, log inspection
- `docs/runbooks/release-checklist.md` — **new** — staged checklist from local validation through post-release cleanup

## Test plan

- [x] `git diff --check` passes
- [x] Docs-only change, no runtime code modified
- [x] Cross-checked against actual repo files (service-config.ts, Dockerfiles, docker-compose.yml, vercel.json, railway.toml, index.ts, main.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)