### PR TITLE
fix(engine): align Dockerfile COPY paths with Railway rootDirectory builds

### DIFF
--- a/apps/engine/Dockerfile
+++ b/apps/engine/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir "uv>=0.5"
 # ─── Dependencies layer ───────────────────────────────────────────────────────
 FROM base AS deps
 
-COPY apps/engine/pyproject.toml ./
+COPY pyproject.toml ./
 
 RUN uv venv .venv \
   && uv pip install --python .venv/bin/python --no-cache "."
@@ -23,7 +23,7 @@ FROM base AS runner
 WORKDIR /app
 
 COPY --from=deps /app/.venv ./.venv
-COPY apps/engine/src ./src
+COPY src ./src
 
 RUN addgroup --system --gid 1001 sentinel \
   && adduser --system --uid 1001 --ingroup sentinel sentinel


### PR DESCRIPTION
## Summary

Re-opens the minimal engine deploy fix from `railway/code-change-JX6-rK` as a clean PR against current `main`.

The current `main` commit is still failing the `captivating-abundance - sentinel-engine` deployment status, while the `railway/code-change-JX6-rK` branch has a successful engine deployment. The only code delta is `apps/engine/Dockerfile`, switching COPY paths from repo-root-relative paths to paths relative to `apps/engine`.

## Scope

- Changes only `apps/engine/Dockerfile`
- Leaves web, agents, shared packages, migrations, and runtime code untouched

## Why this is needed

`main` currently uses:

```dockerfile
COPY apps/engine/pyproject.toml ./
COPY apps/engine/src ./src
```

This works only when the Docker build context is the monorepo root. The successful Railway branch uses:

```dockerfile
COPY pyproject.toml ./
COPY src ./src
```

That matches Railway builds where `apps/engine` is the effective build context because `rootDirectory` is configured.

## Validation

- Branch `main` status: engine deployment failing
- Branch `railway/code-change-JX6-rK` status: engine deployment succeeding
- Diff scope verified with GitHub compare: one file changed

## Notes from audit

- The `@sentinel/web` Railway failure appears to be separate from this engine-specific fix.
- The open `deploy/railway-vercel-proxy` PR is heavily diverged and should not be merged as-is.
