### PR TITLE
fix(deploy): repair Railway engine and web Docker builds

### DIFF
--- a/apps/engine/Dockerfile
+++ b/apps/engine/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir "uv>=0.5"
 # ─── Dependencies layer ───────────────────────────────────────────────────────
 FROM base AS deps
 
-COPY apps/engine/pyproject.toml ./
+COPY pyproject.toml ./
 
 RUN uv venv .venv \
   && uv pip install --python .venv/bin/python --no-cache "."
@@ -23,7 +23,7 @@ FROM base AS runner
 WORKDIR /app
 
 COPY --from=deps /app/.venv ./.venv
-COPY apps/engine/src ./src
+COPY src ./src
 
 RUN addgroup --system --gid 1001 sentinel \
   && adduser --system --uid 1001 --ingroup sentinel sentinel

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,10 +21,10 @@ FROM base AS builder
 
 WORKDIR /app
 
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/ ./
 COPY packages/shared ./packages/shared
 COPY apps/web ./apps/web
-COPY package.json pnpm-workspace.yaml ./
+COPY tsconfig.base.json ./
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
@@ -36,7 +36,7 @@ ENV NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
 ENV SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
 
-RUN pnpm --filter web build
+RUN pnpm --filter @sentinel/web build
 
 # ─── Runtime image ────────────────────────────────────────────────────────────
 FROM node:22-alpine AS runner

--- a/docs/ai/state/project-state.md
+++ b/docs/ai/state/project-state.md
@@ -1,6 +1,6 @@
 # Project State Ledger
 
-_Last updated: 2026-03-20_
+_Last updated: 2026-03-21_
 
 This is the live status board for Claude Code, Codex, and human collaborators.
 
@@ -59,6 +59,7 @@ Before editing files:
 | T2.1/T4.2/T5.1-T5.4      | done   | Codex | `work`                             | `docs/deployment.md`, `README.md`, `docs/ai/state/project-state.md`                                                           | `git diff --check`                                                                                                                                                                      | 2026-03-20   | Added the canonical deployment guide and root README, then reflected completion in the state ledger.                                                                                                            |
 | T2.3/T3.3/T3.4/T4.1/T4.3 | done   | Codex | `feat/deployment-canonicalization` | `.env.example`, runtime proxy callers, Docker assets, Compose, runbooks                                                       | `pnpm lint`; `pnpm test:web`; `pnpm test:agents`; `pnpm --filter @sentinel/web build`; `pnpm lint:engine`; `pnpm format:check:engine`; `pnpm test:engine`; preview smoke + runtime logs | 2026-03-20   | Canonicalized env contracts, removed public backend assumptions, aligned Railway/Vercel topology, deployed a healthy preview, and completed the operator runbooks.                                              |
 | T6.1                     | done   | Codex | `deploy/railway-vercel-proxy`      | `apps/engine/src/data/polygon_client.py`, `apps/engine/src/api/routes/*.py`, targeted tests, `docs/ai/state/project-state.md` | `pnpm lint:engine`; `pnpm test:engine`; `pnpm test`; `pnpm build`; runtime log re-check                                                                                                 | 2026-03-20   | Hardened interactive Polygon reads with fast-fail throttling behavior and stale cache fallback, deployed the engine to Railway production, and verified proxy quotes/scan requests complete without fresh 504s. |
+| T7.1                     | done   | Codex | `chore/repo-maintenance-20260321`  | `docs/ai/state/project-state.md`, `apps/engine/Dockerfile`, `apps/web/Dockerfile`, GitHub branches/PRs/runs                 | Docker build reproduction for `apps/engine`, `apps/web`, `apps/agents`; targeted repo validation; `git diff --check`                                                                  | 2026-03-21   | Fixed the engine rootDirectory Docker build, repaired the web Docker build workspace handoff, and used that maintenance branch as the basis for GitHub cleanup.                                               |
 
 ---
 


### PR DESCRIPTION
## Summary
Repair the two live deployment regressions on main.

- Make pps/engine/Dockerfile work with the pps/engine build context used by Compose and Railway rootDirectory deployments.
- Preserve the pnpm workspace install layout into the web builder stage and copy 	sconfig.base.json so pps/web/Dockerfile can complete a production build.

## Scope
- Changed: pps/engine/Dockerfile, pps/web/Dockerfile, docs/ai/state/project-state.md
- Unchanged: app runtime code, shared contracts, migrations, env contract, workflows

## Validation
- [x] git diff --check
- [x] Docker build: docker build --progress=plain -f Dockerfile . in pps/engine
- [x] Docker build: docker build --progress=plain -f apps/web/Dockerfile . from repo root
- [x] Docker build: docker build --progress=plain -f apps/agents/Dockerfile . from repo root

## Command Results
- git diff --check: pass
- docker build --progress=plain -f Dockerfile . (pps/engine): pass
- docker build --progress=plain -f apps/web/Dockerfile . (repo root): pass
- docker build --progress=plain -f apps/agents/Dockerfile . (repo root): pass

## Reviewer Focus
Review the Docker build-context assumptions in pps/engine/Dockerfile and the workspace handoff in pps/web/Dockerfile. GitHub Actions checks are currently blocked by a GitHub billing lock, so the validation here is local/docker-based rather than CI-based.