### PR TITLE
feat(agents): add pr_manager and workflow_manager agents

### DIFF
--- a/apps/agents/src/agent.ts
+++ b/apps/agents/src/agent.ts
@@ -79,6 +79,34 @@ Responsibilities:
 
 Always run risk checks before submitting orders.
 Report any execution anomalies immediately via alerts.`,
+
+  pr_manager: `You are the PR Manager agent for the Sentinel Trading Platform.
+Your role is to monitor and audit open pull requests on the repository.
+
+Responsibilities:
+- List and review all open pull requests
+- Check PR age and flag stale PRs that lack reviews
+- Verify CI check status for each PR
+- Assess merge readiness (passing checks, approved reviews, no conflicts)
+- Identify draft PRs that may need attention
+- Create alerts for PRs that exceed age thresholds or have failing checks
+
+Be thorough but concise. Prioritize PRs by urgency (failing checks > stale > healthy).
+Always use your tools to gather data before making assessments.`,
+
+  workflow_manager: `You are the Workflow Manager agent for the Sentinel Trading Platform.
+Your role is to monitor GitHub Actions workflows and CI/CD health.
+
+Responsibilities:
+- List all repository workflows and their active/disabled state
+- Review recent workflow runs for failures
+- Focus especially on main-branch failures as they block releases
+- Calculate failure rates and identify trends
+- Investigate failed run logs to identify root causes
+- Create alerts for critical CI failures or elevated failure rates
+
+Be data-driven. Use failure rates and patterns to distinguish flaky tests from real regressions.
+Always use your tools to gather data before making assessments.`,
 };
 
 export class Agent {

--- a/apps/agents/src/config.ts
+++ b/apps/agents/src/config.ts
@@ -50,6 +50,12 @@ export const RESEARCH_COOLDOWN_MS = 30 * 60 * 1_000;
 /** How often the Execution Monitor may run (10 seconds). */
 export const EXECUTION_MONITOR_COOLDOWN_MS = 10 * 1_000;
 
+/** How often the PR Manager may run (30 minutes). */
+export const PR_MANAGER_COOLDOWN_MS = 30 * 60 * 1_000;
+
+/** How often the Workflow Manager may run (15 minutes). */
+export const WORKFLOW_MANAGER_COOLDOWN_MS = 15 * 60 * 1_000;
+
 // ─── Agent Prompts ───────────────────────────────────────────────────────────
 
 /**
@@ -68,6 +74,12 @@ export const DEFAULT_AGENT_PROMPTS: Readonly<Record<string, string>> = {
 
   execution_monitor:
     'Check for any open orders. If there are approved trades from this cycle that pass risk checks, prepare them for execution. Report on execution quality for any fills.',
+
+  pr_manager:
+    'Audit all open pull requests. For each PR, check its age, review status, CI check results, and mergeable state. Flag stale PRs that have not been reviewed. Identify PRs with failing checks. Produce a concise health report with actionable recommendations. Create alerts for any critical issues.',
+
+  workflow_manager:
+    'Audit GitHub Actions workflow health. List all workflows and recent runs. Identify failing runs, especially on the main branch. Calculate the overall failure rate. Investigate logs for any recent failures. Produce a concise CI health report with actionable recommendations. Create alerts for any critical issues.',
 };
 
 // ─── GitHub Ops Commander ────────────────────────────────────────────────────

--- a/apps/agents/src/github-client.ts
+++ b/apps/agents/src/github-client.ts
@@ -1,0 +1,254 @@
+/**
+ * GitHub Client — reusable helpers for GitHub API access via `gh` CLI.
+ *
+ * Extracted from `scripts/github-ops.ts` so the PR Manager and Workflow Manager
+ * agents can query GitHub without duplicating shell-exec plumbing.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { GITHUB_REPO, OPS_THRESHOLDS } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Rating = 'PASS' | 'WARN' | 'FAIL' | 'SKIP';
+
+export interface PRSummary {
+  number: number;
+  title: string;
+  author: string;
+  createdAt: string;
+  reviewDecision: string | null;
+  isDraft: boolean;
+  headRefName: string;
+  ageDays: number;
+}
+
+export interface WorkflowRunSummary {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string;
+  branch: string;
+  createdAt: string;
+  ageDays: number;
+}
+
+export interface WorkflowSummary {
+  id: number;
+  name: string;
+  path: string;
+  state: string;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+export function gh(args: string[]): unknown {
+  try {
+    const out = execFileSync('gh', args, {
+      encoding: 'utf8',
+      env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? '' },
+      timeout: 30_000,
+    });
+    try {
+      return JSON.parse(out);
+    } catch {
+      return out.trim();
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: msg.slice(0, 300) };
+  }
+}
+
+export function ghApi(path: string, repo?: string): unknown {
+  const slug = repo ?? GITHUB_REPO;
+  return gh(['api', `/repos/${slug}${path}`]);
+}
+
+export function daysSince(isoDate: string): number {
+  return Math.floor((Date.now() - new Date(isoDate).getTime()) / 86_400_000);
+}
+
+export function rate(value: number, warnThreshold: number, failThreshold: number): Rating {
+  if (value >= failThreshold) return 'FAIL';
+  if (value >= warnThreshold) return 'WARN';
+  return 'PASS';
+}
+
+// ---------------------------------------------------------------------------
+// PR queries
+// ---------------------------------------------------------------------------
+
+export function listOpenPRs(repo?: string): PRSummary[] {
+  const slug = repo ?? GITHUB_REPO;
+  const raw = gh([
+    'pr',
+    'list',
+    '--repo',
+    slug,
+    '--json',
+    'number,title,author,createdAt,reviewDecision,isDraft,headRefName',
+  ]);
+
+  if (!Array.isArray(raw)) return [];
+
+  return (
+    raw as Array<{
+      number: number;
+      title: string;
+      author: { login: string };
+      createdAt: string;
+      reviewDecision: string | null;
+      isDraft: boolean;
+      headRefName: string;
+    }>
+  ).map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    author: pr.author.login,
+    createdAt: pr.createdAt,
+    reviewDecision: pr.reviewDecision,
+    isDraft: pr.isDraft,
+    headRefName: pr.headRefName,
+    ageDays: daysSince(pr.createdAt),
+  }));
+}
+
+export function getPRDetails(prNumber: number, repo?: string): unknown {
+  const slug = repo ?? GITHUB_REPO;
+  return gh([
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    slug,
+    '--json',
+    'number,title,body,author,createdAt,reviewDecision,isDraft,headRefName,mergeable,reviewRequests,statusCheckRollup,additions,deletions,changedFiles',
+  ]);
+}
+
+export function getPRChecks(prNumber: number, repo?: string): unknown {
+  const slug = repo ?? GITHUB_REPO;
+  return gh(['pr', 'checks', String(prNumber), '--repo', slug, '--json', 'name,state,description']);
+}
+
+export function auditPRs(repo?: string): {
+  rating: Rating;
+  summary: string;
+  prs: PRSummary[];
+  stale: PRSummary[];
+  critical: PRSummary[];
+} {
+  const prs = listOpenPRs(repo);
+  const activePRs = prs.filter((p) => !p.isDraft);
+  const stale = activePRs.filter(
+    (p) => p.ageDays >= OPS_THRESHOLDS.PR_WARN_AGE_DAYS && !p.reviewDecision,
+  );
+  const critical = activePRs.filter((p) => p.ageDays >= OPS_THRESHOLDS.PR_FAIL_AGE_DAYS);
+  const rating: Rating = critical.length > 0 ? 'FAIL' : stale.length > 0 ? 'WARN' : 'PASS';
+  const summary =
+    rating === 'PASS'
+      ? `${activePRs.length} open PR(s), all within thresholds`
+      : `${stale.length} stale PR(s) need attention`;
+
+  return { rating, summary, prs: activePRs, stale, critical };
+}
+
+// ---------------------------------------------------------------------------
+// Workflow / CI queries
+// ---------------------------------------------------------------------------
+
+export function listWorkflows(repo?: string): WorkflowSummary[] {
+  const slug = repo ?? GITHUB_REPO;
+  const raw = ghApi('/actions/workflows', slug);
+  if (typeof raw !== 'object' || raw === null || !('workflows' in raw)) return [];
+  const workflows = (
+    raw as { workflows: Array<{ id: number; name: string; path: string; state: string }> }
+  ).workflows;
+  return workflows.map((w) => ({
+    id: w.id,
+    name: w.name,
+    path: w.path,
+    state: w.state,
+  }));
+}
+
+export function listWorkflowRuns(limit = 20, repo?: string): WorkflowRunSummary[] {
+  const slug = repo ?? GITHUB_REPO;
+  const raw = gh([
+    'run',
+    'list',
+    '--repo',
+    slug,
+    '--limit',
+    String(limit),
+    '--json',
+    'databaseId,status,conclusion,name,createdAt,headBranch',
+  ]);
+
+  if (!Array.isArray(raw)) return [];
+
+  return (
+    raw as Array<{
+      databaseId: number;
+      status: string;
+      conclusion: string;
+      name: string;
+      createdAt: string;
+      headBranch: string;
+    }>
+  ).map((r) => ({
+    id: r.databaseId,
+    name: r.name,
+    status: r.status,
+    conclusion: r.conclusion,
+    branch: r.headBranch,
+    createdAt: r.createdAt,
+    ageDays: daysSince(r.createdAt),
+  }));
+}
+
+export function getWorkflowRunLogs(runId: number, repo?: string): unknown {
+  const slug = repo ?? GITHUB_REPO;
+  return gh(['run', 'view', String(runId), '--repo', slug, '--log-failed']);
+}
+
+export function auditCI(repo?: string): {
+  rating: Rating;
+  summary: string;
+  runs: WorkflowRunSummary[];
+  mainFailCount: number;
+  failRate: number;
+} {
+  const runs = listWorkflowRuns(20, repo);
+  const completed = runs.filter((r) => r.status === 'completed');
+  const mainRuns = completed.filter((r) => r.branch === 'main').slice(0, 5);
+  const mainFails = mainRuns.filter((r) => r.conclusion === 'failure');
+  const failRate =
+    completed.length > 0
+      ? completed.filter((r) => r.conclusion === 'failure').length / Math.min(completed.length, 30)
+      : 0;
+
+  let rating: Rating = 'PASS';
+  let summary = 'All recent runs green';
+
+  if (mainFails.length >= 2) {
+    rating = 'FAIL';
+    summary = `${mainFails.length} consecutive failures on main`;
+  } else if (mainFails.length === 1) {
+    rating = 'WARN';
+    summary = `1 failed run on main (run #${mainFails[0]?.id})`;
+  } else if (failRate > OPS_THRESHOLDS.CI_FAIL_RATE_FAIL) {
+    rating = 'FAIL';
+    summary = `High failure rate: ${Math.round(failRate * 100)}% of recent runs failed`;
+  } else if (failRate > OPS_THRESHOLDS.CI_FAIL_RATE_WARN) {
+    rating = 'WARN';
+    summary = `Elevated failure rate: ${Math.round(failRate * 100)}% of recent runs failed`;
+  }
+
+  return { rating, summary, runs: completed, mainFailCount: mainFails.length, failRate };
+}

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -1,12 +1,16 @@
 /**
- * Agent Orchestrator — coordinates the 5-agent trading system.
+ * Agent Orchestrator — coordinates the 7-agent system.
  *
- * Runs agents in a defined sequence with dependency management:
+ * Trading cycle (runs in sequence with dependency management):
  * 1. Market Sentinel → assess market conditions
  * 2. Strategy Analyst → generate signals (depends on market data)
  * 3. Risk Monitor → check portfolio risk (depends on positions)
  * 4. Research → deep dive on top signals (depends on strategy output)
  * 5. Execution Monitor → execute approved trades (depends on risk approval)
+ *
+ * On-demand agents (invoked independently):
+ * 6. PR Manager → audit and manage pull requests
+ * 7. Workflow Manager → audit GitHub Actions workflows and runs
  */
 
 import { Agent } from './agent.js';
@@ -19,9 +23,11 @@ import {
   DEFAULT_CYCLE_INTERVAL_MS,
   EXECUTION_MONITOR_COOLDOWN_MS,
   MARKET_SENTINEL_COOLDOWN_MS,
+  PR_MANAGER_COOLDOWN_MS,
   RESEARCH_COOLDOWN_MS,
   RISK_MONITOR_COOLDOWN_MS,
   STRATEGY_ANALYST_COOLDOWN_MS,
+  WORKFLOW_MANAGER_COOLDOWN_MS,
 } from './config.js';
 import { logger } from './logger.js';
 
@@ -66,6 +72,22 @@ const DEFAULT_CONFIGS: AgentConfig[] = [
     enabled: true,
     cooldownMs: EXECUTION_MONITOR_COOLDOWN_MS,
   },
+  {
+    role: 'pr_manager',
+    name: 'PR Manager',
+    description: 'Audits open pull requests, checks review status and CI health',
+    schedule: 'on demand',
+    enabled: true,
+    cooldownMs: PR_MANAGER_COOLDOWN_MS,
+  },
+  {
+    role: 'workflow_manager',
+    name: 'Workflow Manager',
+    description: 'Monitors GitHub Actions workflows, identifies failures, and reports CI health',
+    schedule: 'on demand',
+    enabled: true,
+    cooldownMs: WORKFLOW_MANAGER_COOLDOWN_MS,
+  },
 ];
 
 export class Orchestrator {
@@ -82,8 +104,7 @@ export class Orchestrator {
     /** Inject a pre-built ToolExecutor — used in tests to supply a mock executor. */
     executor?: ToolExecutor;
   }) {
-    this.executor =
-      options?.executor ?? new ToolExecutor(new EngineClient(options?.engineUrl));
+    this.executor = options?.executor ?? new ToolExecutor(new EngineClient(options?.engineUrl));
 
     const configs = options?.configs ?? DEFAULT_CONFIGS;
 
@@ -190,7 +211,11 @@ export class Orchestrator {
     this.state.lastRun[role] = result.timestamp;
 
     if (result.success) {
-      logger.info('agent.complete', { role, name: agent.config.name, durationMs: result.durationMs });
+      logger.info('agent.complete', {
+        role,
+        name: agent.config.name,
+        durationMs: result.durationMs,
+      });
     } else {
       logger.error('agent.failed', { role, name: agent.config.name, error: result.error });
     }

--- a/apps/agents/src/server.ts
+++ b/apps/agents/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * Sentinel Agent HTTP Server — Express app exposing 9 REST endpoints.
+ * Sentinel Agent HTTP Server — Express app exposing 11 REST endpoints.
  *
  * Endpoints:
  *   GET  /health
@@ -7,6 +7,8 @@
  *   POST /cycle
  *   POST /halt
  *   POST /resume
+ *   POST /pr-audit
+ *   POST /workflow-audit
  *   GET  /recommendations[?status=pending|all|approved|filled|rejected|risk_blocked]
  *   POST /recommendations/:id/approve
  *   POST /recommendations/:id/reject
@@ -27,6 +29,7 @@ import {
 } from './recommendations-store.js';
 import { EngineClient } from './engine-client.js';
 import { getNextCycleAt } from './scheduler.js';
+import { DEFAULT_AGENT_PROMPTS } from './config.js';
 
 // ── Cycle-in-progress flag ─────────────────────────────────────────
 // Module-level so the scheduler can also check it.
@@ -132,6 +135,31 @@ export function createApp(orchestrator: Orchestrator): Express {
   app.post('/resume', (_req: Request, res: Response) => {
     orchestrator.resume();
     res.json({ halted: false, message: 'Trading resumed' });
+  });
+
+  // ── GitHub Ops (on-demand) ──────────────────────────────────────
+
+  app.post('/pr-audit', (_req: Request, res: Response) => {
+    orchestrator
+      .runAgent('pr_manager', DEFAULT_AGENT_PROMPTS['pr_manager'] ?? 'Audit open pull requests.')
+      .then((result) => res.json(result))
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: 'pr_audit_failed', detail: msg });
+      });
+  });
+
+  app.post('/workflow-audit', (_req: Request, res: Response) => {
+    orchestrator
+      .runAgent(
+        'workflow_manager',
+        DEFAULT_AGENT_PROMPTS['workflow_manager'] ?? 'Audit GitHub Actions workflow health.',
+      )
+      .then((result) => res.json(result))
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: 'workflow_audit_failed', detail: msg });
+      });
   });
 
   // ── Recommendations ─────────────────────────────────────────────

--- a/apps/agents/src/tool-executor.ts
+++ b/apps/agents/src/tool-executor.ts
@@ -10,6 +10,16 @@ import {
 } from './recommendations-store.js';
 import type { MarketSentiment, RiskAssessment } from './types.js';
 import { WATCHLIST_TICKERS } from './config.js';
+import {
+  listOpenPRs,
+  getPRDetails,
+  getPRChecks,
+  auditPRs,
+  listWorkflows,
+  listWorkflowRuns,
+  getWorkflowRunLogs,
+  auditCI,
+} from './github-client.js';
 
 export class ToolExecutor {
   private engine: EngineClient;
@@ -52,6 +62,25 @@ export class ToolExecutor {
         return this.analyzeTicker(input);
       case 'create_alert':
         return this.createAlert(input);
+
+      // ── GitHub Ops ──────────────────────────────────────────────
+      case 'list_open_prs':
+        return listOpenPRs();
+      case 'get_pr_details':
+        return getPRDetails(input.pr_number as number);
+      case 'get_pr_checks':
+        return getPRChecks(input.pr_number as number);
+      case 'audit_prs':
+        return auditPRs();
+      case 'list_workflows':
+        return listWorkflows();
+      case 'list_workflow_runs':
+        return listWorkflowRuns((input.limit as number | undefined) ?? 20);
+      case 'get_workflow_run_logs':
+        return getWorkflowRunLogs(input.run_id as number);
+      case 'audit_ci':
+        return auditCI();
+
       default:
         throw new Error(`Unknown tool: ${toolName}`);
     }

--- a/apps/agents/src/tools.ts
+++ b/apps/agents/src/tools.ts
@@ -6,7 +6,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 
 // Tool parameter schemas using Anthropic's format
-export const TOOL_DEFINITIONS: Anthropic.Tool[] = [
+const TRADING_TOOL_DEFINITIONS: Anthropic.Tool[] = [
   // Market Data Tools
   {
     name: 'get_market_data',
@@ -186,6 +186,107 @@ export const TOOL_DEFINITIONS: Anthropic.Tool[] = [
   },
 ];
 
+// GitHub Ops Tools — used by pr_manager and workflow_manager agents
+const GITHUB_TOOL_DEFINITIONS: Anthropic.Tool[] = [
+  {
+    name: 'list_open_prs',
+    description:
+      'List all open pull requests in the repository. Returns number, title, author, age, review status, and draft flag for each PR.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'get_pr_details',
+    description:
+      'Get detailed information about a specific pull request including body, review status, mergeable state, check results, and diff stats.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        pr_number: { type: 'number', description: 'Pull request number' },
+      },
+      required: ['pr_number'],
+    },
+  },
+  {
+    name: 'get_pr_checks',
+    description:
+      'Get the CI/CD check status for a specific pull request. Returns name, state, and description of each check.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        pr_number: { type: 'number', description: 'Pull request number' },
+      },
+      required: ['pr_number'],
+    },
+  },
+  {
+    name: 'audit_prs',
+    description:
+      'Run a full PR health audit. Identifies stale PRs (no review after threshold days), critical-age PRs, and produces a PASS/WARN/FAIL rating.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'list_workflows',
+    description:
+      'List all GitHub Actions workflows defined in the repository. Returns workflow id, name, file path, and active/disabled state.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'list_workflow_runs',
+    description:
+      'List recent GitHub Actions workflow runs. Returns run id, workflow name, status, conclusion, branch, and age.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Maximum number of runs to return (default: 20)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_workflow_run_logs',
+    description:
+      'Get the failed-job logs for a specific workflow run. Useful for diagnosing CI failures.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        run_id: { type: 'number', description: 'Workflow run ID' },
+      },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: 'audit_ci',
+    description:
+      'Run a full CI health audit. Checks recent workflow run failure rates, main-branch failures, and produces a PASS/WARN/FAIL rating.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+];
+
+// Combine all tool definitions
+export const TOOL_DEFINITIONS: Anthropic.Tool[] = [
+  ...TRADING_TOOL_DEFINITIONS,
+  ...GITHUB_TOOL_DEFINITIONS,
+];
+
 // Map agent roles to their available tools
 export const AGENT_TOOLS: Record<string, string[]> = {
   market_sentinel: ['get_market_data', 'get_market_sentiment', 'create_alert'],
@@ -208,6 +309,14 @@ export const AGENT_TOOLS: Record<string, string[]> = {
     'get_open_orders',
     'check_risk_limits',
     'calculate_position_size',
+    'create_alert',
+  ],
+  pr_manager: ['list_open_prs', 'get_pr_details', 'get_pr_checks', 'audit_prs', 'create_alert'],
+  workflow_manager: [
+    'list_workflows',
+    'list_workflow_runs',
+    'get_workflow_run_logs',
+    'audit_ci',
     'create_alert',
   ],
 };

--- a/apps/agents/src/types.ts
+++ b/apps/agents/src/types.ts
@@ -7,7 +7,9 @@ export type AgentRole =
   | 'strategy_analyst'
   | 'risk_monitor'
   | 'research'
-  | 'execution_monitor';
+  | 'execution_monitor'
+  | 'pr_manager'
+  | 'workflow_manager';
 
 export type AgentStatus = 'idle' | 'running' | 'error' | 'cooldown';
 

--- a/apps/agents/src/wat/workflow-loader.ts
+++ b/apps/agents/src/wat/workflow-loader.ts
@@ -121,6 +121,8 @@ export function loadAllWorkflows(workflowsDir?: string): Map<AgentRole, Workflow
     'risk_monitor',
     'research',
     'execution_monitor',
+    'pr_manager',
+    'workflow_manager',
   ];
   const map = new Map<AgentRole, WorkflowConfig>();
   for (const role of roles) {

--- a/apps/agents/tests/github-client.test.ts
+++ b/apps/agents/tests/github-client.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PRSummary, WorkflowRunSummary, WorkflowSummary } from '../src/github-client.js';
+
+// Mock child_process so tests don't require `gh` CLI
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  execSync: vi.fn(),
+}));
+
+const { execFileSync } = await import('node:child_process');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('github-client helpers', () => {
+  it('gh() parses JSON output', async () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify([{ number: 1 }]));
+    const { gh } = await import('../src/github-client.js');
+    const result = gh(['pr', 'list']);
+    expect(result).toEqual([{ number: 1 }]);
+  });
+
+  it('gh() returns plain string when output is not JSON', async () => {
+    vi.mocked(execFileSync).mockReturnValue('some plain output');
+    const { gh } = await import('../src/github-client.js');
+    const result = gh(['run', 'view', '1']);
+    expect(result).toBe('some plain output');
+  });
+
+  it('gh() returns error object on failure', async () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    const { gh } = await import('../src/github-client.js');
+    const result = gh(['pr', 'list']) as { error: string };
+    expect(result).toHaveProperty('error');
+    expect(result.error).toContain('gh not found');
+  });
+
+  it('daysSince() calculates correctly', async () => {
+    const { daysSince } = await import('../src/github-client.js');
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString();
+    expect(daysSince(twoDaysAgo)).toBe(2);
+  });
+
+  it('rate() returns correct ratings', async () => {
+    const { rate } = await import('../src/github-client.js');
+    expect(rate(0, 5, 10)).toBe('PASS');
+    expect(rate(5, 5, 10)).toBe('WARN');
+    expect(rate(10, 5, 10)).toBe('FAIL');
+  });
+});
+
+describe('listOpenPRs', () => {
+  it('returns mapped PR summaries', async () => {
+    const mockPRs = [
+      {
+        number: 42,
+        title: 'Fix bug',
+        author: { login: 'alice' },
+        createdAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+        reviewDecision: 'APPROVED',
+        isDraft: false,
+        headRefName: 'fix/bug',
+      },
+    ];
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify(mockPRs));
+    const { listOpenPRs } = await import('../src/github-client.js');
+    const result = listOpenPRs();
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(42);
+    expect(result[0].author).toBe('alice');
+    expect(result[0].ageDays).toBe(3);
+  });
+
+  it('returns empty array on error', async () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('fail');
+    });
+    const { listOpenPRs } = await import('../src/github-client.js');
+    const result = listOpenPRs();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('auditPRs', () => {
+  it('returns PASS when all PRs are healthy', async () => {
+    const mockPRs = [
+      {
+        number: 1,
+        title: 'Good PR',
+        author: { login: 'bob' },
+        createdAt: new Date().toISOString(),
+        reviewDecision: 'APPROVED',
+        isDraft: false,
+        headRefName: 'feat/good',
+      },
+    ];
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify(mockPRs));
+    const { auditPRs } = await import('../src/github-client.js');
+    const result = auditPRs();
+    expect(result.rating).toBe('PASS');
+    expect(result.stale).toHaveLength(0);
+  });
+
+  it('returns WARN for stale PRs without review', async () => {
+    const mockPRs = [
+      {
+        number: 2,
+        title: 'Stale PR',
+        author: { login: 'carol' },
+        createdAt: new Date(Date.now() - 7 * 86_400_000).toISOString(),
+        reviewDecision: null,
+        isDraft: false,
+        headRefName: 'feat/stale',
+      },
+    ];
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify(mockPRs));
+    const { auditPRs } = await import('../src/github-client.js');
+    const result = auditPRs();
+    expect(result.rating).toBe('WARN');
+    expect(result.stale).toHaveLength(1);
+  });
+});
+
+describe('listWorkflows', () => {
+  it('returns workflow summaries', async () => {
+    const mockResponse = {
+      workflows: [{ id: 1, name: 'CI', path: '.github/workflows/ci.yml', state: 'active' }],
+    };
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify(mockResponse));
+    const { listWorkflows } = await import('../src/github-client.js');
+    const result = listWorkflows();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('CI');
+  });
+});
+
+describe('auditCI', () => {
+  it('returns PASS when all runs are green', async () => {
+    const mockRuns = Array.from({ length: 5 }, (_, i) => ({
+      databaseId: i + 1,
+      status: 'completed',
+      conclusion: 'success',
+      name: 'CI',
+      createdAt: new Date().toISOString(),
+      headBranch: 'main',
+    }));
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify(mockRuns));
+    const { auditCI } = await import('../src/github-client.js');
+    const result = auditCI();
+    expect(result.rating).toBe('PASS');
+    expect(result.mainFailCount).toBe(0);
+  });
+
+  it('returns FAIL when multiple main failures exist', async () => {
+    const mockRuns = Array.from({ length: 5 }, (_, i) => ({
+      databaseId: i + 1,
+      status: 'completed',
+      conclusion: 'failure',
+      name: 'CI',
+      createdAt: new Date().toISOString(),
+      headBranch: 'main',
+    }));
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify(mockRuns));
+    const { auditCI } = await import('../src/github-client.js');
+    const result = auditCI();
+    expect(result.rating).toBe('FAIL');
+    expect(result.mainFailCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/agents/tests/orchestrator-di.test.ts
+++ b/apps/agents/tests/orchestrator-di.test.ts
@@ -41,7 +41,7 @@ describe('Orchestrator constructor — executor injection', () => {
     // executor is provided — no network connection is attempted.
     const executor = makeMockExecutor();
     const orchestrator = new Orchestrator({ executor });
-    expect(orchestrator.getAgentInfo()).toHaveLength(5);
+    expect(orchestrator.getAgentInfo()).toHaveLength(7);
   });
 
   it('creates a real EngineClient when no executor is injected', () => {
@@ -58,7 +58,7 @@ describe('Orchestrator constructor — executor injection', () => {
     });
     // If the EngineClient were used, construction might fail; the fact that
     // getAgentInfo() works confirms the executor path was taken.
-    expect(orchestrator.getAgentInfo()).toHaveLength(5);
+    expect(orchestrator.getAgentInfo()).toHaveLength(7);
   });
 });
 
@@ -83,12 +83,14 @@ describe('Orchestrator — config constants', () => {
     expect(DEFAULT_CYCLE_INTERVAL_MS).toBe(STRATEGY_ANALYST_COOLDOWN_MS);
   });
 
-  it('DEFAULT_AGENT_PROMPTS contains all 4 cycle-sequence roles', async () => {
+  it('DEFAULT_AGENT_PROMPTS contains all cycle-sequence and on-demand roles', async () => {
     const { DEFAULT_AGENT_PROMPTS } = await import('../src/config.js');
     expect(DEFAULT_AGENT_PROMPTS).toHaveProperty('market_sentinel');
     expect(DEFAULT_AGENT_PROMPTS).toHaveProperty('strategy_analyst');
     expect(DEFAULT_AGENT_PROMPTS).toHaveProperty('risk_monitor');
     expect(DEFAULT_AGENT_PROMPTS).toHaveProperty('execution_monitor');
+    expect(DEFAULT_AGENT_PROMPTS).toHaveProperty('pr_manager');
+    expect(DEFAULT_AGENT_PROMPTS).toHaveProperty('workflow_manager');
   });
 
   it('WATCHLIST_TICKERS is non-empty and contains expected symbols', async () => {

--- a/apps/agents/tests/orchestrator.test.ts
+++ b/apps/agents/tests/orchestrator.test.ts
@@ -19,10 +19,10 @@ describe('Orchestrator', () => {
     vi.restoreAllMocks();
   });
 
-  it('should initialize with all 5 agents', () => {
+  it('should initialize with all 7 agents', () => {
     const orchestrator = new Orchestrator({ apiKey: 'test-key' });
     const agents = orchestrator.getAgentInfo();
-    expect(agents).toHaveLength(5);
+    expect(agents).toHaveLength(7);
   });
 
   it('should have all roles represented', () => {
@@ -33,6 +33,8 @@ describe('Orchestrator', () => {
     expect(roles).toContain('risk_monitor');
     expect(roles).toContain('research');
     expect(roles).toContain('execution_monitor');
+    expect(roles).toContain('pr_manager');
+    expect(roles).toContain('workflow_manager');
   });
 
   it('should start with all agents idle', () => {

--- a/apps/agents/tests/server.test.ts
+++ b/apps/agents/tests/server.test.ts
@@ -11,6 +11,8 @@ const mockOrchestrator = {
       risk_monitor: 'idle',
       research: 'idle',
       execution_monitor: 'idle',
+      pr_manager: 'idle',
+      workflow_manager: 'idle',
     },
     lastRun: {
       market_sentinel: null,
@@ -18,11 +20,20 @@ const mockOrchestrator = {
       risk_monitor: null,
       research: null,
       execution_monitor: null,
+      pr_manager: null,
+      workflow_manager: null,
     },
     cycleCount: 3,
     halted: false,
   },
   runCycle: vi.fn().mockResolvedValue([]),
+  runAgent: vi.fn().mockResolvedValue({
+    role: 'pr_manager',
+    success: true,
+    timestamp: new Date().toISOString(),
+    durationMs: 100,
+    data: null,
+  }),
   halt: vi.fn(),
   resume: vi.fn(),
 };
@@ -162,5 +173,32 @@ describe('POST /recommendations/:id/reject', () => {
     vi.mocked(getRecommendation).mockResolvedValue(null as any);
     const res = await request(app).post('/recommendations/nonexistent/reject');
     expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /pr-audit', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 and invokes pr_manager agent', async () => {
+    const res = await request(app).post('/pr-audit');
+    expect(res.status).toBe(200);
+    expect(mockOrchestrator.runAgent).toHaveBeenCalledWith('pr_manager', expect.any(String));
+  });
+});
+
+describe('POST /workflow-audit', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 and invokes workflow_manager agent', async () => {
+    mockOrchestrator.runAgent.mockResolvedValue({
+      role: 'workflow_manager',
+      success: true,
+      timestamp: new Date().toISOString(),
+      durationMs: 80,
+      data: null,
+    });
+    const res = await request(app).post('/workflow-audit');
+    expect(res.status).toBe(200);
+    expect(mockOrchestrator.runAgent).toHaveBeenCalledWith('workflow_manager', expect.any(String));
   });
 });

--- a/apps/agents/tests/tools.test.ts
+++ b/apps/agents/tests/tools.test.ts
@@ -21,24 +21,54 @@ describe('Tool Definitions', () => {
     }
   });
 
-  it('should have at least 10 tools', () => {
-    expect(TOOL_DEFINITIONS.length).toBeGreaterThanOrEqual(10);
+  it('should have at least 18 tools', () => {
+    expect(TOOL_DEFINITIONS.length).toBeGreaterThanOrEqual(18);
+  });
+
+  it('should include GitHub tools', () => {
+    const toolNames = TOOL_DEFINITIONS.map((t) => t.name);
+    expect(toolNames).toContain('list_open_prs');
+    expect(toolNames).toContain('get_pr_details');
+    expect(toolNames).toContain('get_pr_checks');
+    expect(toolNames).toContain('audit_prs');
+    expect(toolNames).toContain('list_workflows');
+    expect(toolNames).toContain('list_workflow_runs');
+    expect(toolNames).toContain('get_workflow_run_logs');
+    expect(toolNames).toContain('audit_ci');
   });
 });
 
 describe('Agent Tool Mapping', () => {
-  it('should define tools for all 5 agent roles', () => {
+  it('should define tools for all 7 agent roles', () => {
     const roles = [
       'market_sentinel',
       'strategy_analyst',
       'risk_monitor',
       'research',
       'execution_monitor',
+      'pr_manager',
+      'workflow_manager',
     ];
     for (const role of roles) {
       expect(AGENT_TOOLS[role]).toBeDefined();
       expect(AGENT_TOOLS[role].length).toBeGreaterThan(0);
     }
+  });
+
+  it('pr_manager should have PR tools', () => {
+    expect(AGENT_TOOLS.pr_manager).toContain('list_open_prs');
+    expect(AGENT_TOOLS.pr_manager).toContain('get_pr_details');
+    expect(AGENT_TOOLS.pr_manager).toContain('get_pr_checks');
+    expect(AGENT_TOOLS.pr_manager).toContain('audit_prs');
+    expect(AGENT_TOOLS.pr_manager).toContain('create_alert');
+  });
+
+  it('workflow_manager should have workflow tools', () => {
+    expect(AGENT_TOOLS.workflow_manager).toContain('list_workflows');
+    expect(AGENT_TOOLS.workflow_manager).toContain('list_workflow_runs');
+    expect(AGENT_TOOLS.workflow_manager).toContain('get_workflow_run_logs');
+    expect(AGENT_TOOLS.workflow_manager).toContain('audit_ci');
+    expect(AGENT_TOOLS.workflow_manager).toContain('create_alert');
   });
 
   it('market_sentinel should have market tools', () => {

--- a/apps/agents/workflows/pr_manager.md
+++ b/apps/agents/workflows/pr_manager.md
@@ -1,0 +1,45 @@
+---
+name: PR Manager
+role: pr_manager
+description: Audits open pull requests, checks review status and CI health
+schedule: on demand
+cooldown_ms: 1800000
+enabled: true
+tools:
+  - list_open_prs
+  - get_pr_details
+  - get_pr_checks
+  - audit_prs
+  - create_alert
+version: 1
+last_updated_by: human
+---
+
+You are the PR Manager agent for the Sentinel Trading Platform.
+
+## Mission
+
+Monitor and audit all open pull requests on the repository to ensure timely reviews,
+healthy CI status, and merge readiness.
+
+## Workflow
+
+1. Run `audit_prs` to get the overall PR health rating and identify stale/critical PRs.
+2. For each stale or critical PR, call `get_pr_details` and `get_pr_checks` to gather
+   full context (review state, check results, mergeable status).
+3. Classify each PR into one of:
+   - **Ready to merge** — approved, all checks passing, no conflicts.
+   - **Needs review** — no review decision yet.
+   - **Needs attention** — failing checks, conflicts, or stale beyond threshold.
+   - **Draft** — not ready for review.
+4. Create an alert for any PR rated WARN or FAIL.
+5. Produce a concise summary report with:
+   - Overall PR health rating (PASS / WARN / FAIL)
+   - Count of open, stale, and critical PRs
+   - Per-PR action items ranked by urgency
+
+## Guardrails
+
+- Do not merge, close, or modify PRs. This agent is read-only.
+- Do not speculate on PR quality beyond what CI checks and review status indicate.
+- Always use tools to gather data before making assessments.

--- a/apps/agents/workflows/workflow_manager.md
+++ b/apps/agents/workflows/workflow_manager.md
@@ -1,0 +1,48 @@
+---
+name: Workflow Manager
+role: workflow_manager
+description: Monitors GitHub Actions workflows, identifies failures, and reports CI health
+schedule: on demand
+cooldown_ms: 900000
+enabled: true
+tools:
+  - list_workflows
+  - list_workflow_runs
+  - get_workflow_run_logs
+  - audit_ci
+  - create_alert
+version: 1
+last_updated_by: human
+---
+
+You are the Workflow Manager agent for the Sentinel Trading Platform.
+
+## Mission
+
+Monitor GitHub Actions workflows and CI/CD health to ensure the repository
+maintains a reliable build and test pipeline.
+
+## Workflow
+
+1. Run `audit_ci` to get the overall CI health rating, failure rates, and main-branch status.
+2. Call `list_workflows` to enumerate all repository workflows and check for disabled workflows.
+3. Call `list_workflow_runs` to review the most recent runs across all workflows.
+4. For any failed run (especially on main), call `get_workflow_run_logs` to retrieve
+   the failure logs and identify the root cause.
+5. Classify failures into:
+   - **Regression** — a previously passing test or build step now fails.
+   - **Flaky** — intermittent failure that passes on re-run.
+   - **Config issue** — workflow YAML or environment misconfiguration.
+   - **External dependency** — third-party service or network failure.
+6. Create an alert for any critical failure (main-branch failure or elevated failure rate).
+7. Produce a concise CI health report with:
+   - Overall CI rating (PASS / WARN / FAIL)
+   - Failure rate percentage
+   - Main-branch failure count
+   - Per-failure root cause summary and recommended action
+
+## Guardrails
+
+- Do not re-run, cancel, or modify workflows. This agent is read-only.
+- Distinguish between flaky tests and real regressions before recommending action.
+- Always use tools to gather data before making assessments.


### PR DESCRIPTION
Add two new GitHub-ops-oriented agent roles to the orchestrator:

- pr_manager: audits open PRs for staleness, review status, and CI health
- workflow_manager: monitors GitHub Actions workflows, failure rates, and logs

Changes:
- Extended AgentRole union type with pr_manager | workflow_manager
- Created github-client.ts: reusable gh CLI wrappers for PR/workflow queries
- Added 8 GitHub tool definitions (list_open_prs, get_pr_details, etc.)
- Added tool executor dispatch handlers for all new tools
- Registered both agents in orchestrator DEFAULT_CONFIGS
- Added system prompts in agent.ts for both roles
- Added POST /pr-audit and POST /workflow-audit server endpoints
- Created workflow Markdown definitions with YAML frontmatter
- Updated workflow-loader to include new roles
- Updated all existing tests and added github-client.test.ts

Both agents are on-demand only (not in the trading cycle sequence). They are invoked via dedicated HTTP endpoints.

## Summary

Describe the outcome in 2-5 lines.

## Scope

- Files or modules intentionally changed:
- Files or modules intentionally untouched:

## Validation

- [ ] `git diff --check`
- [ ] Relevant commands from `docs/ai/commands.md` were run
- [ ] Exact command results are listed below

### Command Results

- `command`: pass/fail

## Forbidden Changes Checked

- [ ] No accidental shared contract drift
- [ ] No accidental migration or env contract change
- [ ] No secrets or credentials in the diff

## Reviewer Focus

Call out the riskiest part of the change and where to review it.
