### PR TITLE
chore: clean up deployments, add cleanup script, wire GitHub environments

### DIFF
--- a/.github/workflows/vercel-deployment-checks.yml
+++ b/.github/workflows/vercel-deployment-checks.yml
@@ -31,6 +31,7 @@ jobs:
     name: Verify Deployment Health
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: ${{ github.event.client_payload.environment || inputs.environment || 'preview' }}
     env:
       DEPLOYMENT_URL: ${{ github.event.client_payload.url || inputs.deployment_url }}
       EXPECTED_ENVIRONMENT: ${{ github.event.client_payload.environment || inputs.environment || 'preview' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Sentinel Trading Platform
+
+Thank you for your interest in contributing! Whether you're fixing a bug, adding a feature, or improving documentation, your help is appreciated.
+
+## Development Setup
+
+### Prerequisites
+
+- **Node.js** 22+ with **pnpm** 10.32+
+- **Python** 3.12+ with **uv**
+- A populated `.env` file (copy from `.env.example`)
+
+### Install
+
+```bash
+# Install Node dependencies
+pnpm install
+
+# Set up the Python engine virtual environment
+cd apps/engine
+uv sync
+cd ../..
+```
+
+## Code Style
+
+### TypeScript / JavaScript
+
+Prettier is the single formatter. Key settings: semicolons enabled, single quotes, trailing commas (all). ESLint enforces lint rules across all Node workspaces.
+
+### Python
+
+Ruff handles both linting and formatting for the engine (`apps/engine`).
+
+### Enforcement
+
+Husky pre-commit hooks run formatters and linters automatically. You can also run them manually:
+
+```bash
+pnpm lint                 # Node workspaces
+pnpm lint:engine          # Ruff lint (Python)
+pnpm format:check:engine  # Ruff format check (Python)
+```
+
+## Commit Conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) enforced via **commitlint**.
+
+Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `test`, `ci`, `perf`, `revert`
+
+```
+feat(web): add portfolio allocation chart
+fix(engine): handle empty ticker list in screener
+chore: bump dependencies
+```
+
+## Branch Naming
+
+Use a prefix that matches the commit type:
+
+- `feat/` — new features
+- `fix/` — bug fixes
+- `chore/` — maintenance, dependencies, config
+- `docs/` — documentation changes
+
+Example: `feat/portfolio-chart`, `fix/screener-empty-list`
+
+> **Note for AI agents:** Do not create branches with `copilot/`, `claude/`, or `worktree-` prefixes.
+> These patterns are excluded from Vercel preview deployments and will not receive automated builds.
+> Use the standard prefixes above instead.
+
+## Pull Request Process
+
+1. Create a branch from `main` using the naming convention above.
+2. Make your changes with clear, focused commits.
+3. Fill out the **PR template** when opening your pull request.
+4. Ensure all CI checks pass before requesting review.
+5. Request review from the relevant [CODEOWNERS](.github/CODEOWNERS).
+6. Address review feedback promptly; prefer fixup commits during review.
+
+## Testing Requirements
+
+All tests must pass before merge:
+
+```bash
+pnpm test          # Node workspace tests (web + agents)
+pnpm test:engine   # Python engine tests (pytest)
+```
+
+- No test coverage regressions.
+- New features should include tests; bug fixes should include a regression test.
+
+## Validation Checklist
+
+Before opening a PR, confirm:
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm lint:engine` passes (if engine was changed)
+- [ ] `pnpm test:engine` passes (if engine was changed)
+- [ ] No secrets in code, docs, or test fixtures
+
+## Architecture
+
+For a full overview of the system architecture, deployment topology, and AI collaboration guidelines, see:
+
+- [Architecture Guide](docs/ai/architecture.md)
+- [Agent Operations](AGENTS.md)

--- a/scripts/cleanup-deployments.sh
+++ b/scripts/cleanup-deployments.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─────────────────────────────────────────────────────────────
+# Sentinel Trading Platform — Deployment Cleanup Script
+#
+# Deactivates stale GitHub deployments and removes orphaned
+# environments. Requires a GitHub token with repo_deployment
+# and environment scopes.
+#
+# Usage:
+#   ./scripts/cleanup-deployments.sh                 # dry-run
+#   ./scripts/cleanup-deployments.sh --apply         # execute
+#   ./scripts/cleanup-deployments.sh --max-age 14    # 14-day cutoff
+# ─────────────────────────────────────────────────────────────
+
+REPO="${GITHUB_REPOSITORY:-stevenschling13/Trading-App}"
+TOKEN="${GITHUB_TOKEN:-}"
+MAX_AGE_DAYS=30
+DRY_RUN=true
+API="https://api.github.com"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --apply           Actually deactivate deployments (default: dry-run)
+  --max-age DAYS    Deactivate deployments older than DAYS (default: 30)
+  --repo OWNER/REPO Override target repository
+  --help            Show this help
+
+Environment:
+  GITHUB_TOKEN      Required. Personal access token with repo_deployment scope.
+  GITHUB_REPOSITORY Optional. Defaults to stevenschling13/Trading-App.
+EOF
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) DRY_RUN=false; shift ;;
+    --max-age) MAX_AGE_DAYS="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --help) usage ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$TOKEN" ]]; then
+  echo "Error: GITHUB_TOKEN is required." >&2
+  echo "Create one at https://github.com/settings/tokens with 'repo' scope." >&2
+  exit 1
+fi
+
+gh_api() {
+  local method="$1" endpoint="$2"
+  shift 2
+  curl -fsSL \
+    -X "$method" \
+    -H "Authorization: token $TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@" \
+    "$API/repos/$REPO$endpoint"
+}
+
+cutoff_date=$(date -u -d "$MAX_AGE_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+              date -u -v-"${MAX_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ)
+
+echo "╔════════════════════════════════════════════════════╗"
+echo "║   Sentinel Deployment Cleanup                     ║"
+echo "╠════════════════════════════════════════════════════╣"
+echo "║  Repo:     $REPO"
+echo "║  Max age:  $MAX_AGE_DAYS days (before $cutoff_date)"
+echo "║  Mode:     $(if $DRY_RUN; then echo 'DRY RUN'; else echo 'APPLYING CHANGES'; fi)"
+echo "╚════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. List environments ──────────────────────────────────
+
+echo "── Environments ──"
+environments=$(gh_api GET /environments | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for env in data.get('environments', []):
+    print(env['name'])
+" 2>/dev/null || echo "")
+
+if [[ -z "$environments" ]]; then
+  echo "  No environments found (or API error)."
+else
+  echo "$environments" | while read -r env; do
+    echo "  • $env"
+  done
+fi
+echo ""
+
+# ── 2. Remove orphaned environments ──────────────────────
+
+ORPHANED_ENVS=("github-pages")
+echo "── Orphaned Environment Cleanup ──"
+for env in "${ORPHANED_ENVS[@]}"; do
+  if echo "$environments" | grep -qx "$env"; then
+    if $DRY_RUN; then
+      echo "  [DRY RUN] Would delete environment: $env"
+    else
+      echo "  Deleting environment: $env"
+      gh_api DELETE "/environments/$env" || echo "  ⚠ Failed to delete $env"
+    fi
+  else
+    echo "  ✓ $env does not exist (already clean)"
+  fi
+done
+echo ""
+
+# ── 3. Deactivate stale deployments ──────────────────────
+
+echo "── Stale Deployment Cleanup ──"
+page=1
+total=0
+deactivated=0
+skipped=0
+
+while true; do
+  deployments=$(gh_api GET "/deployments?per_page=100&page=$page")
+  count=$(echo "$deployments" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+
+  if [[ "$count" == "0" ]]; then
+    break
+  fi
+
+  results=$(echo "$deployments" | python3 -c "
+import sys, json
+from datetime import datetime
+
+cutoff = '$cutoff_date'
+data = json.load(sys.stdin)
+for d in data:
+    created = d['created_at']
+    env = d.get('environment', 'unknown')
+    dep_id = d['id']
+    ref = d.get('ref', 'unknown')
+    is_old = created < cutoff
+    print(f'{dep_id}|{env}|{ref}|{created}|{is_old}')
+")
+
+  while IFS='|' read -r dep_id env ref created is_old; do
+    total=$((total + 1))
+    if [[ "$is_old" == "True" ]]; then
+      if $DRY_RUN; then
+        echo "  [DRY RUN] Would deactivate: #$dep_id ($env, ref=$ref, created=$created)"
+      else
+        gh_api POST "/deployments/$dep_id/statuses" \
+          -d '{"state":"inactive","description":"Cleaned up by deployment cleanup script"}' > /dev/null
+        echo "  ✓ Deactivated: #$dep_id ($env, ref=$ref)"
+      fi
+      deactivated=$((deactivated + 1))
+    else
+      skipped=$((skipped + 1))
+    fi
+  done <<< "$results"
+
+  if [[ "$count" -lt 100 ]]; then
+    break
+  fi
+  page=$((page + 1))
+done
+
+echo ""
+echo "── Summary ──"
+echo "  Total deployments scanned: $total"
+echo "  Stale (would deactivate):  $deactivated"
+echo "  Recent (kept):             $skipped"
+
+if $DRY_RUN && [[ $deactivated -gt 0 ]]; then
+  echo ""
+  echo "  Run with --apply to execute these changes."
+fi
+
+echo ""
+echo "Done."


### PR DESCRIPTION
## Summary

Optimizes the deployment setup to reduce noise and match professional standards.

### Changes
- **\scripts/cleanup-deployments.sh\** — Reusable script to deactivate stale GitHub deployments and remove orphaned environments via API (dry-run by default, \--apply\ to execute)
- **\.github/workflows/vercel-deployment-checks.yml\** — Added \nvironment:\ reference so deployment status is tracked in GitHub Settings → Environments
- **\CONTRIBUTING.md\** — Added branch naming guidance for AI agents (no \copilot/*\, \claude/*\, \worktree-*\ branches to avoid unwanted Vercel preview deployments)
- Cleaned up 9 stale local branches and pruned stale remote refs

### Manual Follow-ups (after merge)
1. Delete orphaned \github-pages\ environment (Settings → Environments)
2. Run \GITHUB_TOKEN=<pat> bash scripts/cleanup-deployments.sh --apply\ to deactivate stale deployments
3. Enable 'Auto-delete head branches' in Settings → General
4. Create \production\ GitHub Environment restricted to \main\ branch
5. Scope Vercel preview branches to \eature/*\, \ix/*\, \chore/*\, \docs/*\ only
6. Set Vercel deployment retention to 30 days for previews

### Validation
- \pnpm lint\ — not affected (no TS/JS source changes)
- \pnpm test\ — not affected
- \pnpm build\ — not affected
- Workflow YAML validated by pre-commit prettier