### PR TITLE
feat: Server-side trading policy (Phase 2)

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Settings, Shield, Bell, Activity, Save, Check, Info } from 'lucide-react';
+import {
+  Settings,
+  Shield,
+  Bell,
+  Activity,
+  Save,
+  Check,
+  Info,
+  Loader2,
+  AlertCircle,
+} from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -12,8 +22,10 @@ import {
 import { RiskSettings } from '@/components/settings/risk-settings';
 import { ScheduleSettings } from '@/components/settings/schedule-settings';
 import { ToggleField } from '@/components/settings/toggle-field';
+import { useTradingPolicy, policyValue } from '@/hooks/use-trading-policy';
 
-const STORAGE_KEY = 'sentinel:settings';
+/** localStorage key for notification preferences (UI-only, not policy). */
+const NOTIFICATION_STORAGE_KEY = 'sentinel:notification-prefs';
 
 export default function SettingsPage() {
   const [saved, setSaved] = useState(false);
@@ -28,26 +40,48 @@ export default function SettingsPage() {
     alpaca: 'checking',
   });
 
-  // Risk settings
+  // ── Server-backed trading policy ────────────────────────────────────
+  const {
+    policy,
+    loading: policyLoading,
+    saving: policySaving,
+    error: policyError,
+    updatePolicy,
+  } = useTradingPolicy();
+
+  // Local form state mirrors the DB policy, updated on load
   const [maxPosition, setMaxPosition] = useState('5');
   const [maxSector, setMaxSector] = useState('20');
   const [dailyLossLimit, setDailyLossLimit] = useState('2');
   const [softDrawdown, setSoftDrawdown] = useState('10');
   const [hardDrawdown, setHardDrawdown] = useState('15');
   const [maxPositions, setMaxPositions] = useState('20');
+  const [paperMode, setPaperMode] = useState(true);
+  const [autoTrading, setAutoTrading] = useState(false);
+  const [requireConfirmation, setRequireConfirmation] = useState(true);
 
-  // Notification preferences
+  // Sync form state when policy loads from server
+  useEffect(() => {
+    if (policy) {
+      setMaxPosition(String(policyValue(policy, 'max_position_pct')));
+      setMaxSector(String(policyValue(policy, 'max_sector_pct')));
+      setDailyLossLimit(String(policyValue(policy, 'daily_loss_limit_pct')));
+      setSoftDrawdown(String(policyValue(policy, 'soft_drawdown_pct')));
+      setHardDrawdown(String(policyValue(policy, 'hard_drawdown_pct')));
+      setMaxPositions(String(policyValue(policy, 'max_open_positions')));
+      setPaperMode(policyValue(policy, 'paper_trading'));
+      setAutoTrading(policyValue(policy, 'auto_trading'));
+      setRequireConfirmation(policyValue(policy, 'require_confirmation'));
+    }
+  }, [policy]);
+
+  // ── Notification preferences (localStorage only) ───────────────────
   const [alertCritical, setAlertCritical] = useState(true);
   const [alertWarning, setAlertWarning] = useState(true);
   const [alertInfo, setAlertInfo] = useState(false);
   const [alertSound, setAlertSound] = useState(true);
   const [agentNotifications, setAgentNotifications] = useState(true);
   const [tradeNotifications, setTradeNotifications] = useState(true);
-
-  // Trading
-  const [paperMode, setPaperMode] = useState(true);
-  const [autoTrading, setAutoTrading] = useState(false);
-  const [requireConfirmation, setRequireConfirmation] = useState(true);
 
   const checkConnections = useCallback(async () => {
     setCheckingConnections(true);
@@ -69,28 +103,32 @@ export default function SettingsPage() {
     }
   }, []);
 
-  // Load persisted settings from localStorage and fetch real service status
+  // Load notification preferences from localStorage + check connections
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(NOTIFICATION_STORAGE_KEY);
       if (raw) {
         const s = JSON.parse(raw) as Record<string, unknown>;
-        if (typeof s.maxPosition === 'string') setMaxPosition(s.maxPosition);
-        if (typeof s.maxSector === 'string') setMaxSector(s.maxSector);
-        if (typeof s.dailyLossLimit === 'string') setDailyLossLimit(s.dailyLossLimit);
-        if (typeof s.softDrawdown === 'string') setSoftDrawdown(s.softDrawdown);
-        if (typeof s.hardDrawdown === 'string') setHardDrawdown(s.hardDrawdown);
-        if (typeof s.maxPositions === 'string') setMaxPositions(s.maxPositions);
         if (typeof s.alertCritical === 'boolean') setAlertCritical(s.alertCritical);
         if (typeof s.alertWarning === 'boolean') setAlertWarning(s.alertWarning);
         if (typeof s.alertInfo === 'boolean') setAlertInfo(s.alertInfo);
         if (typeof s.alertSound === 'boolean') setAlertSound(s.alertSound);
         if (typeof s.agentNotifications === 'boolean') setAgentNotifications(s.agentNotifications);
         if (typeof s.tradeNotifications === 'boolean') setTradeNotifications(s.tradeNotifications);
-        if (typeof s.paperMode === 'boolean') setPaperMode(s.paperMode);
-        if (typeof s.autoTrading === 'boolean') setAutoTrading(s.autoTrading);
-        if (typeof s.requireConfirmation === 'boolean')
-          setRequireConfirmation(s.requireConfirmation);
+      } else {
+        // Migrate old combined storage → notification prefs only
+        const legacy = localStorage.getItem('sentinel:settings');
+        if (legacy) {
+          const s = JSON.parse(legacy) as Record<string, unknown>;
+          if (typeof s.alertCritical === 'boolean') setAlertCritical(s.alertCritical);
+          if (typeof s.alertWarning === 'boolean') setAlertWarning(s.alertWarning);
+          if (typeof s.alertInfo === 'boolean') setAlertInfo(s.alertInfo);
+          if (typeof s.alertSound === 'boolean') setAlertSound(s.alertSound);
+          if (typeof s.agentNotifications === 'boolean')
+            setAgentNotifications(s.agentNotifications);
+          if (typeof s.tradeNotifications === 'boolean')
+            setTradeNotifications(s.tradeNotifications);
+        }
       }
     } catch {
       // Ignore corrupt storage
@@ -99,27 +137,37 @@ export default function SettingsPage() {
     checkConnections();
   }, [checkConnections]);
 
-  const handleSave = () => {
-    const settings = {
-      maxPosition,
-      maxSector,
-      dailyLossLimit,
-      softDrawdown,
-      hardDrawdown,
-      maxPositions,
+  const handleSave = async () => {
+    // Save notification preferences to localStorage
+    const notificationPrefs = {
       alertCritical,
       alertWarning,
       alertInfo,
       alertSound,
       agentNotifications,
       tradeNotifications,
-      paperMode,
-      autoTrading,
-      requireConfirmation,
     };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    localStorage.setItem(NOTIFICATION_STORAGE_KEY, JSON.stringify(notificationPrefs));
+
+    // Save policy to server
+    const success = await updatePolicy({
+      max_position_pct: Number(maxPosition),
+      max_sector_pct: Number(maxSector),
+      daily_loss_limit_pct: Number(dailyLossLimit),
+      soft_drawdown_pct: Number(softDrawdown),
+      hard_drawdown_pct: Number(hardDrawdown),
+      max_open_positions: Number(maxPositions),
+      paper_trading: paperMode,
+      auto_trading: autoTrading,
+      require_confirmation: requireConfirmation,
+    });
+
+    if (success) {
+      // Clean up old combined localStorage key
+      localStorage.removeItem('sentinel:settings');
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    }
   };
 
   return (
@@ -135,19 +183,32 @@ export default function SettingsPage() {
             </p>
           </div>
         </div>
-        <Button onClick={handleSave} size="sm">
-          {saved ? (
-            <>
-              <Check className="h-4 w-4 text-profit" />
-              <span className="ml-1.5">Saved</span>
-            </>
-          ) : (
-            <>
-              <Save className="h-4 w-4" />
-              <span className="ml-1.5">Save Changes</span>
-            </>
+        <div className="flex items-center gap-2">
+          {policyError && (
+            <div className="flex items-center gap-1 text-xs text-destructive">
+              <AlertCircle className="h-3.5 w-3.5" />
+              <span>{policyError}</span>
+            </div>
           )}
-        </Button>
+          <Button onClick={handleSave} size="sm" disabled={policyLoading || policySaving}>
+            {policySaving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="ml-1.5">Saving…</span>
+              </>
+            ) : saved ? (
+              <>
+                <Check className="h-4 w-4 text-profit" />
+                <span className="ml-1.5">Saved</span>
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" />
+                <span className="ml-1.5">Save Changes</span>
+              </>
+            )}
+          </Button>
+        </div>
       </div>
 
       <ConnectionStatusPanel
@@ -156,126 +217,135 @@ export default function SettingsPage() {
         onCheckConnections={checkConnections}
       />
 
-      <Tabs defaultValue="risk" className="space-y-3">
-        <TabsList className="bg-muted/50">
-          <TabsTrigger value="risk">
-            <Shield className="h-3.5 w-3.5 mr-1.5" />
-            Risk
-          </TabsTrigger>
-          <TabsTrigger value="notifications">
-            <Bell className="h-3.5 w-3.5 mr-1.5" />
-            Notifications
-          </TabsTrigger>
-          <TabsTrigger value="trading">
-            <Activity className="h-3.5 w-3.5 mr-1.5" />
-            Trading
-          </TabsTrigger>
-        </TabsList>
+      {policyLoading ? (
+        <div className="flex items-center justify-center py-12 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin mr-2" />
+          <span className="text-sm">Loading settings…</span>
+        </div>
+      ) : (
+        <Tabs defaultValue="risk" className="space-y-3">
+          <TabsList className="bg-muted/50">
+            <TabsTrigger value="risk">
+              <Shield className="h-3.5 w-3.5 mr-1.5" />
+              Risk
+            </TabsTrigger>
+            <TabsTrigger value="notifications">
+              <Bell className="h-3.5 w-3.5 mr-1.5" />
+              Notifications
+            </TabsTrigger>
+            <TabsTrigger value="trading">
+              <Activity className="h-3.5 w-3.5 mr-1.5" />
+              Trading
+            </TabsTrigger>
+          </TabsList>
 
-        <TabsContent value="risk">
-          <RiskSettings
-            maxPosition={maxPosition}
-            onMaxPosition={setMaxPosition}
-            maxSector={maxSector}
-            onMaxSector={setMaxSector}
-            dailyLossLimit={dailyLossLimit}
-            onDailyLossLimit={setDailyLossLimit}
-            softDrawdown={softDrawdown}
-            onSoftDrawdown={setSoftDrawdown}
-            hardDrawdown={hardDrawdown}
-            onHardDrawdown={setHardDrawdown}
-            maxPositions={maxPositions}
-            onMaxPositions={setMaxPositions}
-          />
-        </TabsContent>
+          <TabsContent value="risk">
+            <RiskSettings
+              maxPosition={maxPosition}
+              onMaxPosition={setMaxPosition}
+              maxSector={maxSector}
+              onMaxSector={setMaxSector}
+              dailyLossLimit={dailyLossLimit}
+              onDailyLossLimit={setDailyLossLimit}
+              softDrawdown={softDrawdown}
+              onSoftDrawdown={setSoftDrawdown}
+              hardDrawdown={hardDrawdown}
+              onHardDrawdown={setHardDrawdown}
+              maxPositions={maxPositions}
+              onMaxPositions={setMaxPositions}
+            />
+          </TabsContent>
 
-        <TabsContent value="notifications">
-          <ScheduleSettings
-            alertCritical={alertCritical}
-            onAlertCritical={setAlertCritical}
-            alertWarning={alertWarning}
-            onAlertWarning={setAlertWarning}
-            alertInfo={alertInfo}
-            onAlertInfo={setAlertInfo}
-            alertSound={alertSound}
-            onAlertSound={setAlertSound}
-            agentNotifications={agentNotifications}
-            onAgentNotifications={setAgentNotifications}
-            tradeNotifications={tradeNotifications}
-            onTradeNotifications={setTradeNotifications}
-          />
-        </TabsContent>
+          <TabsContent value="notifications">
+            <ScheduleSettings
+              alertCritical={alertCritical}
+              onAlertCritical={setAlertCritical}
+              alertWarning={alertWarning}
+              onAlertWarning={setAlertWarning}
+              alertInfo={alertInfo}
+              onAlertInfo={setAlertInfo}
+              alertSound={alertSound}
+              onAlertSound={setAlertSound}
+              agentNotifications={agentNotifications}
+              onAgentNotifications={setAgentNotifications}
+              tradeNotifications={tradeNotifications}
+              onTradeNotifications={setTradeNotifications}
+            />
+          </TabsContent>
 
-        {/* ── Trading ──────────────────────────────────────────────── */}
-        <TabsContent value="trading">
-          <div className="grid gap-4 lg:grid-cols-2">
-            <Card className="bg-card border-border">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium text-foreground">Trading Mode</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-1 divide-y divide-border/50">
-                <ToggleField
-                  label="Paper Trading Mode"
-                  description="Use simulated orders instead of real broker. Recommended during development."
-                  checked={paperMode}
-                  onChange={setPaperMode}
-                />
-                <ToggleField
-                  label="Auto Trading"
-                  description="Allow agents to submit orders automatically. When off, orders require manual approval."
-                  checked={autoTrading}
-                  onChange={setAutoTrading}
-                />
-                <ToggleField
-                  label="Require Confirmation"
-                  description="Show confirmation dialog before executing trades."
-                  checked={requireConfirmation}
-                  onChange={setRequireConfirmation}
-                />
-              </CardContent>
-            </Card>
+          {/* ── Trading ──────────────────────────────────────────────── */}
+          <TabsContent value="trading">
+            <div className="grid gap-4 lg:grid-cols-2">
+              <Card className="bg-card border-border">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium text-foreground">
+                    Trading Mode
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-1 divide-y divide-border/50">
+                  <ToggleField
+                    label="Paper Trading Mode"
+                    description="Use simulated orders instead of real broker. Recommended during development."
+                    checked={paperMode}
+                    onChange={setPaperMode}
+                  />
+                  <ToggleField
+                    label="Auto Trading"
+                    description="Allow agents to submit orders automatically. When off, orders require manual approval."
+                    checked={autoTrading}
+                    onChange={setAutoTrading}
+                  />
+                  <ToggleField
+                    label="Require Confirmation"
+                    description="Show confirmation dialog before executing trades."
+                    checked={requireConfirmation}
+                    onChange={setRequireConfirmation}
+                  />
+                </CardContent>
+              </Card>
 
-            <Card className="bg-card border-border">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium text-foreground">Environment</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div className="rounded-md border border-border/50 overflow-hidden">
-                  <div className="bg-muted/30 px-3 py-1.5">
-                    <p className="text-[10px] font-medium tracking-wider text-muted-foreground uppercase">
-                      System Information
+              <Card className="bg-card border-border">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium text-foreground">Environment</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="rounded-md border border-border/50 overflow-hidden">
+                    <div className="bg-muted/30 px-3 py-1.5">
+                      <p className="text-[10px] font-medium tracking-wider text-muted-foreground uppercase">
+                        System Information
+                      </p>
+                    </div>
+                    <div className="divide-y divide-border/50">
+                      {[
+                        ['Platform', 'Sentinel Trading v0.1.0'],
+                        ['Engine', 'FastAPI (Python 3.12)'],
+                        ['Dashboard', 'Next.js 16 + React 19'],
+                        ['Agents', 'Claude SDK (TypeScript)'],
+                        ['Database', 'Supabase (PostgreSQL 15)'],
+                        ['Broker', 'Alpaca Markets API'],
+                        ['Market Data', 'Polygon.io REST + WebSocket'],
+                      ].map(([label, value]) => (
+                        <div key={label} className="flex items-center justify-between px-3 py-2">
+                          <span className="text-xs text-muted-foreground">{label}</span>
+                          <span className="text-xs font-mono text-foreground">{value}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-2 rounded-md bg-muted/30 px-3 py-2">
+                    <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
+                    <p className="text-[11px] text-muted-foreground">
+                      API keys are configured via environment variables in{' '}
+                      <code className="font-mono text-foreground">.env</code>. Risk limits and
+                      trading mode are saved to the database and synced across devices.
                     </p>
                   </div>
-                  <div className="divide-y divide-border/50">
-                    {[
-                      ['Platform', 'Sentinel Trading v0.1.0'],
-                      ['Engine', 'FastAPI (Python 3.12)'],
-                      ['Dashboard', 'Next.js 16 + React 19'],
-                      ['Agents', 'Claude SDK (TypeScript)'],
-                      ['Database', 'Supabase (PostgreSQL 15)'],
-                      ['Broker', 'Alpaca Markets API'],
-                      ['Market Data', 'Polygon.io REST + WebSocket'],
-                    ].map(([label, value]) => (
-                      <div key={label} className="flex items-center justify-between px-3 py-2">
-                        <span className="text-xs text-muted-foreground">{label}</span>
-                        <span className="text-xs font-mono text-foreground">{value}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-                <div className="flex items-start gap-2 rounded-md bg-muted/30 px-3 py-2">
-                  <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
-                  <p className="text-[11px] text-muted-foreground">
-                    API keys are configured via environment variables in{' '}
-                    <code className="font-mono text-foreground">.env</code>. Check the connection
-                    status panel above to verify which services are connected.
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </TabsContent>
-      </Tabs>
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+        </Tabs>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/api/settings/policy/route.ts
+++ b/apps/web/src/app/api/settings/policy/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+import type { TradingPolicy, TradingPolicyUpdate } from '@sentinel/shared';
+import { DEFAULT_TRADING_POLICY } from '@sentinel/shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// ─── Validation ─────────────────────────────────────────────────────
+
+const NUMERIC_FIELDS = [
+  'max_position_pct',
+  'max_sector_pct',
+  'daily_loss_limit_pct',
+  'soft_drawdown_pct',
+  'hard_drawdown_pct',
+] as const;
+
+const BOOLEAN_FIELDS = ['paper_trading', 'auto_trading', 'require_confirmation'] as const;
+
+function validatePolicyUpdate(body: unknown):
+  | {
+      valid: true;
+      data: TradingPolicyUpdate;
+    }
+  | {
+      valid: false;
+      error: string;
+    } {
+  if (!body || typeof body !== 'object') {
+    return { valid: false, error: 'Request body must be a JSON object' };
+  }
+
+  const update: TradingPolicyUpdate = {};
+  const raw = body as Record<string, unknown>;
+
+  for (const field of NUMERIC_FIELDS) {
+    if (field in raw) {
+      const val = Number(raw[field]);
+      if (isNaN(val) || val <= 0 || val > 100) {
+        return { valid: false, error: `${field} must be a number between 0 and 100` };
+      }
+      (update as Record<string, number>)[field] = val;
+    }
+  }
+
+  if ('max_open_positions' in raw) {
+    const val = Number(raw.max_open_positions);
+    if (isNaN(val) || val < 1 || val > 1000 || !Number.isInteger(val)) {
+      return { valid: false, error: 'max_open_positions must be an integer between 1 and 1000' };
+    }
+    update.max_open_positions = val;
+  }
+
+  for (const field of BOOLEAN_FIELDS) {
+    if (field in raw) {
+      if (typeof raw[field] !== 'boolean') {
+        return { valid: false, error: `${field} must be a boolean` };
+      }
+      (update as Record<string, boolean>)[field] = raw[field] as boolean;
+    }
+  }
+
+  // Cross-field validation: soft drawdown must be ≤ hard drawdown
+  const soft = update.soft_drawdown_pct;
+  const hard = update.hard_drawdown_pct;
+  if (soft !== undefined && hard !== undefined && soft > hard) {
+    return { valid: false, error: 'soft_drawdown_pct must be ≤ hard_drawdown_pct' };
+  }
+
+  if (Object.keys(update).length === 0) {
+    return { valid: false, error: 'No valid fields provided' };
+  }
+
+  return { valid: true, data: update };
+}
+
+// ─── GET: Fetch user policy (upserts default if none exists) ────────
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    // Try to fetch existing policy
+    const { data: existing, error: fetchError } = await supabase
+      .from('user_trading_policy')
+      .select('*')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (fetchError) {
+      return NextResponse.json(
+        { error: 'Failed to fetch policy', details: fetchError.message },
+        { status: 500 },
+      );
+    }
+
+    if (existing) {
+      return NextResponse.json(existing as TradingPolicy);
+    }
+
+    // No policy yet — create default
+    const { data: created, error: insertError } = await supabase
+      .from('user_trading_policy')
+      .insert({ user_id: user.id, ...DEFAULT_TRADING_POLICY })
+      .select()
+      .single();
+
+    if (insertError) {
+      return NextResponse.json(
+        { error: 'Failed to create default policy', details: insertError.message },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(created as TradingPolicy);
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// ─── PUT: Update user policy ────────────────────────────────────────
+
+export async function PUT(request: Request): Promise<NextResponse> {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const validation = validatePolicyUpdate(body);
+
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    // Upsert: insert if not exists, update if exists
+    const { data: updated, error: upsertError } = await supabase
+      .from('user_trading_policy')
+      .upsert({ user_id: user.id, ...validation.data }, { onConflict: 'user_id' })
+      .select()
+      .single();
+
+    if (upsertError) {
+      return NextResponse.json(
+        { error: 'Failed to update policy', details: upsertError.message },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(updated as TradingPolicy);
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/hooks/use-trading-policy.ts
+++ b/apps/web/src/hooks/use-trading-policy.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { TradingPolicy, TradingPolicyUpdate } from '@sentinel/shared';
+import { DEFAULT_TRADING_POLICY } from '@sentinel/shared';
+
+interface UseTradingPolicyResult {
+  /** Current policy (defaults until loaded) */
+  policy: TradingPolicy | null;
+  /** Whether the initial fetch is in progress */
+  loading: boolean;
+  /** Whether a save is in progress */
+  saving: boolean;
+  /** Error message from last operation */
+  error: string | null;
+  /** Update policy fields and persist to server */
+  updatePolicy: (update: TradingPolicyUpdate) => Promise<boolean>;
+  /** Refresh policy from server */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Hook for reading and writing the user's trading policy from Supabase.
+ *
+ * - On mount, fetches the user's policy (auto-creates default if none).
+ * - `updatePolicy()` sends a PUT to persist changes and returns success status.
+ * - Optimistic update: UI updates immediately, rolls back on failure.
+ */
+export function useTradingPolicy(): UseTradingPolicyResult {
+  const [policy, setPolicy] = useState<TradingPolicy | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchPolicy = useCallback(async () => {
+    try {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const res = await fetch('/api/settings/policy', {
+        signal: controller.signal,
+        cache: 'no-store',
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+
+      const data = (await res.json()) as TradingPolicy;
+      setPolicy(data);
+      setError(null);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load policy');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPolicy();
+    return () => abortRef.current?.abort();
+  }, [fetchPolicy]);
+
+  const updatePolicy = useCallback(
+    async (update: TradingPolicyUpdate): Promise<boolean> => {
+      setSaving(true);
+      setError(null);
+
+      // Optimistic update
+      const previous = policy;
+      if (policy) {
+        setPolicy({ ...policy, ...update });
+      }
+
+      try {
+        const res = await fetch('/api/settings/policy', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(update),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `HTTP ${res.status}`);
+        }
+
+        const data = (await res.json()) as TradingPolicy;
+        setPolicy(data);
+        return true;
+      } catch (err) {
+        // Rollback on failure
+        setPolicy(previous);
+        setError(err instanceof Error ? err.message : 'Failed to save policy');
+        return false;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [policy],
+  );
+
+  return { policy, loading, saving, error, updatePolicy, refresh: fetchPolicy };
+}
+
+/**
+ * Get a policy value or fall back to default.
+ * Useful in components that need a value before the policy loads.
+ */
+export function policyValue<K extends keyof typeof DEFAULT_TRADING_POLICY>(
+  policy: TradingPolicy | null,
+  key: K,
+): (typeof DEFAULT_TRADING_POLICY)[K] {
+  if (policy && key in policy) {
+    return policy[key as keyof TradingPolicy] as (typeof DEFAULT_TRADING_POLICY)[K];
+  }
+  return DEFAULT_TRADING_POLICY[key];
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,3 +1,56 @@
+// ─── Trading Policy (server-side settings) ──────────────────────────
+
+/**
+ * Risk limits and trading mode persisted in `user_trading_policy` table.
+ * Values are percentages (e.g. 5 = 5%), not decimal fractions.
+ */
+export interface TradingPolicy {
+  id: string;
+  user_id: string;
+  max_position_pct: number;
+  max_sector_pct: number;
+  daily_loss_limit_pct: number;
+  soft_drawdown_pct: number;
+  hard_drawdown_pct: number;
+  max_open_positions: number;
+  paper_trading: boolean;
+  auto_trading: boolean;
+  require_confirmation: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Fields the client can update via PUT /api/settings/policy. */
+export type TradingPolicyUpdate = Partial<
+  Omit<TradingPolicy, 'id' | 'user_id' | 'created_at' | 'updated_at'>
+>;
+
+/** Default policy values matching engine risk_manager.py defaults. */
+export const DEFAULT_TRADING_POLICY: Omit<
+  TradingPolicy,
+  'id' | 'user_id' | 'created_at' | 'updated_at'
+> = {
+  max_position_pct: 5,
+  max_sector_pct: 20,
+  daily_loss_limit_pct: 2,
+  soft_drawdown_pct: 10,
+  hard_drawdown_pct: 15,
+  max_open_positions: 20,
+  paper_trading: true,
+  auto_trading: false,
+  require_confirmation: true,
+};
+
+/** Entry in the policy_change_log audit table. */
+export interface PolicyChangeEntry {
+  id: string;
+  user_id: string;
+  changed_at: string;
+  field_name: string;
+  old_value: string | null;
+  new_value: string | null;
+}
+
 // ─── Enums as Union Types ───────────────────────────────────────────
 
 /** The class of financial instrument being traded or tracked. */

--- a/supabase/migrations/00005_user_trading_policy.sql
+++ b/supabase/migrations/00005_user_trading_policy.sql
@@ -1,0 +1,152 @@
+-- Migration: 00005_user_trading_policy.sql
+-- Purpose: Server-side trading policy storage (replaces localStorage)
+-- Splits settings into: UI preferences (local), trading policy (DB), runtime config (env)
+
+-- ============================================================================
+-- Trigger function for updated_at (reusable across tables)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- User Trading Policy table
+-- ============================================================================
+CREATE TABLE user_trading_policy (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Risk limits (stored as percentages, e.g. 5 = 5%)
+  max_position_pct    NUMERIC(5,2) NOT NULL DEFAULT 5.00,
+  max_sector_pct      NUMERIC(5,2) NOT NULL DEFAULT 20.00,
+  daily_loss_limit_pct NUMERIC(5,2) NOT NULL DEFAULT 2.00,
+  soft_drawdown_pct   NUMERIC(5,2) NOT NULL DEFAULT 10.00,
+  hard_drawdown_pct   NUMERIC(5,2) NOT NULL DEFAULT 15.00,
+  max_open_positions  INTEGER      NOT NULL DEFAULT 20,
+
+  -- Trading mode
+  paper_trading       BOOLEAN NOT NULL DEFAULT true,
+  auto_trading        BOOLEAN NOT NULL DEFAULT false,
+  require_confirmation BOOLEAN NOT NULL DEFAULT true,
+
+  -- Timestamps
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- One policy per user
+  CONSTRAINT uq_user_trading_policy_user UNIQUE (user_id),
+
+  -- Validation
+  CONSTRAINT chk_max_position   CHECK (max_position_pct > 0 AND max_position_pct <= 100),
+  CONSTRAINT chk_max_sector     CHECK (max_sector_pct > 0 AND max_sector_pct <= 100),
+  CONSTRAINT chk_daily_loss     CHECK (daily_loss_limit_pct > 0 AND daily_loss_limit_pct <= 100),
+  CONSTRAINT chk_soft_drawdown  CHECK (soft_drawdown_pct > 0 AND soft_drawdown_pct <= 100),
+  CONSTRAINT chk_hard_drawdown  CHECK (hard_drawdown_pct > 0 AND hard_drawdown_pct <= 100),
+  CONSTRAINT chk_drawdown_order CHECK (soft_drawdown_pct <= hard_drawdown_pct),
+  CONSTRAINT chk_max_positions  CHECK (max_open_positions > 0 AND max_open_positions <= 1000)
+);
+
+-- Auto-update updated_at on every write
+CREATE TRIGGER trg_user_trading_policy_updated_at
+  BEFORE UPDATE ON user_trading_policy
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- Row-Level Security
+-- ============================================================================
+ALTER TABLE user_trading_policy ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own policy"
+  ON user_trading_policy FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own policy"
+  ON user_trading_policy FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own policy"
+  ON user_trading_policy FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================================
+-- Policy change audit log
+-- ============================================================================
+CREATE TABLE policy_change_log (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  changed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  field_name  TEXT NOT NULL,
+  old_value   TEXT,
+  new_value   TEXT
+);
+
+ALTER TABLE policy_change_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own audit log"
+  ON policy_change_log FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Trigger to auto-log policy changes
+CREATE OR REPLACE FUNCTION log_policy_changes()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.max_position_pct IS DISTINCT FROM NEW.max_position_pct THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'max_position_pct', OLD.max_position_pct::TEXT, NEW.max_position_pct::TEXT);
+  END IF;
+  IF OLD.max_sector_pct IS DISTINCT FROM NEW.max_sector_pct THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'max_sector_pct', OLD.max_sector_pct::TEXT, NEW.max_sector_pct::TEXT);
+  END IF;
+  IF OLD.daily_loss_limit_pct IS DISTINCT FROM NEW.daily_loss_limit_pct THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'daily_loss_limit_pct', OLD.daily_loss_limit_pct::TEXT, NEW.daily_loss_limit_pct::TEXT);
+  END IF;
+  IF OLD.soft_drawdown_pct IS DISTINCT FROM NEW.soft_drawdown_pct THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'soft_drawdown_pct', OLD.soft_drawdown_pct::TEXT, NEW.soft_drawdown_pct::TEXT);
+  END IF;
+  IF OLD.hard_drawdown_pct IS DISTINCT FROM NEW.hard_drawdown_pct THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'hard_drawdown_pct', OLD.hard_drawdown_pct::TEXT, NEW.hard_drawdown_pct::TEXT);
+  END IF;
+  IF OLD.max_open_positions IS DISTINCT FROM NEW.max_open_positions THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'max_open_positions', OLD.max_open_positions::TEXT, NEW.max_open_positions::TEXT);
+  END IF;
+  IF OLD.paper_trading IS DISTINCT FROM NEW.paper_trading THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'paper_trading', OLD.paper_trading::TEXT, NEW.paper_trading::TEXT);
+  END IF;
+  IF OLD.auto_trading IS DISTINCT FROM NEW.auto_trading THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'auto_trading', OLD.auto_trading::TEXT, NEW.auto_trading::TEXT);
+  END IF;
+  IF OLD.require_confirmation IS DISTINCT FROM NEW.require_confirmation THEN
+    INSERT INTO policy_change_log (user_id, field_name, old_value, new_value)
+    VALUES (NEW.user_id, 'require_confirmation', OLD.require_confirmation::TEXT, NEW.require_confirmation::TEXT);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_log_policy_changes
+  AFTER UPDATE ON user_trading_policy
+  FOR EACH ROW
+  EXECUTE FUNCTION log_policy_changes();
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+CREATE INDEX idx_policy_change_log_user ON policy_change_log (user_id, changed_at DESC);
+
+-- ============================================================================
+-- Enable Realtime for cross-tab/device sync
+-- ============================================================================
+ALTER PUBLICATION supabase_realtime ADD TABLE user_trading_policy;


### PR DESCRIPTION
Promotes risk limits and trading mode from localStorage to server-side Supabase persistence (Phase 2).

Changes:
- Migration 00005: user_trading_policy + policy_change_log tables with RLS and realtime
- Shared types: TradingPolicy, TradingPolicyUpdate, DEFAULT_TRADING_POLICY
- API route: GET/PUT /api/settings/policy with auth + validation
- Hook: useTradingPolicy with optimistic updates
- Settings page: Risk + Trading from DB, Notifications from localStorage
