### PR TITLE
fix: optimize Railway connection and deployment reliability

### DIFF
--- a/apps/agents/Dockerfile
+++ b/apps/agents/Dockerfile
@@ -1,24 +1,44 @@
 # ─── Sentinel Agents — TypeScript Express ────────────────────────────────────
 # Build context: monorepo root  (docker build -f apps/agents/Dockerfile .)
 FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
 
-RUN npm install --global pnpm@10.32.1
-
-# ─── Dependencies + Runtime ───────────────────────────────────────────────────
-FROM base AS runner
-
+# ─── Dependencies ─────────────────────────────────────────────────────
+FROM base AS deps
 WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/
+COPY apps/agents/package.json apps/agents/
+COPY apps/web/package.json apps/web/
+RUN pnpm install --frozen-lockfile
 
+# ─── Build ────────────────────────────────────────────────────────────
+FROM deps AS build
+COPY packages/shared ./packages/shared
+COPY apps/agents ./apps/agents
+RUN pnpm --filter @sentinel/agents build
+
+# ─── Production dependencies ─────────────────────────────────────────
+FROM base AS prod-deps
+WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/shared/package.json packages/shared/
 COPY apps/agents/package.json apps/agents/
 COPY apps/web/package.json apps/web/
+RUN pnpm install --frozen-lockfile --prod
 
-RUN pnpm install --frozen-lockfile
+# ─── Runner ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+WORKDIR /app
 
-# Copy source after deps (layer cache: deps change less often than src)
-COPY packages/shared ./packages/shared
-COPY apps/agents ./apps/agents
+# Copy production deps (entire workspace to preserve pnpm link structure)
+COPY --from=prod-deps /app ./
+
+# Copy compiled agents output
+COPY --from=build /app/apps/agents/dist ./apps/agents/dist
+
+# Copy shared package source (workspace link target)
+COPY --from=build /app/packages/shared ./packages/shared
 
 RUN addgroup --system --gid 1001 sentinel \
   && adduser --system --uid 1001 --ingroup sentinel sentinel
@@ -26,7 +46,7 @@ USER sentinel
 
 EXPOSE 3001
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD sh -c "wget -qO- http://localhost:${PORT:-3001}/health || exit 1"
 
-CMD ["pnpm", "--filter", "@sentinel/agents", "start"]
+CMD ["node", "apps/agents/dist/index.js"]

--- a/apps/agents/src/engine-client.ts
+++ b/apps/agents/src/engine-client.ts
@@ -3,6 +3,11 @@
  * Used by agents to interact with the quant engine.
  */
 
+import { logger } from './logger.js';
+
+const DEFAULT_READ_TIMEOUT_MS = 10_000;
+const DEFAULT_MUTATION_TIMEOUT_MS = 15_000;
+
 export interface EngineHealth {
   status: string;
   engine: string;
@@ -64,35 +69,106 @@ export class EngineClient {
     this.apiKey = apiKey;
   }
 
-  private async request<T>(path: string, options?: RequestInit): Promise<T> {
-    const url = `${this.baseUrl}${path}`;
-    const res = await fetch(url, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.apiKey}`,
-        ...options?.headers,
-      },
-    });
+  private headers(extra?: HeadersInit): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+      ...(extra as Record<string, string>),
+    };
+  }
 
-    if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new Error(`Engine API error ${res.status}: ${body}`);
+  /** Plain fetch with timeout — used for non-idempotent (POST) requests. */
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number,
+  ): Promise<Response> {
+    try {
+      const res = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+      if (!res.ok) throw new Error(`Engine error: ${res.status}`);
+      return res;
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('Engine error:')) throw err;
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        throw new Error(
+          `Engine timed out after ${timeoutMs}ms: ${init.method ?? 'GET'} ${url}`,
+        );
+      }
+      throw new Error(`Engine unreachable: ${(err as Error).message}`);
     }
+  }
 
+  /** Fetch with timeout + retry on transient failures — used for idempotent GET requests. */
+  private async fetchWithRetry(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number,
+    retries = 1,
+  ): Promise<Response> {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        const res = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+        if (res.ok) return res;
+        if (attempt < retries && [502, 503, 504].includes(res.status)) {
+          logger.warn('engine.retry', { url, status: res.status, attempt: attempt + 1 });
+          await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+          continue;
+        }
+        throw new Error(`Engine error: ${res.status}`);
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('Engine error:')) throw err;
+        if (attempt < retries) {
+          logger.warn('engine.retry', {
+            url,
+            error: (err as Error).message,
+            attempt: attempt + 1,
+          });
+          await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+          continue;
+        }
+        if (err instanceof DOMException && err.name === 'TimeoutError') {
+          throw new Error(
+            `Engine timed out after ${timeoutMs}ms: ${init.method ?? 'GET'} ${url}`,
+          );
+        }
+        throw new Error(`Engine unreachable: ${(err as Error).message}`);
+      }
+    }
+    throw new Error('Engine request failed after all retries');
+  }
+
+  /** GET request with retry and read timeout. */
+  private async get<T>(path: string): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await this.fetchWithRetry(
+      url,
+      { method: 'GET', headers: this.headers() },
+      DEFAULT_READ_TIMEOUT_MS,
+    );
+    return res.json() as Promise<T>;
+  }
+
+  /** POST request with mutation timeout (no retry). */
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await this.fetchWithTimeout(
+      url,
+      { method: 'POST', headers: this.headers(), body: JSON.stringify(body) },
+      DEFAULT_MUTATION_TIMEOUT_MS,
+    );
     return res.json() as Promise<T>;
   }
 
   async getHealth(): Promise<EngineHealth> {
-    return this.request<EngineHealth>('/health');
+    return this.get<EngineHealth>('/health');
   }
 
   async getStrategies(): Promise<StrategiesResponse> {
-    return this.request<StrategiesResponse>('/api/v1/strategies/');
+    return this.get<StrategiesResponse>('/api/v1/strategies/');
   }
 
   async getRiskLimits(): Promise<RiskLimits> {
-    return this.request<RiskLimits>('/api/v1/risk/limits');
+    return this.get<RiskLimits>('/api/v1/risk/limits');
   }
 
   async assessRisk(state: {
@@ -103,10 +179,7 @@ export class EngineClient {
     positions: Record<string, number>;
     position_sectors: Record<string, string>;
   }): Promise<RiskAssessmentResponse> {
-    return this.request<RiskAssessmentResponse>('/api/v1/risk/assess', {
-      method: 'POST',
-      body: JSON.stringify(state),
-    });
+    return this.post<RiskAssessmentResponse>('/api/v1/risk/assess', state);
   }
 
   async calculatePositionSize(params: {
@@ -117,16 +190,13 @@ export class EngineClient {
     risk_fraction?: number;
     atr?: number;
   }): Promise<PositionSizeResponse> {
-    return this.request<PositionSizeResponse>('/api/v1/risk/position-size', {
-      method: 'POST',
-      body: JSON.stringify(params),
-    });
+    return this.post<PositionSizeResponse>('/api/v1/risk/position-size', params);
   }
 
   async ingestData(tickers: string[], timeframe = '1d') {
-    return this.request<{ ingested: number; errors: string[] }>('/api/v1/data/ingest', {
-      method: 'POST',
-      body: JSON.stringify({ tickers, timeframe }),
+    return this.post<{ ingested: number; errors: string[] }>('/api/v1/data/ingest', {
+      tickers,
+      timeframe,
     });
   }
 
@@ -141,7 +211,7 @@ export class EngineClient {
     status?: string;
     account_id?: string;
   }> {
-    return this.request('/api/v1/portfolio/account');
+    return this.get('/api/v1/portfolio/account');
   }
 
   async getPositions(): Promise<
@@ -154,7 +224,7 @@ export class EngineClient {
       current_price?: number;
     }>
   > {
-    return this.request('/api/v1/portfolio/positions');
+    return this.get('/api/v1/portfolio/positions');
   }
 
   async submitOrder(params: {
@@ -171,14 +241,11 @@ export class EngineClient {
     fill_quantity?: number;
     risk_note?: string;
   }> {
-    return this.request('/api/v1/portfolio/orders', {
-      method: 'POST',
-      body: JSON.stringify(params),
-    });
+    return this.post('/api/v1/portfolio/orders', params);
   }
 
   async getOpenOrders(): Promise<unknown[]> {
-    return this.request('/api/v1/portfolio/orders?status=open');
+    return this.get('/api/v1/portfolio/orders?status=open');
   }
 
   // ── Strategies ─────────────────────────────────────────────────
@@ -208,7 +275,7 @@ export class EngineClient {
     const body = Array.isArray(params)
       ? { tickers: params, days: 90, min_strength: 0.3 }
       : { days: 90, min_strength: 0.3, ...params };
-    return this.request('/api/v1/strategies/scan', { method: 'POST', body: JSON.stringify(body) });
+    return this.post('/api/v1/strategies/scan', body);
   }
 
   // ── Data ───────────────────────────────────────────────────────
@@ -225,7 +292,7 @@ export class EngineClient {
       timestamp: string;
     }>
   > {
-    return this.request(`/api/v1/data/quotes?tickers=${tickers.join(',')}`);
+    return this.get(`/api/v1/data/quotes?tickers=${tickers.join(',')}`);
   }
 
   // ── Risk ───────────────────────────────────────────────────────
@@ -247,9 +314,6 @@ export class EngineClient {
     reason: string;
     adjusted_shares: number | null;
   }> {
-    return this.request('/api/v1/risk/pre-trade-check', {
-      method: 'POST',
-      body: JSON.stringify(params),
-    });
+    return this.post('/api/v1/risk/pre-trade-check', params);
   }
 }

--- a/apps/engine/gunicorn_conf.py
+++ b/apps/engine/gunicorn_conf.py
@@ -13,7 +13,8 @@ backlog = 2048
 
 # Worker processes
 # Formula: (2 x CPU cores) + 1 is a good default for I/O-bound apps
-workers = int(os.getenv("WORKERS", multiprocessing.cpu_count() * 2 + 1))
+# Railway sets WEB_CONCURRENCY automatically based on container resources
+workers = int(os.getenv("WEB_CONCURRENCY", os.getenv("WORKERS", multiprocessing.cpu_count() * 2 + 1)))
 worker_class = "uvicorn.workers.UvicornWorker"
 worker_connections = 1000
 max_requests = 1000  # Restart workers after N requests to prevent memory leaks

--- a/apps/engine/railway.toml
+++ b/apps/engine/railway.toml
@@ -1,7 +1,15 @@
 [build]
 dockerfilePath = "Dockerfile"
+watchPatterns = [
+  "src/**",
+  "pyproject.toml",
+  "gunicorn_conf.py",
+  "start.sh"
+]
 
 [deploy]
 healthcheckPath = "/health"
+healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 3
+restartPolicyMaxRetries = 5
+startCommand = "gunicorn src.api.main:app -c gunicorn_conf.py"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,6 +20,25 @@ agents  -> engine, Supabase, Anthropic
 - **Docker Compose** is local development only. Not a production path.
 - The browser never calls backend services directly. All backend traffic flows through same-origin `/api/engine/*` and `/api/agents/*` route handlers.
 
+### Railway Private Networking
+
+Services on the same Railway project can communicate over an internal private network using `<service>.railway.internal` hostnames. This is faster (no public internet round-trip) and more secure (traffic never leaves Railway's network).
+
+**How it works:**
+
+- Engine and Agents both run on Railway, so Agents → Engine calls use the private network.
+- Vercel (Web) is outside Railway, so Web → Engine and Web → Agents must use public Railway URLs.
+
+**Environment variable configuration:**
+
+| Service          | Variable     | Value                                                          | Network  |
+| ---------------- | ------------ | -------------------------------------------------------------- | -------- |
+| Railway Agents   | `ENGINE_URL` | `http://sentinel-engine-trading.railway.internal:8000`         | Private  |
+| Vercel Web       | `ENGINE_URL` | `https://<engine>.up.railway.app`                              | Public   |
+| Vercel Web       | `AGENTS_URL` | `https://<agents>.up.railway.app`                              | Public   |
+
+> **Note:** Private network hostnames use `http` (not `https`) and the Railway-assigned `PORT`. Public URLs use `https` and do not need a port suffix.
+
 ## Environment Ownership by Runtime
 
 ### Vercel (apps/web) -- Browser-Safe


### PR DESCRIPTION
## Railway Connection Optimization

### Changes

**Engine Deploy Config** — \pps/engine/railway.toml\
- Added \healthcheckTimeout = 120\ (engine has heavy gunicorn preload)
- Added \watchPatterns\ to scope rebuilds to relevant files only
- Added explicit \startCommand\ for gunicorn
- Bumped \estartPolicyMaxRetries\ to 5

**Agents EngineClient Timeout + Retry** — \pps/agents/src/engine-client.ts\
- All fetch calls now have \AbortSignal.timeout()\ (10s reads, 15s mutations)
- GET requests retry once on 502/503/504 with 200ms backoff
- POST requests do not retry (not idempotent)
- Clear error messages: timeout vs unreachable vs HTTP status

**Agents Dockerfile** — 4-stage multi-stage build
- \deps\ → \uild\ → \prod-deps\ → \unner\ (proper layer caching)
- TypeScript compiled at build time (\
ode dist/index.js\ not \	sx src/index.ts\)
- Production-only dependencies in runner (smaller image, faster cold starts)
- \start-period=30s\ (up from 15s) for Railway cold starts

**Gunicorn Worker Config** — \pps/engine/gunicorn_conf.py\
- Now checks \WEB_CONCURRENCY\ first (Railway auto-sets this), then \WORKERS\, then auto-calculates

**Documentation** — \docs/deployment.md\
- Added Railway private networking section

### Verification
| Check | Result |
|-------|--------|
| \pnpm lint\ | ✅ 3/3 clean |
| \pnpm test\ | ✅ 537/537 (345 web + 192 agents) |
| Engine pytest | ✅ 467/467 |
| \	sc --noEmit\ (agents) | ✅ |