### PR TITLE
feat(web): bridge Supabase Realtime to TanStack Query cache invalidation

### DIFF
--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from '@/components/layout/sidebar';
 import { Header } from '@/components/layout/header';
 import { useAppStore } from '@/stores/app-store';
 import { useServiceHealth } from '@/hooks/use-service-health';
+import { useRealtimeSync } from '@/hooks/use-realtime-sync';
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen);
@@ -11,6 +12,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   // Single global health pulse — all pages read from the store
   useServiceHealth();
+
+  // Bridge Supabase Realtime → TanStack Query cache invalidation
+  useRealtimeSync();
 
   return (
     <div className="flex h-screen overflow-hidden">

--- a/apps/web/src/hooks/use-realtime-sync.ts
+++ b/apps/web/src/hooks/use-realtime-sync.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { createClient } from '@/lib/supabase/client';
+import { queryKeys } from '@/lib/query-keys';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+/**
+ * Table-to-query-key mapping.
+ *
+ * When a Postgres change fires on a Realtime-enabled table, every query key
+ * listed here is invalidated so TanStack Query triggers a background refetch.
+ */
+const TABLE_INVALIDATION_MAP: Record<string, readonly (readonly string[])[]> = {
+  orders: [queryKeys.portfolio.orders.all(), queryKeys.portfolio.account()],
+  portfolio_positions: [queryKeys.portfolio.positions(), queryKeys.portfolio.account()],
+  alerts: [queryKeys.agents.alerts()],
+  signals: [queryKeys.agents.all, queryKeys.strategies.all],
+  market_data: [queryKeys.data.all],
+  user_trading_policy: [queryKeys.settings.policy()],
+};
+
+const SUBSCRIBED_TABLES = Object.keys(TABLE_INVALIDATION_MAP);
+
+/**
+ * Bridges Supabase Realtime → TanStack Query cache invalidation.
+ *
+ * Mount once at the app-shell level. When any Realtime-enabled table receives
+ * an INSERT, UPDATE, or DELETE, the corresponding query keys are invalidated
+ * and TanStack Query silently refetches in the background.
+ *
+ * This replaces the need for per-component polling or manual refetch triggers.
+ */
+export function useRealtimeSync() {
+  const queryClient = useQueryClient();
+  const channelsRef = useRef<RealtimeChannel[]>([]);
+
+  useEffect(() => {
+    const supabase = createClient();
+    const channels: RealtimeChannel[] = [];
+
+    for (const table of SUBSCRIBED_TABLES) {
+      const channel = supabase
+        .channel(`sentinel-sync:${table}`)
+        .on('postgres_changes' as never, { event: '*', schema: 'public', table }, () => {
+          const keys = TABLE_INVALIDATION_MAP[table];
+          if (!keys) return;
+          for (const queryKey of keys) {
+            queryClient.invalidateQueries({ queryKey: [...queryKey] });
+          }
+        })
+        .subscribe();
+
+      channels.push(channel);
+    }
+
+    channelsRef.current = channels;
+
+    return () => {
+      for (const channel of channelsRef.current) {
+        supabase.removeChannel(channel);
+      }
+      channelsRef.current = [];
+    };
+  }, [queryClient]);
+}

--- a/apps/web/tests/hooks/use-realtime-sync.test.ts
+++ b/apps/web/tests/hooks/use-realtime-sync.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for useRealtimeSync hook.
+ *
+ * Verifies that Supabase Realtime events trigger the correct TanStack Query
+ * cache invalidations, and that channels are properly cleaned up on unmount.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRealtimeSync } from '@/hooks/use-realtime-sync';
+
+// ── Supabase mock ──────────────────────────────────────────────────────────
+
+type ChangeCallback = (payload: Record<string, unknown>) => void;
+
+const subscriptions: { table: string; callback: ChangeCallback }[] = [];
+
+const mockChannel = {
+  on: vi.fn(function (
+    this: typeof mockChannel,
+    _type: string,
+    opts: { table: string },
+    callback: ChangeCallback,
+  ) {
+    subscriptions.push({ table: opts.table, callback });
+    return this;
+  }),
+  subscribe: vi.fn().mockReturnThis(),
+};
+
+const mockSupabaseClient = {
+  channel: vi.fn(() => ({ ...mockChannel, on: mockChannel.on })),
+  removeChannel: vi.fn(),
+};
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabaseClient,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('useRealtimeSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subscriptions.length = 0;
+    // Reset the .on mock to rebuild subscriptions each test
+    mockChannel.on.mockImplementation(function (
+      this: typeof mockChannel,
+      _type: string,
+      opts: { table: string },
+      callback: ChangeCallback,
+    ) {
+      subscriptions.push({ table: opts.table, callback });
+      return this;
+    });
+  });
+
+  it('subscribes to all expected tables on mount', () => {
+    const qc = makeQueryClient();
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    const expectedTables = [
+      'orders',
+      'portfolio_positions',
+      'alerts',
+      'signals',
+      'market_data',
+      'user_trading_policy',
+    ];
+
+    // One channel per table
+    expect(mockSupabaseClient.channel).toHaveBeenCalledTimes(expectedTables.length);
+
+    for (const table of expectedTables) {
+      expect(mockSupabaseClient.channel).toHaveBeenCalledWith(`sentinel-sync:${table}`);
+    }
+  });
+
+  it('removes all channels on unmount', () => {
+    const qc = makeQueryClient();
+    const { unmount } = renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    expect(mockSupabaseClient.removeChannel).not.toHaveBeenCalled();
+    unmount();
+    // One removeChannel call per subscribed table
+    expect(mockSupabaseClient.removeChannel.mock.calls.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('invalidates portfolio queries when orders table changes', () => {
+    const qc = makeQueryClient();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    // Fire the callback for the orders subscription
+    const ordersSub = subscriptions.find((s) => s.table === 'orders');
+    expect(ordersSub).toBeDefined();
+    ordersSub!.callback({ eventType: 'INSERT', new: { id: '1' }, old: {} });
+
+    // Should invalidate portfolio.orders.all and portfolio.account
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['portfolio', 'orders'] }),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['portfolio', 'account'] }),
+    );
+  });
+
+  it('invalidates alerts queries when alerts table changes', () => {
+    const qc = makeQueryClient();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    const alertsSub = subscriptions.find((s) => s.table === 'alerts');
+    alertsSub!.callback({ eventType: 'INSERT', new: { id: '1' }, old: {} });
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['agents', 'alerts'] }));
+  });
+
+  it('invalidates settings policy when user_trading_policy changes', () => {
+    const qc = makeQueryClient();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    const policySub = subscriptions.find((s) => s.table === 'user_trading_policy');
+    expect(policySub).toBeDefined();
+    policySub!.callback({ eventType: 'UPDATE', new: { id: '1' }, old: {} });
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['settings', 'policy'] }));
+  });
+
+  it('invalidates data queries when market_data changes', () => {
+    const qc = makeQueryClient();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    const marketSub = subscriptions.find((s) => s.table === 'market_data');
+    marketSub!.callback({ eventType: 'UPDATE', new: { id: '1' }, old: {} });
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['data'] }));
+  });
+
+  it('invalidates positions and account when portfolio_positions changes', () => {
+    const qc = makeQueryClient();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    const posSub = subscriptions.find((s) => s.table === 'portfolio_positions');
+    posSub!.callback({ eventType: 'DELETE', new: {}, old: { id: '1' } });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['portfolio', 'positions'] }),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['portfolio', 'account'] }),
+    );
+  });
+});


### PR DESCRIPTION
## Phase 3F: Realtime-Query Integration

Bridges Supabase Realtime postgres_changes events to TanStack Query cache invalidation, replacing per-page polling with event-driven refetch.

### Changes

**New: useRealtimeSync hook** (apps/web/src/hooks/use-realtime-sync.ts)
- Subscribes to all 6 Realtime-enabled tables: orders, portfolio_positions, alerts, signals, market_data, user_trading_policy
- Declarative table-to-query-key mapping for easy extension
- On any INSERT/UPDATE/DELETE, invalidates the corresponding TanStack Query caches
- RLS is enforced automatically by Supabase

**Updated: AppShell** (apps/web/src/components/layout/app-shell.tsx)
- Mounts useRealtimeSync() once at the shell level

**New: 7 tests** (apps/web/tests/hooks/use-realtime-sync.test.ts)
- Subscription setup for all expected tables
- Channel cleanup on unmount
- Per-table invalidation verification

### Validation
- pnpm lint: 0 warnings
- pnpm test: 39 files, 352 tests (7 new)
