### PR TITLE
feat: operator roles and approval tiers

### DIFF
--- a/apps/web/src/app/(dashboard)/roles/page.tsx
+++ b/apps/web/src/app/(dashboard)/roles/page.tsx
@@ -1,0 +1,427 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import {
+  Shield,
+  Eye,
+  MessageSquare,
+  CheckCircle2,
+  Settings2,
+  ChevronDown,
+  Clock,
+  AlertTriangle,
+  User,
+} from 'lucide-react';
+import {
+  useRolesQuery,
+  useMyProfileQuery,
+  useUpdateRoleMutation,
+  ROLE_LABELS,
+  ROLE_DESCRIPTIONS,
+  hasRoleLevel,
+} from '@/hooks/queries';
+import type { OperatorRole, UserProfile, RoleChangeEntry } from '@/hooks/queries';
+
+const ROLE_ICONS: Record<OperatorRole, typeof Eye> = {
+  observer: Eye,
+  reviewer: MessageSquare,
+  approver: CheckCircle2,
+  operator: Settings2,
+};
+
+const ROLE_COLORS: Record<OperatorRole, string> = {
+  observer: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  reviewer: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  approver: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  operator: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+};
+
+const ALL_ROLES: OperatorRole[] = ['observer', 'reviewer', 'approver', 'operator'];
+
+function RoleBadge({ role }: { role: OperatorRole }) {
+  const Icon = ROLE_ICONS[role];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${ROLE_COLORS[role]}`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {ROLE_LABELS[role]}
+    </span>
+  );
+}
+
+function RolePermissionsGrid() {
+  const permissions = [
+    {
+      action: 'View dashboards & data',
+      observer: true,
+      reviewer: true,
+      approver: true,
+      operator: true,
+    },
+    {
+      action: 'View recommendations',
+      observer: true,
+      reviewer: true,
+      approver: true,
+      operator: true,
+    },
+    {
+      action: 'Comment on recommendations',
+      observer: false,
+      reviewer: true,
+      approver: true,
+      operator: true,
+    },
+    {
+      action: 'Approve / reject trades',
+      observer: false,
+      reviewer: false,
+      approver: true,
+      operator: true,
+    },
+    {
+      action: 'Change risk policy',
+      observer: false,
+      reviewer: false,
+      approver: false,
+      operator: true,
+    },
+    {
+      action: 'Manage trading mode',
+      observer: false,
+      reviewer: false,
+      approver: false,
+      operator: true,
+    },
+    {
+      action: 'Halt / resume trading',
+      observer: false,
+      reviewer: false,
+      approver: false,
+      operator: true,
+    },
+    {
+      action: 'Assign user roles',
+      observer: false,
+      reviewer: false,
+      approver: false,
+      operator: true,
+    },
+  ];
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 dark:bg-gray-800/50">
+          <tr>
+            <th className="p-3 text-left font-medium text-gray-600 dark:text-gray-400">
+              Permission
+            </th>
+            {ALL_ROLES.map((role) => (
+              <th
+                key={role}
+                className="p-3 text-center font-medium text-gray-600 dark:text-gray-400"
+              >
+                <RoleBadge role={role} />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+          {permissions.map((perm) => (
+            <tr key={perm.action} className="hover:bg-gray-50 dark:hover:bg-gray-800/30">
+              <td className="p-3 text-gray-700 dark:text-gray-300">{perm.action}</td>
+              {ALL_ROLES.map((role) => (
+                <td key={role} className="p-3 text-center">
+                  {perm[role] ? (
+                    <CheckCircle2 className="inline h-4 w-4 text-green-500" />
+                  ) : (
+                    <span className="inline-block h-4 w-4 rounded-full border-2 border-gray-300 dark:border-gray-600" />
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function UserCard({
+  profile,
+  isCurrentUser,
+  canChangeRoles,
+  onChangeRole,
+}: {
+  profile: UserProfile;
+  isCurrentUser: boolean;
+  canChangeRoles: boolean;
+  onChangeRole: (userId: string, newRole: OperatorRole) => void;
+}) {
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  return (
+    <div
+      className={`rounded-lg border p-4 ${isCurrentUser ? 'border-purple-300 bg-purple-50/50 dark:border-purple-700 dark:bg-purple-900/10' : 'border-gray-200 dark:border-gray-700'}`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700">
+            <User className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-gray-900 dark:text-gray-100">
+                {profile.display_name ?? 'Unknown User'}
+              </span>
+              {isCurrentUser && (
+                <span className="rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
+                  You
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Joined {new Date(profile.created_at).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+
+        <div className="relative">
+          {canChangeRoles ? (
+            <button
+              onClick={() => setShowDropdown(!showDropdown)}
+              className="flex items-center gap-1"
+            >
+              <RoleBadge role={profile.role} />
+              <ChevronDown className="h-3.5 w-3.5 text-gray-400" />
+            </button>
+          ) : (
+            <RoleBadge role={profile.role} />
+          )}
+
+          {showDropdown && (
+            <>
+              <div className="fixed inset-0 z-10" onClick={() => setShowDropdown(false)} />
+              <div className="absolute right-0 top-full z-20 mt-1 w-56 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+                {ALL_ROLES.map((role) => (
+                  <button
+                    key={role}
+                    onClick={() => {
+                      onChangeRole(profile.id, role);
+                      setShowDropdown(false);
+                    }}
+                    disabled={role === profile.role}
+                    className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 ${role === profile.role ? 'opacity-50' : ''}`}
+                  >
+                    <RoleBadge role={role} />
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {ROLE_DESCRIPTIONS[role]}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HistoryItem({ entry, profiles }: { entry: RoleChangeEntry; profiles: UserProfile[] }) {
+  const changedBy = profiles.find((p) => p.id === entry.changed_by);
+  const target = profiles.find((p) => p.id === entry.target_user_id);
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-gray-100 p-3 dark:border-gray-800">
+      <Clock className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          <span className="font-medium">{changedBy?.display_name ?? 'System'}</span>
+          {' changed '}
+          <span className="font-medium">{target?.display_name ?? 'Unknown'}</span>
+          {' from '}
+          <RoleBadge role={entry.old_role} />
+          {' to '}
+          <RoleBadge role={entry.new_role} />
+        </p>
+        {entry.reason && (
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Reason: {entry.reason}</p>
+        )}
+        <p className="mt-1 text-xs text-gray-400">{new Date(entry.created_at).toLocaleString()}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function OperatorRolesPage() {
+  const { data: myProfile } = useMyProfileQuery();
+  const { data, isLoading, error } = useRolesQuery();
+  const updateRole = useUpdateRoleMutation();
+  const [reasonDialogUser, setReasonDialogUser] = useState<{
+    id: string;
+    newRole: OperatorRole;
+  } | null>(null);
+  const [reason, setReason] = useState('');
+
+  const myRole = myProfile?.profile?.role ?? 'operator';
+  const canChangeRoles = hasRoleLevel(myRole, 'operator');
+  const profiles = useMemo(() => data?.profiles ?? [], [data?.profiles]);
+
+  const handleChangeRole = (userId: string, newRole: OperatorRole) => {
+    setReasonDialogUser({ id: userId, newRole });
+    setReason('');
+  };
+
+  const confirmRoleChange = () => {
+    if (!reasonDialogUser) return;
+    updateRole.mutate({
+      targetUserId: reasonDialogUser.id,
+      newRole: reasonDialogUser.newRole,
+      reason: reason || undefined,
+    });
+    setReasonDialogUser(null);
+  };
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        <AlertTriangle className="h-5 w-5" />
+        Failed to load roles: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Shield className="h-6 w-6 text-purple-500" />
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Operator Roles</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Manage access levels and approval permissions
+            </p>
+          </div>
+        </div>
+        {myProfile?.profile && <RoleBadge role={myProfile.profile.role} />}
+      </div>
+
+      {/* Your role summary */}
+      <div className="rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-800 dark:bg-purple-900/20">
+        <div className="flex items-center gap-2">
+          <Shield className="h-5 w-5 text-purple-500" />
+          <span className="font-medium text-purple-900 dark:text-purple-100">
+            Your Role: {ROLE_LABELS[myRole]}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-purple-700 dark:text-purple-300">
+          {ROLE_DESCRIPTIONS[myRole]}
+        </p>
+      </div>
+
+      {/* Permissions matrix */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Permission Matrix
+        </h2>
+        <RolePermissionsGrid />
+      </div>
+
+      {/* Team Members */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Team Members
+        </h2>
+        {isLoading ? (
+          <div className="space-y-3">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-20 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {profiles.map((profile) => (
+              <UserCard
+                key={profile.id}
+                profile={profile}
+                isCurrentUser={profile.id === data?.currentUserId}
+                canChangeRoles={canChangeRoles}
+                onChangeRole={handleChangeRole}
+              />
+            ))}
+            {profiles.length === 0 && (
+              <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-8">
+                No team members found. Your profile will be created on first sign-in.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Role Change History */}
+      {(data?.history?.length ?? 0) > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Role Change History
+          </h2>
+          <div className="space-y-2">
+            {data?.history?.map((entry) => (
+              <HistoryItem key={entry.id} entry={entry} profiles={profiles} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Role change confirmation dialog */}
+      {reasonDialogUser && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Change Role</h3>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              Assigning role <RoleBadge role={reasonDialogUser.newRole} /> to this user.
+            </p>
+            <label className="mt-4 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Reason (optional)
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={2}
+              className="mt-1 w-full rounded-lg border border-gray-300 p-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+              placeholder="Why is this role being changed?"
+            />
+            {updateRole.error && (
+              <p className="mt-2 text-sm text-red-600">{updateRole.error.message}</p>
+            )}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setReasonDialogUser(null)}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmRoleChange}
+                disabled={updateRole.isPending}
+                className="rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700 disabled:opacity-50"
+              >
+                {updateRole.isPending ? 'Updating...' : 'Confirm'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Mutation error toast */}
+      {updateRole.isSuccess && (
+        <div className="fixed bottom-4 right-4 rounded-lg bg-green-600 px-4 py-2 text-sm text-white shadow-lg">
+          Role updated successfully
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/api/roles/route.ts
+++ b/apps/web/src/app/api/roles/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type OperatorRole = 'observer' | 'reviewer' | 'approver' | 'operator';
+
+const VALID_ROLES: OperatorRole[] = ['observer', 'reviewer', 'approver', 'operator'];
+
+const ROLE_LEVELS: Record<OperatorRole, number> = {
+  observer: 1,
+  reviewer: 2,
+  approver: 3,
+  operator: 4,
+};
+
+// GET /api/roles — list all user profiles or own profile
+export async function GET(request: Request) {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const scope = searchParams.get('scope') ?? 'all';
+
+  if (scope === 'me') {
+    const { data, error } = await supabase
+      .from('user_profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single();
+
+    if (error && error.code === 'PGRST116') {
+      return NextResponse.json({
+        profile: {
+          id: user.id,
+          display_name: user.email,
+          role: 'operator' as OperatorRole,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      });
+    }
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ profile: data });
+  }
+
+  const { data: profiles, error } = await supabase
+    .from('user_profiles')
+    .select('*')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const { data: history } = await supabase
+    .from('role_change_log')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  return NextResponse.json({
+    profiles: profiles ?? [],
+    history: history ?? [],
+    currentUserId: user.id,
+  });
+}
+
+// PATCH /api/roles — update a user's role (operator only)
+export async function PATCH(request: Request) {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { targetUserId, newRole, reason } = body as {
+    targetUserId: string;
+    newRole: OperatorRole;
+    reason?: string | undefined;
+  };
+
+  if (!targetUserId || !newRole) {
+    return NextResponse.json({ error: 'targetUserId and newRole are required' }, { status: 400 });
+  }
+
+  if (!VALID_ROLES.includes(newRole)) {
+    return NextResponse.json(
+      { error: `Invalid role. Must be: ${VALID_ROLES.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  // Check requester is operator
+  const { data: requesterProfile } = await supabase
+    .from('user_profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  const requesterRole = (requesterProfile?.role ?? 'operator') as OperatorRole;
+  if (ROLE_LEVELS[requesterRole] < ROLE_LEVELS['operator']) {
+    return NextResponse.json({ error: 'Only operators can change roles' }, { status: 403 });
+  }
+
+  // Get current role of target user
+  const { data: targetProfile } = await supabase
+    .from('user_profiles')
+    .select('role')
+    .eq('id', targetUserId)
+    .single();
+
+  const oldRole = (targetProfile?.role ?? 'operator') as OperatorRole;
+
+  if (oldRole === newRole) {
+    return NextResponse.json({ error: 'User already has this role' }, { status: 400 });
+  }
+
+  // Prevent removing the last operator
+  if (targetUserId === user.id && newRole !== 'operator') {
+    const { count } = await supabase
+      .from('user_profiles')
+      .select('id', { count: 'exact', head: true })
+      .eq('role', 'operator');
+
+    if ((count ?? 0) <= 1) {
+      return NextResponse.json({ error: 'Cannot remove the last operator' }, { status: 400 });
+    }
+  }
+
+  // Update role
+  const { error: updateError } = await supabase.from('user_profiles').upsert({
+    id: targetUserId,
+    role: newRole,
+    updated_at: new Date().toISOString(),
+  });
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  // Log the change
+  await supabase.from('role_change_log').insert({
+    target_user_id: targetUserId,
+    changed_by: user.id,
+    old_role: oldRole,
+    new_role: newRole,
+    reason: reason ?? null,
+  });
+
+  return NextResponse.json({
+    success: true,
+    targetUserId,
+    oldRole,
+    newRole,
+  });
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Database,
   Clock,
   Calendar,
+  Shield,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -38,6 +39,7 @@ const navItems = [
   { label: 'Catalysts', href: '/catalysts', icon: Calendar },
   { label: 'Backtest', href: '/backtest', icon: FlaskConical },
   { label: 'Agents', href: '/agents', icon: Bot },
+  { label: 'Roles', href: '/roles', icon: Shield },
   { label: 'Settings', href: '/settings', icon: Settings },
 ] as const;
 

--- a/apps/web/src/hooks/queries/index.ts
+++ b/apps/web/src/hooks/queries/index.ts
@@ -89,6 +89,24 @@ export type {
   CatalystEventCreate,
 } from './use-catalysts-query';
 
+// ── Operator Roles ─────────────────────────────────────────────────
+export {
+  useMyProfileQuery,
+  useRolesQuery,
+  useUpdateRoleMutation,
+  hasRoleLevel,
+  ROLE_LABELS,
+  ROLE_DESCRIPTIONS,
+  ROLE_LEVELS,
+} from './use-roles-query';
+export type {
+  OperatorRole,
+  UserProfile,
+  RoleChangeEntry,
+  RolesResponse,
+  RoleUpdateRequest,
+} from './use-roles-query';
+
 // ── Mutation hooks ─────────────────────────────────────────────────
 export { useSubmitOrderMutation } from './use-submit-order-mutation';
 export { useApproveRecommendationMutation } from './use-approve-recommendation-mutation';

--- a/apps/web/src/hooks/queries/use-roles-query.ts
+++ b/apps/web/src/hooks/queries/use-roles-query.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/query-keys';
+
+export type OperatorRole = 'observer' | 'reviewer' | 'approver' | 'operator';
+
+export interface UserProfile {
+  id: string;
+  display_name: string | null;
+  role: OperatorRole;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RoleChangeEntry {
+  id: string;
+  target_user_id: string;
+  changed_by: string;
+  old_role: OperatorRole;
+  new_role: OperatorRole;
+  reason: string | null;
+  created_at: string;
+}
+
+export interface RolesResponse {
+  profiles: UserProfile[];
+  history: RoleChangeEntry[];
+  currentUserId: string;
+}
+
+export interface MyProfileResponse {
+  profile: UserProfile;
+}
+
+export interface RoleUpdateRequest {
+  targetUserId: string;
+  newRole: OperatorRole;
+  reason?: string | undefined;
+}
+
+export const ROLE_LABELS: Record<OperatorRole, string> = {
+  observer: 'Observer',
+  reviewer: 'Reviewer',
+  approver: 'Approver',
+  operator: 'Operator',
+};
+
+export const ROLE_DESCRIPTIONS: Record<OperatorRole, string> = {
+  observer: 'Read-only access to all dashboards and data',
+  reviewer: 'Can view and comment on recommendations',
+  approver: 'Can approve or reject trade recommendations',
+  operator: 'Full control including role management and policy changes',
+};
+
+export const ROLE_LEVELS: Record<OperatorRole, number> = {
+  observer: 1,
+  reviewer: 2,
+  approver: 3,
+  operator: 4,
+};
+
+export function hasRoleLevel(userRole: OperatorRole, requiredRole: OperatorRole): boolean {
+  return ROLE_LEVELS[userRole] >= ROLE_LEVELS[requiredRole];
+}
+
+export function useMyProfileQuery() {
+  return useQuery<MyProfileResponse>({
+    queryKey: queryKeys.roles.me(),
+    queryFn: async () => {
+      const res = await fetch('/api/roles?scope=me');
+      if (!res.ok) throw new Error('Failed to fetch profile');
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useRolesQuery() {
+  return useQuery<RolesResponse>({
+    queryKey: queryKeys.roles.all(),
+    queryFn: async () => {
+      const res = await fetch('/api/roles');
+      if (!res.ok) throw new Error('Failed to fetch roles');
+      return res.json();
+    },
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useUpdateRoleMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (req: RoleUpdateRequest) => {
+      const res = await fetch('/api/roles', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? 'Failed to update role');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.roles.all(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.roles.me(),
+      });
+    },
+  });
+}

--- a/apps/web/src/hooks/use-realtime-sync.ts
+++ b/apps/web/src/hooks/use-realtime-sync.ts
@@ -27,6 +27,7 @@ const TABLE_INVALIDATION_MAP: Record<string, readonly (readonly string[])[]> = {
   regime_playbooks: [queryKeys.regime.all],
   data_quality_events: [queryKeys.dataQuality.all],
   catalyst_events: [queryKeys.catalysts.all],
+  user_profiles: [queryKeys.roles.all(), queryKeys.roles.me()],
 };
 
 const SUBSCRIBED_TABLES = Object.keys(TABLE_INVALIDATION_MAP);

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -104,4 +104,10 @@ export const queryKeys = {
     all: ['catalysts'] as const,
     list: (filters?: object) => ['catalysts', 'list', filters] as const,
   },
+
+  // ── Roles ──────────────────────────────────────────────────────────
+  roles: {
+    all: () => ['roles'] as const,
+    me: () => ['roles', 'me'] as const,
+  },
 } as const;

--- a/apps/web/tests/hooks/use-realtime-sync.test.ts
+++ b/apps/web/tests/hooks/use-realtime-sync.test.ts
@@ -90,6 +90,7 @@ describe('useRealtimeSync', () => {
       'regime_playbooks',
       'data_quality_events',
       'catalyst_events',
+      'user_profiles',
     ];
 
     // One channel per table
@@ -107,7 +108,7 @@ describe('useRealtimeSync', () => {
     expect(mockSupabaseClient.removeChannel).not.toHaveBeenCalled();
     unmount();
     // One removeChannel call per subscribed table
-    expect(mockSupabaseClient.removeChannel.mock.calls.length).toBeGreaterThanOrEqual(14);
+    expect(mockSupabaseClient.removeChannel.mock.calls.length).toBeGreaterThanOrEqual(15);
   });
 
   it('invalidates portfolio queries when orders table changes', () => {
@@ -290,5 +291,18 @@ describe('useRealtimeSync', () => {
     catSub!.callback({ eventType: 'INSERT', new: { id: '1', event_type: 'earnings' }, old: {} });
 
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['catalysts'] }));
+  });
+
+  it('invalidates roles queries when user_profiles changes', () => {
+    const qc = makeQueryClient();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderHook(() => useRealtimeSync(), { wrapper: wrapper(qc) });
+
+    const profileSub = subscriptions.find((s) => s.table === 'user_profiles');
+    expect(profileSub).toBeDefined();
+    profileSub!.callback({ eventType: 'UPDATE', new: { id: '1', role: 'approver' }, old: {} });
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['roles'] }));
   });
 });

--- a/supabase/migrations/00013_operator_roles.sql
+++ b/supabase/migrations/00013_operator_roles.sql
@@ -1,0 +1,126 @@
+-- Migration: Operator Roles & Approval Tiers
+-- Adds role-based access control for the Sentinel Trading Platform.
+-- Roles: observer (read-only), reviewer (can comment), approver (can approve trades), operator (full control)
+
+-- 1. User profiles table with role assignment
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name TEXT,
+  role TEXT NOT NULL DEFAULT 'operator'
+    CHECK (role IN ('observer', 'reviewer', 'approver', 'operator')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE user_profiles IS 'User profiles with operator role assignments';
+COMMENT ON COLUMN user_profiles.role IS 'observer=read-only, reviewer=can comment, approver=can approve trades, operator=full control';
+
+-- Auto-create profile on first sign-in (default to operator for solo users)
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.user_profiles (id, display_name, role)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.email),
+    'operator'
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger on auth.users insert
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Updated_at trigger
+CREATE TRIGGER set_user_profiles_updated_at
+  BEFORE UPDATE ON user_profiles
+  FOR EACH ROW EXECUTE FUNCTION moddatetime(updated_at);
+
+-- 2. RLS policies for user_profiles
+ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
+
+-- All authenticated users can read all profiles (needed for display names in UI)
+CREATE POLICY "authenticated_read_profiles"
+  ON user_profiles FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- Users can update their own display_name only (role changes require operator)
+CREATE POLICY "users_update_own_profile"
+  ON user_profiles FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+-- Only operators can insert profiles (auto-trigger handles normal creation)
+CREATE POLICY "operators_insert_profiles"
+  ON user_profiles FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated');
+
+-- 3. Helper function to check user role
+CREATE OR REPLACE FUNCTION public.get_user_role(p_user_id UUID DEFAULT auth.uid())
+RETURNS TEXT AS $$
+  SELECT COALESCE(
+    (SELECT role FROM public.user_profiles WHERE id = p_user_id),
+    'operator'
+  );
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+-- 4. Helper function to check if user has minimum role level
+CREATE OR REPLACE FUNCTION public.has_role_level(
+  p_required_role TEXT,
+  p_user_id UUID DEFAULT auth.uid()
+) RETURNS BOOLEAN AS $$
+DECLARE
+  v_user_role TEXT;
+  v_role_levels JSONB := '{"observer": 1, "reviewer": 2, "approver": 3, "operator": 4}'::jsonb;
+BEGIN
+  v_user_role := public.get_user_role(p_user_id);
+  RETURN (v_role_levels->>v_user_role)::int >= (v_role_levels->>p_required_role)::int;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+-- 5. Role change audit log
+CREATE TABLE IF NOT EXISTS role_change_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  target_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  changed_by UUID NOT NULL REFERENCES auth.users(id),
+  old_role TEXT NOT NULL,
+  new_role TEXT NOT NULL,
+  reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE role_change_log ENABLE ROW LEVEL SECURITY;
+
+-- All authenticated users can read role change history
+CREATE POLICY "authenticated_read_role_changes"
+  ON role_change_log FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- Only operators can insert role change records
+CREATE POLICY "operators_insert_role_changes"
+  ON role_change_log FOR INSERT
+  WITH CHECK (public.has_role_level('operator'));
+
+-- 6. Add approved_by to agent_recommendations if not exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'agent_recommendations' AND column_name = 'reviewed_by'
+  ) THEN
+    ALTER TABLE agent_recommendations
+      ADD COLUMN reviewed_by UUID REFERENCES auth.users(id);
+  END IF;
+END $$;
+
+-- 7. Enable realtime for user_profiles
+ALTER PUBLICATION supabase_realtime ADD TABLE user_profiles;
+
+-- 8. Create indexes
+CREATE INDEX IF NOT EXISTS idx_user_profiles_role ON user_profiles(role);
+CREATE INDEX IF NOT EXISTS idx_role_change_log_target ON role_change_log(target_user_id, created_at DESC);


### PR DESCRIPTION
## Operator Roles & Approval Tiers (Phase 7G)

Role-based access control for the Sentinel Trading Platform. Even if solo today, the model is ready for teams.

### Roles Hierarchy
- **Observer**: Read-only access to dashboards and data
- **Reviewer**: Can view and comment on recommendations
- **Approver**: Can approve or reject trade recommendations
- **Operator**: Full control including role management and policy changes

### Changes
- **Migration**: `00013_operator_roles.sql`
  - `user_profiles` table with 4-level role enum
  - Auto-profile creation trigger on `auth.users` insert
  - `get_user_role()` and `has_role_level()` SQL helpers
  - `role_change_log` audit table
  - `reviewed_by` column on `agent_recommendations`
  - RLS policies for profile reads and operator-only writes
- **API**: GET/PATCH `/api/roles` with operator-only role changes
  - Last-operator protection (cannot demote sole operator)
  - Role change audit logging
- **Hooks**: `useMyProfileQuery`, `useRolesQuery`, `useUpdateRoleMutation`
  - `hasRoleLevel()` client-side permission checker
  - Full type exports for `OperatorRole`, `UserProfile`, etc.
- **Page**: `/roles` with permission matrix, user cards, role change dialog
- **Realtime**: `user_profiles` added to sync (15 tables total)
- **Nav**: Roles with Shield icon in sidebar

### Validation
- Lint: pass
- Tests: 362 pass (16 realtime sync tests)
- Build: pass
