### PR TITLE
feat: operator-grade workflow pages (Blueprint Phase 1)

### DIFF
--- a/apps/web/src/app/(dashboard)/approvals/page.tsx
+++ b/apps/web/src/app/(dashboard)/approvals/page.tsx
@@ -1,0 +1,453 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  CheckCircle,
+  Clock,
+  ExternalLink,
+  Filter,
+  Loader2,
+  Shield,
+  TrendingDown,
+  TrendingUp,
+  XCircle,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { TradeRecommendation } from '@/lib/agents-client';
+import { useRecommendationsQuery } from '@/hooks/queries/use-recommendations-query';
+import { useApproveRecommendationMutation } from '@/hooks/queries/use-approve-recommendation-mutation';
+import { useRejectRecommendationMutation } from '@/hooks/queries/use-reject-recommendation-mutation';
+import { ApprovalDialog } from '@/components/agents/approval-dialog';
+
+// ── Filter / sort types ────────────────────────────────────────────
+
+type SideFilter = 'all' | 'buy' | 'sell';
+type SortOption = 'newest' | 'strength';
+
+// ── Skeleton placeholder ───────────────────────────────────────────
+
+function CardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-lg border border-border/50 bg-muted/30 px-4 py-4">
+      <div className="flex items-center gap-3">
+        <div className="h-4 w-4 rounded-full bg-muted" />
+        <div className="flex-1 space-y-2">
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-16 rounded bg-muted" />
+            <div className="h-4 w-10 rounded bg-muted" />
+            <div className="h-3 w-24 rounded bg-muted" />
+          </div>
+          <div className="h-3 w-48 rounded bg-muted" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-7 w-32 rounded bg-muted" />
+          <div className="h-7 w-20 rounded bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Stats bar ──────────────────────────────────────────────────────
+
+interface StatsBarProps {
+  recommendations: TradeRecommendation[];
+}
+
+function StatsBar({ recommendations }: StatsBarProps) {
+  const stats = useMemo(() => {
+    const total = recommendations.length;
+    const buyCount = recommendations.filter((r) => r.side === 'buy').length;
+    const sellCount = recommendations.filter((r) => r.side === 'sell').length;
+    const strengths = recommendations
+      .map((r) => r.signal_strength)
+      .filter((s): s is number => s != null);
+    const avgStrength =
+      strengths.length > 0 ? strengths.reduce((a, b) => a + b, 0) / strengths.length : 0;
+
+    return { total, buyCount, sellCount, avgStrength };
+  }, [recommendations]);
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="rounded-lg border border-border bg-card px-4 py-3">
+        <div className="text-[11px] text-muted-foreground">Pending</div>
+        <div className="mt-1 flex items-center gap-2">
+          <Clock className="h-4 w-4 text-amber-400" />
+          <span className="text-xl font-bold text-foreground">{stats.total}</span>
+        </div>
+      </div>
+      <div className="rounded-lg border border-border bg-card px-4 py-3">
+        <div className="text-[11px] text-muted-foreground">Avg Signal</div>
+        <div className="mt-1 flex items-center gap-2">
+          <CheckCircle className="h-4 w-4 text-blue-400" />
+          <span className="text-xl font-bold text-foreground">
+            {stats.avgStrength > 0 ? `${(stats.avgStrength * 100).toFixed(0)}%` : '—'}
+          </span>
+        </div>
+      </div>
+      <div className="rounded-lg border border-border bg-card px-4 py-3">
+        <div className="text-[11px] text-muted-foreground">Buy</div>
+        <div className="mt-1 flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-profit" />
+          <span className="text-xl font-bold text-foreground">{stats.buyCount}</span>
+        </div>
+      </div>
+      <div className="rounded-lg border border-border bg-card px-4 py-3">
+        <div className="text-[11px] text-muted-foreground">Sell</div>
+        <div className="mt-1 flex items-center gap-2">
+          <TrendingDown className="h-4 w-4 text-loss" />
+          <span className="text-xl font-bold text-foreground">{stats.sellCount}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ──────────────────────────────────────────────────────
+
+export default function ApprovalsPage() {
+  const { data: recommendations, isLoading, isError } = useRecommendationsQuery('pending');
+  const approveMutation = useApproveRecommendationMutation();
+  const rejectMutation = useRejectRecommendationMutation();
+
+  const [reviewingRec, setReviewingRec] = useState<TradeRecommendation | null>(null);
+  const [sideFilter, setSideFilter] = useState<SideFilter>('all');
+  const [strategyFilter, setStrategyFilter] = useState<string>('all');
+  const [sortBy, setSortBy] = useState<SortOption>('newest');
+
+  // Derive unique strategy names for the filter dropdown
+  const strategies = useMemo(() => {
+    if (!recommendations) return [];
+    const names = new Set<string>();
+    for (const r of recommendations) {
+      if (r.strategy_name) names.add(r.strategy_name);
+    }
+    return Array.from(names).sort();
+  }, [recommendations]);
+
+  // Filter and sort
+  const filtered = useMemo(() => {
+    if (!recommendations) return [];
+    let list = [...recommendations];
+
+    if (sideFilter !== 'all') {
+      list = list.filter((r) => r.side === sideFilter);
+    }
+    if (strategyFilter !== 'all') {
+      list = list.filter((r) => r.strategy_name === strategyFilter);
+    }
+
+    list.sort((a, b) => {
+      if (sortBy === 'newest') {
+        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+      }
+      const aStr = a.signal_strength ?? -1;
+      const bStr = b.signal_strength ?? -1;
+      return bStr - aStr;
+    });
+
+    return list;
+  }, [recommendations, sideFilter, strategyFilter, sortBy]);
+
+  // ── Loading state ──────────────────────────────────────────────
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4 p-4">
+        <div className="flex items-center gap-3">
+          <Shield className="h-5 w-5 text-primary" />
+          <h1 className="text-lg font-semibold text-foreground">Pending Approvals</h1>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
+            >
+              <div className="h-3 w-16 rounded bg-muted" />
+              <div className="mt-2 h-6 w-12 rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error state ────────────────────────────────────────────────
+
+  if (isError) {
+    return (
+      <div className="space-y-4 p-4">
+        <div className="flex items-center gap-3">
+          <Shield className="h-5 w-5 text-primary" />
+          <h1 className="text-lg font-semibold text-foreground">Pending Approvals</h1>
+        </div>
+        <Card className="border-red-500/30 bg-red-500/5">
+          <CardContent className="flex items-center gap-3 py-6">
+            <XCircle className="h-5 w-5 shrink-0 text-red-400" />
+            <div>
+              <p className="text-sm font-medium text-red-400">Failed to load recommendations</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Make sure the agents service is running and try again.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const allRecs = recommendations ?? [];
+
+  // ── Rendered page ──────────────────────────────────────────────
+
+  return (
+    <>
+      <div className="space-y-4 p-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Shield className="h-5 w-5 text-primary" />
+            <h1 className="text-lg font-semibold text-foreground">Pending Approvals</h1>
+            {allRecs.length > 0 && (
+              <Badge className="border bg-amber-500/15 text-amber-400 border-amber-500/30 text-[10px]">
+                {allRecs.length} awaiting review
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        {/* Stats bar — always computed from unfiltered pending recs */}
+        <StatsBar recommendations={allRecs} />
+
+        {/* Filters */}
+        <Card className="border-border bg-card">
+          <CardContent className="flex flex-wrap items-center gap-3 py-3">
+            <Filter className="h-4 w-4 shrink-0 text-muted-foreground" />
+
+            {/* Side filter */}
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">Side:</span>
+              {(['all', 'buy', 'sell'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setSideFilter(s)}
+                  className={cn(
+                    'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+                    sideFilter === s
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground hover:bg-muted',
+                  )}
+                >
+                  {s === 'all' ? 'All' : s.toUpperCase()}
+                </button>
+              ))}
+            </div>
+
+            {/* Strategy filter */}
+            {strategies.length > 0 && (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Strategy:</span>
+                <select
+                  value={strategyFilter}
+                  onChange={(e) => setStrategyFilter(e.target.value)}
+                  className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  <option value="all">All</option>
+                  {strategies.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Sort */}
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">Sort:</span>
+              {(['newest', 'strength'] as const).map((opt) => (
+                <button
+                  key={opt}
+                  onClick={() => setSortBy(opt)}
+                  className={cn(
+                    'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+                    sortBy === opt
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground hover:bg-muted',
+                  )}
+                >
+                  {opt === 'newest' ? 'Newest' : 'Strength'}
+                </button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Empty state */}
+        {filtered.length === 0 && (
+          <Card className="border-border bg-card">
+            <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+              <CheckCircle className="mb-3 h-10 w-10 text-emerald-400" />
+              <h2 className="text-sm font-semibold text-foreground">
+                All caught up! No pending approvals.
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {allRecs.length > 0
+                  ? 'No recommendations match the current filters.'
+                  : 'New recommendations will appear here when agents generate them.'}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Recommendation cards */}
+        {filtered.length > 0 && (
+          <div className="space-y-3">
+            {filtered.map((rec) => {
+              const isApproving = approveMutation.isPending && approveMutation.variables === rec.id;
+              const isRejecting = rejectMutation.isPending && rejectMutation.variables === rec.id;
+              const isBusy = isApproving || isRejecting;
+
+              return (
+                <Card key={rec.id} className="border-border bg-card">
+                  <CardContent className="px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      {/* Left: recommendation details */}
+                      <div className="flex min-w-0 items-start gap-3">
+                        {rec.side === 'buy' ? (
+                          <TrendingUp className="mt-0.5 h-5 w-5 shrink-0 text-profit" />
+                        ) : (
+                          <TrendingDown className="mt-0.5 h-5 w-5 shrink-0 text-loss" />
+                        )}
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="text-sm font-bold text-foreground">{rec.ticker}</span>
+                            <Badge
+                              className={cn(
+                                'border text-[9px]',
+                                rec.side === 'buy'
+                                  ? 'bg-profit/10 text-profit border-profit/20'
+                                  : 'bg-loss/10 text-loss border-loss/20',
+                              )}
+                            >
+                              {rec.side.toUpperCase()}
+                            </Badge>
+                            <span className="text-xs text-muted-foreground">
+                              {rec.quantity} shares @ {rec.order_type}
+                            </span>
+                            {rec.signal_strength != null && (
+                              <Badge className="border border-blue-500/20 bg-blue-500/10 text-[9px] text-blue-400">
+                                {(rec.signal_strength * 100).toFixed(0)}% signal
+                              </Badge>
+                            )}
+                          </div>
+
+                          {rec.strategy_name && (
+                            <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+                              {rec.strategy_name}
+                            </div>
+                          )}
+
+                          {rec.reason && (
+                            <p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
+                              {rec.reason}
+                            </p>
+                          )}
+
+                          <div className="mt-1.5 flex items-center gap-3 text-[10px] text-muted-foreground">
+                            <span className="flex items-center gap-1">
+                              <Clock className="h-3 w-3" />
+                              {new Date(rec.created_at).toLocaleString()}
+                            </span>
+                            <Link
+                              href={`/recommendations/${rec.id}`}
+                              className="flex items-center gap-1 text-primary hover:underline"
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                              Full details
+                            </Link>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Right: action buttons */}
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Button
+                          size="sm"
+                          variant="default"
+                          disabled={isBusy}
+                          onClick={() => setReviewingRec(rec)}
+                          className="h-7 bg-profit text-xs hover:bg-profit/80"
+                        >
+                          {isApproving ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <>
+                              <Shield className="mr-1 h-3 w-3" />
+                              Review &amp; Approve
+                            </>
+                          )}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={isBusy}
+                          onClick={() => rejectMutation.mutate(rec.id)}
+                          className="h-7 text-xs"
+                        >
+                          {isRejecting ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <>
+                              <XCircle className="mr-1 h-3 w-3" />
+                              Reject
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Risk review dialog */}
+      {reviewingRec && (
+        <ApprovalDialog
+          recommendationId={reviewingRec.id}
+          ticker={reviewingRec.ticker}
+          side={reviewingRec.side}
+          quantity={reviewingRec.quantity}
+          orderType={reviewingRec.order_type}
+          reason={reviewingRec.reason}
+          strategyName={reviewingRec.strategy_name}
+          signalStrength={reviewingRec.signal_strength}
+          isApproving={approveMutation.isPending && approveMutation.variables === reviewingRec.id}
+          onConfirm={() => {
+            approveMutation.mutate(reviewingRec.id);
+            setReviewingRec(null);
+          }}
+          onCancel={() => setReviewingRec(null)}
+          onReject={() => {
+            rejectMutation.mutate(reviewingRec.id);
+            setReviewingRec(null);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/audit-log/page.tsx
+++ b/apps/web/src/app/(dashboard)/audit-log/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import Link from 'next/link';
 import type { OperatorAction, OperatorActionType } from '@sentinel/shared';
 import {
   useOperatorActionsQuery,
@@ -73,6 +74,16 @@ function truncateUuid(uuid: string): string {
   return uuid.length > 8 ? `${uuid.slice(0, 8)}…` : uuid;
 }
 
+function targetUrl(targetType: string | null, targetId: string | null): string | null {
+  if (!targetType || !targetId) return null;
+  const t = targetType.toLowerCase();
+  if (t === 'recommendation') return `/recommendations/${targetId}`;
+  if (t === 'order') return `/orders`;
+  if (t === 'policy' || t === 'risk_policy') return `/settings`;
+  if (t === 'user' || t === 'role') return `/roles`;
+  return null;
+}
+
 // ─── Sub-components ─────────────────────────────────────────────────
 
 function ActionTypeBadge({ actionType }: { actionType: OperatorActionType }) {
@@ -123,18 +134,28 @@ function ActionRow({ action }: { action: OperatorAction }) {
         {truncateUuid(action.operator_id)}
       </td>
       <td className="px-4 py-3 text-sm text-muted-foreground">
-        {action.target_type ? (
-          <span>
-            <span className="text-foreground">{action.target_type}</span>
-            {action.target_id && (
-              <span className="ml-1 font-mono text-xs" title={action.target_id}>
-                {truncateUuid(action.target_id)}
-              </span>
-            )}
-          </span>
-        ) : (
-          '—'
-        )}
+        {action.target_type
+          ? (() => {
+              const url = targetUrl(action.target_type, action.target_id);
+              const content = (
+                <span>
+                  <span className="text-foreground">{action.target_type}</span>
+                  {action.target_id && (
+                    <span className="ml-1 font-mono text-xs" title={action.target_id}>
+                      {truncateUuid(action.target_id)}
+                    </span>
+                  )}
+                </span>
+              );
+              return url ? (
+                <Link href={url} className="underline-offset-2 hover:underline hover:text-blue-400">
+                  {content}
+                </Link>
+              ) : (
+                content
+              );
+            })()
+          : '—'}
       </td>
       <td
         className="max-w-xs truncate px-4 py-3 text-sm text-muted-foreground"

--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -1,0 +1,674 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import Link from 'next/link';
+import {
+  ArrowUpDown,
+  CheckCircle,
+  Shield,
+  ChevronDown,
+  ChevronUp,
+  Search,
+  Clock,
+  Activity,
+  DollarSign,
+  BarChart3,
+  ExternalLink,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useFillsQuery, useRiskEvaluationsQuery } from '@/hooks/queries';
+import type { Fill, RiskEvaluation, RiskCheck } from '@sentinel/shared';
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+type TimelineEntryType = 'fill' | 'risk';
+
+interface TimelineEntry {
+  id: string;
+  type: TimelineEntryType;
+  timestamp: string;
+  data: Fill | RiskEvaluation;
+}
+
+type DateRange = 'today' | 'week' | 'month' | 'all';
+type TypeFilter = 'all' | 'fills' | 'risk';
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function getDateRangeFrom(range: DateRange): string | undefined {
+  if (range === 'all') return undefined;
+  const now = new Date();
+  if (range === 'today') {
+    now.setHours(0, 0, 0, 0);
+  } else if (range === 'week') {
+    now.setDate(now.getDate() - 7);
+  } else if (range === 'month') {
+    now.setMonth(now.getMonth() - 1);
+  }
+  return now.toISOString();
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`;
+}
+
+function formatCurrency(val: number): string {
+  return `$${val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+// ─── Type Metadata ──────────────────────────────────────────────────────
+
+const ENTRY_META: Record<TimelineEntryType, { label: string; icon: typeof CheckCircle }> = {
+  fill: { label: 'Fill', icon: CheckCircle },
+  risk: { label: 'Risk Eval', icon: Shield },
+};
+
+function getEntryBadgeColor(entry: TimelineEntry): string {
+  if (entry.type === 'fill') {
+    return 'bg-green-500/15 text-green-400';
+  }
+  const risk = entry.data as RiskEvaluation;
+  return risk.allowed ? 'bg-orange-500/15 text-orange-400' : 'bg-red-500/15 text-red-400';
+}
+
+// ─── Stats Row ──────────────────────────────────────────────────────────
+
+function StatsRow({
+  fills,
+  riskEvals,
+  isLoading,
+}: {
+  fills: Fill[];
+  riskEvals: RiskEvaluation[];
+  isLoading: boolean;
+}) {
+  const stats = useMemo(() => {
+    const totalFills = fills.length;
+    const totalRiskEvals = riskEvals.length;
+    const totalEntries = totalFills + totalRiskEvals;
+
+    const totalCommission = fills.reduce((sum, f) => sum + (f.commission ?? 0), 0);
+
+    const slippageValues = fills.filter((f) => f.slippage != null).map((f) => f.slippage as number);
+    const avgSlippage =
+      slippageValues.length > 0
+        ? slippageValues.reduce((a, b) => a + b, 0) / slippageValues.length
+        : null;
+
+    const fillRate = totalEntries > 0 ? ((totalFills / totalEntries) * 100).toFixed(1) : '—';
+
+    return { totalEntries, totalFills, fillRate, totalCommission, avgSlippage };
+  }, [fills, riskEvals]);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i} className="border-zinc-800 bg-zinc-900/50">
+            <CardContent className="p-4">
+              <div className="h-4 w-16 animate-pulse rounded bg-zinc-800" />
+              <div className="mt-2 h-6 w-10 animate-pulse rounded bg-zinc-800" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  const cells = [
+    {
+      label: 'Total Events',
+      value: String(stats.totalEntries),
+      icon: Activity,
+    },
+    {
+      label: 'Fill Rate',
+      value: `${stats.fillRate}%`,
+      icon: BarChart3,
+    },
+    {
+      label: 'Total Commission',
+      value: formatCurrency(stats.totalCommission),
+      icon: DollarSign,
+    },
+    {
+      label: 'Avg Slippage',
+      value: stats.avgSlippage != null ? `${stats.avgSlippage.toFixed(4)}` : '—',
+      icon: ArrowUpDown,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {cells.map((c) => {
+        const Icon = c.icon;
+        return (
+          <Card key={c.label} className="border-zinc-800 bg-zinc-900/50">
+            <CardContent className="p-4">
+              <div className="flex items-center gap-1.5">
+                <Icon className="h-3.5 w-3.5 text-zinc-500" />
+                <p className="text-xs text-zinc-500">{c.label}</p>
+              </div>
+              <p className="mt-1 text-lg font-semibold text-zinc-100">{c.value}</p>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Entry Badge ────────────────────────────────────────────────────────
+
+function EntryBadge({ entry }: { entry: TimelineEntry }) {
+  const meta = ENTRY_META[entry.type];
+  const color = getEntryBadgeColor(entry);
+  const Icon = meta.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${color}`}
+    >
+      <Icon className="h-3 w-3" />
+      {entry.type === 'risk'
+        ? (entry.data as RiskEvaluation).allowed
+          ? 'Allowed'
+          : 'Blocked'
+        : meta.label}
+    </span>
+  );
+}
+
+// ─── Risk Check Row ─────────────────────────────────────────────────────
+
+function RiskCheckRow({ check }: { check: RiskCheck }) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${check.passed ? 'bg-green-400' : 'bg-red-400'}`}
+      />
+      <span className="text-zinc-300">{check.name}</span>
+      {check.actual != null && check.limit != null && (
+        <span className="text-zinc-500">
+          ({check.actual} / {check.limit})
+        </span>
+      )}
+      {check.message && <span className="text-zinc-600 truncate max-w-xs">{check.message}</span>}
+    </div>
+  );
+}
+
+// ─── Fill Detail ────────────────────────────────────────────────────────
+
+function FillDetail({ fill }: { fill: Fill }) {
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-3">
+        <div>
+          <span className="text-zinc-500">Order ID</span>
+          <p className="text-zinc-300 font-mono text-[11px] truncate">{fill.order_id}</p>
+        </div>
+        <div>
+          <span className="text-zinc-500">Fill Price</span>
+          <p className="text-zinc-300">{formatCurrency(fill.fill_price)}</p>
+        </div>
+        <div>
+          <span className="text-zinc-500">Fill Qty</span>
+          <p className="text-zinc-300">{fill.fill_qty}</p>
+        </div>
+        <div>
+          <span className="text-zinc-500">Commission</span>
+          <p className="text-zinc-300">
+            {fill.commission != null ? formatCurrency(fill.commission) : '—'}
+          </p>
+        </div>
+        <div>
+          <span className="text-zinc-500">Slippage</span>
+          <p className="text-zinc-300">{fill.slippage != null ? fill.slippage.toFixed(4) : '—'}</p>
+        </div>
+        <div>
+          <span className="text-zinc-500">Venue</span>
+          <p className="text-zinc-300">{(fill as Fill & { venue?: string | null }).venue ?? '—'}</p>
+        </div>
+      </div>
+      {(fill as Fill & { broker_fill_id?: string | null }).broker_fill_id && (
+        <div className="text-xs">
+          <span className="text-zinc-500">Broker Fill ID: </span>
+          <span className="text-zinc-400 font-mono">
+            {(fill as Fill & { broker_fill_id?: string | null }).broker_fill_id}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Risk Eval Detail ───────────────────────────────────────────────────
+
+function RiskEvalDetail({ evaluation }: { evaluation: RiskEvaluation }) {
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-3">
+        <div>
+          <span className="text-zinc-500">Recommendation</span>
+          <div className="flex items-center gap-1">
+            <p className="text-zinc-300 font-mono text-[11px] truncate">
+              {evaluation.recommendation_id}
+            </p>
+            <Link
+              href={`/recommendations/${evaluation.recommendation_id}`}
+              className="text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          </div>
+        </div>
+        <div>
+          <span className="text-zinc-500">Policy Version</span>
+          <p className="text-zinc-300">{evaluation.policy_version ?? '—'}</p>
+        </div>
+        <div>
+          <span className="text-zinc-500">Decision</span>
+          <p className={evaluation.allowed ? 'text-green-400' : 'text-red-400'}>
+            {evaluation.allowed ? 'Allowed' : 'Blocked'}
+          </p>
+        </div>
+        {evaluation.adjusted_quantity != null && (
+          <div>
+            <span className="text-zinc-500">Adjusted Qty</span>
+            <p className="text-zinc-300">{evaluation.adjusted_quantity}</p>
+          </div>
+        )}
+        {(evaluation as RiskEvaluation & { original_quantity?: number | null }).original_quantity !=
+          null && (
+          <div>
+            <span className="text-zinc-500">Original Qty</span>
+            <p className="text-zinc-300">
+              {
+                (
+                  evaluation as RiskEvaluation & {
+                    original_quantity?: number | null;
+                  }
+                ).original_quantity
+              }
+            </p>
+          </div>
+        )}
+      </div>
+
+      {evaluation.reason && (
+        <div className="text-xs">
+          <span className="text-zinc-500">Reason: </span>
+          <span className="text-zinc-300">{evaluation.reason}</span>
+        </div>
+      )}
+
+      {evaluation.checks_performed.length > 0 && (
+        <div>
+          <p className="mb-1 text-xs font-medium text-zinc-500">
+            Checks ({evaluation.checks_performed.length})
+          </p>
+          <div className="space-y-1">
+            {evaluation.checks_performed.map((check, idx) => (
+              <RiskCheckRow key={`${check.name}-${idx}`} check={check} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Timeline Card ──────────────────────────────────────────────────────
+
+function TimelineCard({ entry }: { entry: TimelineEntry }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const summary = useMemo(() => {
+    if (entry.type === 'fill') {
+      const fill = entry.data as Fill;
+      return {
+        primary: `${fill.fill_qty} @ ${formatCurrency(fill.fill_price)}`,
+        secondary: fill.order_id ? `Order ${fill.order_id.slice(0, 8)}…` : null,
+      };
+    }
+    const risk = entry.data as RiskEvaluation;
+    return {
+      primary: risk.allowed
+        ? `Approved${risk.adjusted_quantity != null ? ` (qty: ${risk.adjusted_quantity})` : ''}`
+        : 'Blocked',
+      secondary: risk.reason,
+    };
+  }, [entry]);
+
+  return (
+    <Card className="border-zinc-800 bg-zinc-900/50">
+      <CardContent className="p-4">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <EntryBadge entry={entry} />
+            <span className="text-sm font-semibold text-zinc-100">{summary.primary}</span>
+            {summary.secondary && (
+              <span className="text-xs text-zinc-500 truncate max-w-xs">{summary.secondary}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0 text-xs text-zinc-500">
+            <Clock className="h-3 w-3" />
+            <time dateTime={entry.timestamp}>{formatTimestamp(entry.timestamp)}</time>
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+              {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </button>
+          </div>
+        </div>
+
+        {/* Quick stats */}
+        {entry.type === 'fill' && (
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+            {(entry.data as Fill).commission != null && (
+              <span>Commission: {formatCurrency((entry.data as Fill).commission ?? 0)}</span>
+            )}
+            {(entry.data as Fill).slippage != null && (
+              <span>Slippage: {((entry.data as Fill).slippage as number).toFixed(4)}</span>
+            )}
+          </div>
+        )}
+
+        {entry.type === 'risk' && (
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+            {(entry.data as RiskEvaluation).checks_performed.length > 0 && (
+              <span>
+                {(entry.data as RiskEvaluation).checks_performed.filter((c) => c.passed).length}/
+                {(entry.data as RiskEvaluation).checks_performed.length} checks passed
+              </span>
+            )}
+            {(entry.data as RiskEvaluation).policy_version && (
+              <span>Policy: {(entry.data as RiskEvaluation).policy_version}</span>
+            )}
+          </div>
+        )}
+
+        {/* Expanded detail */}
+        {expanded && (
+          <div className="mt-3 border-t border-zinc-800 pt-3">
+            {entry.type === 'fill' ? (
+              <FillDetail fill={entry.data as Fill} />
+            ) : (
+              <RiskEvalDetail evaluation={entry.data as RiskEvaluation} />
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Date Range Buttons ─────────────────────────────────────────────────
+
+const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+  { value: 'all', label: 'All' },
+];
+
+const TYPE_FILTER_OPTIONS: { value: TypeFilter; label: string }[] = [
+  { value: 'all', label: 'All Types' },
+  { value: 'fills', label: 'Fills' },
+  { value: 'risk', label: 'Risk Evals' },
+];
+
+// ─── Main Page ──────────────────────────────────────────────────────────
+
+export default function OrdersPage() {
+  const [dateRange, setDateRange] = useState<DateRange>('all');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [symbolSearch, setSymbolSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const pageSize = 30;
+
+  const from = useMemo(() => getDateRangeFrom(dateRange), [dateRange]);
+
+  const fillsQuery = useFillsQuery({
+    limit: 200,
+    from: from,
+  });
+
+  const riskQuery = useRiskEvaluationsQuery({
+    limit: 200,
+  });
+
+  const isLoading = fillsQuery.isLoading || riskQuery.isLoading;
+  const isError = fillsQuery.isError || riskQuery.isError;
+
+  const fills = useMemo(() => fillsQuery.data?.data ?? [], [fillsQuery.data]);
+  const riskEvals = useMemo(() => riskQuery.data?.data ?? [], [riskQuery.data]);
+
+  // Build unified timeline
+  const timeline = useMemo(() => {
+    const entries: TimelineEntry[] = [];
+
+    if (typeFilter === 'all' || typeFilter === 'fills') {
+      for (const fill of fills) {
+        entries.push({
+          id: `fill-${fill.id}`,
+          type: 'fill',
+          timestamp: fill.fill_ts,
+          data: fill,
+        });
+      }
+    }
+
+    if (typeFilter === 'all' || typeFilter === 'risk') {
+      for (const risk of riskEvals) {
+        // Filter risk evals by date range client-side
+        if (from && new Date(risk.evaluated_at) < new Date(from)) {
+          continue;
+        }
+        entries.push({
+          id: `risk-${risk.id}`,
+          type: 'risk',
+          timestamp: risk.evaluated_at,
+          data: risk,
+        });
+      }
+    }
+
+    // Sort by timestamp descending (newest first)
+    entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+    // Symbol search — filter fills by order_id (partial match)
+    if (symbolSearch.trim()) {
+      const q = symbolSearch.trim().toLowerCase();
+      return entries.filter((e) => {
+        if (e.type === 'fill') {
+          const fill = e.data as Fill;
+          return fill.order_id.toLowerCase().includes(q) || fill.id.toLowerCase().includes(q);
+        }
+        if (e.type === 'risk') {
+          const risk = e.data as RiskEvaluation;
+          return (
+            risk.recommendation_id.toLowerCase().includes(q) ||
+            risk.id.toLowerCase().includes(q) ||
+            (risk.reason?.toLowerCase().includes(q) ?? false)
+          );
+        }
+        return true;
+      });
+    }
+
+    return entries;
+  }, [fills, riskEvals, typeFilter, from, symbolSearch]);
+
+  // Paginate
+  const totalEntries = timeline.length;
+  const totalPages = Math.max(1, Math.ceil(totalEntries / pageSize));
+  const pagedEntries = timeline.slice(page * pageSize, (page + 1) * pageSize);
+
+  const handleDateRange = useCallback((range: DateRange) => {
+    setDateRange(range);
+    setPage(0);
+  }, []);
+
+  const handleTypeFilter = useCallback((filter: TypeFilter) => {
+    setTypeFilter(filter);
+    setPage(0);
+  }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setDateRange('all');
+    setTypeFilter('all');
+    setSymbolSearch('');
+    setPage(0);
+  }, []);
+
+  const hasFilters = dateRange !== 'all' || typeFilter !== 'all' || symbolSearch !== '';
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center gap-3">
+        <ArrowUpDown className="h-6 w-6 text-zinc-400" />
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-100">Orders &amp; Fills</h1>
+          <p className="text-sm text-zinc-500">Execution activity timeline</p>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <StatsRow fills={fills} riskEvals={riskEvals} isLoading={isLoading} />
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Date range */}
+        <div className="flex rounded-md border border-zinc-700 overflow-hidden">
+          {DATE_RANGE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => handleDateRange(opt.value)}
+              className={`px-3 py-1.5 text-xs transition-colors ${
+                dateRange === opt.value
+                  ? 'bg-zinc-700 text-zinc-100 font-medium'
+                  : 'bg-zinc-900 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Type filter */}
+        <select
+          value={typeFilter}
+          onChange={(e) => handleTypeFilter(e.target.value as TypeFilter)}
+          className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-sm text-zinc-300 focus:border-zinc-500 focus:outline-none"
+        >
+          {TYPE_FILTER_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Symbol / ID search */}
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
+          <input
+            type="text"
+            placeholder="Search ID or reason…"
+            value={symbolSearch}
+            onChange={(e) => {
+              setSymbolSearch(e.target.value);
+              setPage(0);
+            }}
+            className="rounded-md border border-zinc-700 bg-zinc-900 py-1.5 pl-8 pr-3 text-sm text-zinc-300 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none w-48"
+          />
+        </div>
+
+        {hasFilters && (
+          <button
+            onClick={handleClearFilters}
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            Clear filters
+          </button>
+        )}
+
+        <span className="ml-auto text-xs text-zinc-600">
+          {totalEntries} {totalEntries === 1 ? 'event' : 'events'}
+        </span>
+      </div>
+
+      {/* Timeline */}
+      {isLoading && (
+        <div className="space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="border-zinc-800 bg-zinc-900/50">
+              <CardContent className="p-4">
+                <div className="flex items-center gap-2">
+                  <div className="h-5 w-16 animate-pulse rounded-full bg-zinc-800" />
+                  <div className="h-4 w-32 animate-pulse rounded bg-zinc-800" />
+                </div>
+                <div className="mt-2 h-3 w-48 animate-pulse rounded bg-zinc-800" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <Card className="border-red-900/50 bg-red-950/20">
+          <CardContent className="p-6 text-center text-red-400">
+            Failed to load execution data. Please try again.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && pagedEntries.length === 0 && (
+        <Card className="border-zinc-800 bg-zinc-900/50">
+          <CardContent className="p-12 text-center">
+            <Activity className="mx-auto h-10 w-10 text-zinc-700" />
+            <h3 className="mt-4 text-lg font-medium text-zinc-400">No execution activity yet</h3>
+            <p className="mt-1 text-sm text-zinc-600">
+              Fills and risk evaluations will appear here as trades are executed.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && pagedEntries.length > 0 && (
+        <div className="space-y-3">
+          {pagedEntries.map((entry) => (
+            <TimelineCard key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button
+            onClick={() => setPage(Math.max(0, page - 1))}
+            disabled={page === 0}
+            className="rounded px-3 py-1 text-sm text-zinc-400 hover:text-zinc-200 disabled:opacity-30"
+          >
+            Previous
+          </button>
+          <span className="text-xs text-zinc-500">
+            Page {page + 1} of {totalPages}
+          </span>
+          <button
+            onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
+            disabled={page >= totalPages - 1}
+            className="rounded px-3 py-1 text-sm text-zinc-400 hover:text-zinc-200 disabled:opacity-30"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/system-controls/page.tsx
+++ b/apps/web/src/app/(dashboard)/system-controls/page.tsx
@@ -1,0 +1,587 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  Shield,
+  AlertTriangle,
+  Play,
+  Pause,
+  Settings,
+  Activity,
+  Clock,
+  User,
+  Loader2,
+  AlertOctagon,
+  Zap,
+  FlaskConical,
+  BarChart3,
+  CheckCircle2,
+  XCircle,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  useSystemControlsQuery,
+  useUpdateSystemControlsMutation,
+  useHaltSystemMutation,
+  useResumeSystemMutation,
+} from '@/hooks/queries/use-system-controls-query';
+import type { SystemMode } from '@sentinel/shared';
+
+/* ------------------------------------------------------------------ */
+/*  Confirmation Dialog                                                */
+/* ------------------------------------------------------------------ */
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  variant: 'danger' | 'warning' | 'default';
+  loading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  variant,
+  loading,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  const confirmColors =
+    variant === 'danger'
+      ? 'bg-red-600 hover:bg-red-700 text-white'
+      : variant === 'warning'
+        ? 'bg-amber-600 hover:bg-amber-700 text-white'
+        : 'bg-primary hover:bg-primary/90 text-primary-foreground';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="mx-4 w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-xl">
+        <div className="mb-4 flex items-center gap-3">
+          {variant === 'danger' ? (
+            <AlertOctagon className="h-6 w-6 text-red-500" />
+          ) : (
+            <AlertTriangle className="h-6 w-6 text-amber-500" />
+          )}
+          <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+        </div>
+        <p className="mb-6 text-sm text-muted-foreground">{description}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="rounded-md border border-border bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50 ${confirmColors}`}
+          >
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Mode config                                                        */
+/* ------------------------------------------------------------------ */
+
+const MODE_CONFIG: Record<SystemMode, { label: string; icon: typeof Settings; color: string }> = {
+  paper: { label: 'Paper', icon: FlaskConical, color: 'text-blue-500' },
+  live: { label: 'Live', icon: Zap, color: 'text-green-500' },
+  backtest: { label: 'Backtest', icon: BarChart3, color: 'text-purple-500' },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'medium',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function truncateId(id: string | null): string {
+  if (!id) return 'System';
+  return id.length > 8 ? `${id.slice(0, 8)}…` : id;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Confirm action types                                               */
+/* ------------------------------------------------------------------ */
+
+type ConfirmAction =
+  | { kind: 'halt' }
+  | { kind: 'resume' }
+  | { kind: 'enable_live' }
+  | { kind: 'disable_live' }
+  | { kind: 'change_mode'; mode: SystemMode };
+
+/* ------------------------------------------------------------------ */
+/*  Page Component                                                     */
+/* ------------------------------------------------------------------ */
+
+export default function SystemControlsPage() {
+  const { data: controls, isLoading, isError, error } = useSystemControlsQuery();
+  const updateMutation = useUpdateSystemControlsMutation();
+  const haltMutation = useHaltSystemMutation();
+  const resumeMutation = useResumeSystemMutation();
+
+  const [pendingAction, setPendingAction] = useState<ConfirmAction | undefined>(undefined);
+
+  const isAnyMutating =
+    updateMutation.isPending || haltMutation.isPending || resumeMutation.isPending;
+
+  const requestConfirm = useCallback((action: ConfirmAction) => {
+    setPendingAction(action);
+  }, []);
+
+  const cancelConfirm = useCallback(() => {
+    setPendingAction(undefined);
+  }, []);
+
+  const executeConfirmed = useCallback(() => {
+    if (!pendingAction) return;
+
+    const onDone = () => setPendingAction(undefined);
+
+    switch (pendingAction.kind) {
+      case 'halt':
+        haltMutation.mutate(undefined, { onSettled: onDone });
+        break;
+      case 'resume':
+        resumeMutation.mutate(undefined, { onSettled: onDone });
+        break;
+      case 'enable_live':
+        updateMutation.mutate({ live_execution_enabled: true }, { onSettled: onDone });
+        break;
+      case 'disable_live':
+        updateMutation.mutate({ live_execution_enabled: false }, { onSettled: onDone });
+        break;
+      case 'change_mode':
+        updateMutation.mutate({ global_mode: pendingAction.mode }, { onSettled: onDone });
+        break;
+    }
+  }, [pendingAction, haltMutation, resumeMutation, updateMutation]);
+
+  /* ---- Dialog config per action ---- */
+  function dialogPropsForAction(
+    action: ConfirmAction,
+  ): Omit<ConfirmDialogProps, 'open' | 'loading' | 'onConfirm' | 'onCancel'> {
+    switch (action.kind) {
+      case 'halt':
+        return {
+          title: 'Halt All Trading',
+          description:
+            'This will immediately stop all trading activity across the platform. Open orders will NOT be cancelled automatically. Are you sure?',
+          confirmLabel: 'Halt Trading',
+          variant: 'danger',
+        };
+      case 'resume':
+        return {
+          title: 'Resume Trading',
+          description:
+            'This will re-enable trading activity. Agents will resume processing signals according to their configuration.',
+          confirmLabel: 'Resume Trading',
+          variant: 'warning',
+        };
+      case 'enable_live':
+        return {
+          title: 'Enable Live Execution',
+          description:
+            'Orders will be submitted to the real brokerage. Real money will be at risk. Ensure your risk limits are properly configured.',
+          confirmLabel: 'Enable Live',
+          variant: 'danger',
+        };
+      case 'disable_live':
+        return {
+          title: 'Disable Live Execution',
+          description:
+            'Orders will no longer be submitted to the brokerage. The system will continue generating signals in paper mode.',
+          confirmLabel: 'Disable Live',
+          variant: 'warning',
+        };
+      case 'change_mode':
+        return {
+          title: `Switch to ${MODE_CONFIG[action.mode].label} Mode`,
+          description:
+            action.mode === 'live'
+              ? 'Switching to Live mode means signals may result in real trades if live execution is also enabled.'
+              : `Switching to ${MODE_CONFIG[action.mode].label} mode. No real trades will be executed.`,
+          confirmLabel: `Switch to ${MODE_CONFIG[action.mode].label}`,
+          variant: action.mode === 'live' ? 'danger' : 'default',
+        };
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Loading state                                                      */
+  /* ------------------------------------------------------------------ */
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="flex flex-col items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-8 w-8 animate-spin" />
+          <p className="text-sm">Loading system controls…</p>
+        </div>
+      </div>
+    );
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Error state                                                        */
+  /* ------------------------------------------------------------------ */
+
+  if (isError || !controls) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Card className="w-full max-w-md">
+          <CardContent className="flex flex-col items-center gap-4 py-8">
+            <XCircle className="h-10 w-10 text-red-500" />
+            <div className="text-center">
+              <p className="font-medium text-foreground">Failed to load system controls</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {error instanceof Error ? error.message : 'An unexpected error occurred'}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Derived state                                                      */
+  /* ------------------------------------------------------------------ */
+
+  const isHalted = controls.trading_halted;
+  const isLiveExec = controls.live_execution_enabled;
+  const currentMode = controls.global_mode;
+  const ModeIcon = MODE_CONFIG[currentMode].icon;
+
+  /* ------------------------------------------------------------------ */
+  /*  Render                                                             */
+  /* ------------------------------------------------------------------ */
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+      {/* Page header */}
+      <div className="flex items-center gap-3">
+        <Shield className="h-7 w-7 text-foreground" />
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">System Controls</h1>
+          <p className="text-sm text-muted-foreground">
+            Manage trading state, execution mode, and emergency controls
+          </p>
+        </div>
+      </div>
+
+      {/* ---- Status Cards ---- */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        {/* Trading Status */}
+        <Card>
+          <CardContent className="flex items-center gap-4 py-4">
+            <div
+              className={`flex h-12 w-12 items-center justify-center rounded-full ${
+                isHalted ? 'bg-red-500/10' : 'bg-green-500/10'
+              }`}
+            >
+              {isHalted ? (
+                <Pause className="h-6 w-6 text-red-500" />
+              ) : (
+                <Activity className="h-6 w-6 text-green-500" />
+              )}
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Trading Status</p>
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-semibold text-foreground">
+                  {isHalted ? 'Halted' : 'Active'}
+                </span>
+                <Badge variant={isHalted ? 'destructive' : 'default'}>
+                  {isHalted ? 'HALTED' : 'RUNNING'}
+                </Badge>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Global Mode */}
+        <Card>
+          <CardContent className="flex items-center gap-4 py-4">
+            <div
+              className={`flex h-12 w-12 items-center justify-center rounded-full ${
+                currentMode === 'live'
+                  ? 'bg-green-500/10'
+                  : currentMode === 'paper'
+                    ? 'bg-blue-500/10'
+                    : 'bg-purple-500/10'
+              }`}
+            >
+              <ModeIcon className={`h-6 w-6 ${MODE_CONFIG[currentMode].color}`} />
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Global Mode</p>
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-semibold text-foreground">
+                  {MODE_CONFIG[currentMode].label}
+                </span>
+                <Badge variant="secondary">{currentMode.toUpperCase()}</Badge>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Live Execution */}
+        <Card>
+          <CardContent className="flex items-center gap-4 py-4">
+            <div
+              className={`flex h-12 w-12 items-center justify-center rounded-full ${
+                isLiveExec ? 'bg-amber-500/10' : 'bg-muted'
+              }`}
+            >
+              {isLiveExec ? (
+                <Zap className="h-6 w-6 text-amber-500" />
+              ) : (
+                <Shield className="h-6 w-6 text-muted-foreground" />
+              )}
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Live Execution</p>
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-semibold text-foreground">
+                  {isLiveExec ? 'Enabled' : 'Disabled'}
+                </span>
+                <Badge variant={isLiveExec ? 'destructive' : 'outline'}>
+                  {isLiveExec ? 'LIVE' : 'OFF'}
+                </Badge>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ---- Emergency Controls ---- */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Emergency Controls
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isHalted ? (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3">
+                  <AlertOctagon className="h-8 w-8 text-red-500" />
+                  <div>
+                    <p className="font-semibold text-red-500">Trading is Halted</p>
+                    <p className="text-sm text-muted-foreground">
+                      All trading activity is suspended. Click Resume to re-enable.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => requestConfirm({ kind: 'resume' })}
+                  disabled={isAnyMutating}
+                  className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-700 disabled:opacity-50"
+                >
+                  {resumeMutation.isPending ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <Play className="h-5 w-5" />
+                  )}
+                  Resume Trading
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-medium text-foreground">Emergency Halt</p>
+                <p className="text-sm text-muted-foreground">
+                  Immediately stop all trading activity across the entire platform.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => requestConfirm({ kind: 'halt' })}
+                disabled={isAnyMutating}
+                className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-8 py-4 text-base font-bold text-white shadow-lg transition-all hover:bg-red-700 hover:shadow-xl disabled:opacity-50"
+              >
+                {haltMutation.isPending ? (
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                ) : (
+                  <AlertOctagon className="h-6 w-6" />
+                )}
+                HALT ALL TRADING
+              </button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ---- Mode Selector ---- */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Settings className="h-5 w-5 text-muted-foreground" />
+            Trading Mode
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Set the global operating mode for all agents and strategies.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {(Object.entries(MODE_CONFIG) as [SystemMode, (typeof MODE_CONFIG)[SystemMode]][]).map(
+              ([mode, config]) => {
+                const Icon = config.icon;
+                const isActive = currentMode === mode;
+                return (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => {
+                      if (!isActive) requestConfirm({ kind: 'change_mode', mode });
+                    }}
+                    disabled={isActive || isAnyMutating}
+                    className={`flex items-center gap-3 rounded-lg border p-4 text-left transition-colors ${
+                      isActive
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border bg-card hover:border-primary/50 hover:bg-muted'
+                    } disabled:cursor-default disabled:opacity-70`}
+                  >
+                    <Icon
+                      className={`h-5 w-5 ${isActive ? config.color : 'text-muted-foreground'}`}
+                    />
+                    <div>
+                      <p
+                        className={`font-medium ${isActive ? 'text-foreground' : 'text-foreground'}`}
+                      >
+                        {config.label}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {mode === 'paper' && 'Simulated orders, no real money'}
+                        {mode === 'live' && 'Real orders sent to brokerage'}
+                        {mode === 'backtest' && 'Replay historical data'}
+                      </p>
+                    </div>
+                    {isActive && <CheckCircle2 className="ml-auto h-5 w-5 text-primary" />}
+                  </button>
+                );
+              },
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ---- Live Execution Toggle ---- */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5 text-muted-foreground" />
+            Live Execution
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-medium text-foreground">
+                {isLiveExec ? 'Live execution is enabled' : 'Live execution is disabled'}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {isLiveExec
+                  ? 'Orders are being submitted to your brokerage. Real money is at risk.'
+                  : 'Orders are simulated. No real trades are being placed.'}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => requestConfirm({ kind: isLiveExec ? 'disable_live' : 'enable_live' })}
+              disabled={isAnyMutating}
+              className={`inline-flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-semibold shadow-sm transition-colors disabled:opacity-50 ${
+                isLiveExec
+                  ? 'border border-border bg-card text-foreground hover:bg-muted'
+                  : 'bg-amber-600 text-white hover:bg-amber-700'
+              }`}
+            >
+              {updateMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : isLiveExec ? (
+                <Shield className="h-4 w-4" />
+              ) : (
+                <Zap className="h-4 w-4" />
+              )}
+              {isLiveExec ? 'Disable Live Execution' : 'Enable Live Execution'}
+            </button>
+          </div>
+          {isLiveExec && (
+            <div className="mt-4 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-amber-600 dark:text-amber-400">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              <span>Real money is at risk. Ensure risk limits are configured before trading.</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ---- Last Updated ---- */}
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-x-6 gap-y-2 py-4 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4" />
+            <span>
+              Last updated:{' '}
+              <span className="font-medium text-foreground">
+                {formatTimestamp(controls.updated_at)}
+              </span>
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <User className="h-4 w-4" />
+            <span>
+              By:{' '}
+              <span className="font-medium text-foreground">{truncateId(controls.updated_by)}</span>
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ---- Confirmation Dialog ---- */}
+      {pendingAction && (
+        <ConfirmDialog
+          open={true}
+          {...dialogPropsForAction(pendingAction)}
+          loading={isAnyMutating}
+          onConfirm={executeConfirmed}
+          onCancel={cancelConfirm}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -22,6 +22,9 @@ import {
   Settings,
   ChevronLeft,
   ChevronRight,
+  Power,
+  CheckSquare,
+  ArrowUpDown,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -40,6 +43,9 @@ const navItems = [
   { label: 'Catalysts', href: '/catalysts', icon: Calendar },
   { label: 'Backtest', href: '/backtest', icon: FlaskConical },
   { label: 'Agents', href: '/agents', icon: Bot },
+  { label: 'Approvals', href: '/approvals', icon: CheckSquare },
+  { label: 'Orders', href: '/orders', icon: ArrowUpDown },
+  { label: 'Controls', href: '/system-controls', icon: Power },
   { label: 'Roles', href: '/roles', icon: Shield },
   { label: 'Audit Log', href: '/audit-log', icon: ClipboardList },
   { label: 'Settings', href: '/settings', icon: Settings },


### PR DESCRIPTION
## Blueprint Phase 1: Operator-Grade Workflows

Adds four operator-facing workflow features so every action path is visible and actionable.

### New Pages

**System Controls** (`/system-controls`)
- Live system state display: trading halted, execution mode, global mode
- Emergency HALT / RESUME with confirmation dialogs
- Mode selector (paper/live/backtest) with visual cards
- Live execution toggle with risk warning

**Approvals Queue** (`/approvals`)
- Dedicated pending recommendation queue
- Stats bar: total pending, avg signal strength, buy/sell breakdown
- Side/strategy/sort filters
- Inline reject + Review & Approve (opens ApprovalDialog)
- Links to recommendation detail pages

**Orders & Fills Timeline** (`/orders`)
- Unified chronological timeline of fills + risk evaluations
- Stats: total events, fill rate, commission, slippage
- Date range / type / search filters with pagination
- Expandable detail cards with risk check breakdown
- Links to recommendation detail for risk evaluations

### Enhancements

**Audit Log** - clickable target links (recommendation, order, policy, role targets now link to their detail pages)

**Sidebar** - 3 new nav items: Approvals, Orders, Controls

### Validation
- Lint: 0 errors, 0 warnings
- Tests: 39 files, 368 tests passing
- Build: all pages compile successfully
