### PR TITLE
fix(deploy): optimize Railway Docker builds for production

### DIFF
--- a/apps/agents/Dockerfile
+++ b/apps/agents/Dockerfile
@@ -10,7 +10,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY packages/shared/package.json packages/shared/
 COPY apps/agents/package.json apps/agents/
 COPY apps/web/package.json apps/web/
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
 
 # ─── Build ────────────────────────────────────────────────────────────
 FROM deps AS build
@@ -25,7 +25,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/shared/package.json packages/shared/
 COPY apps/agents/package.json apps/agents/
 COPY apps/web/package.json apps/web/
-RUN pnpm install --frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts && pnpm rebuild
 
 # ─── Runner ───────────────────────────────────────────────────────────
 FROM node:22-alpine AS runner

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -20,7 +20,6 @@
     "jose": "^6.2.2",
     "node-cron": "^4",
     "yaml": "^2.8.3",
-    "tsx": "^4",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -34,6 +33,7 @@
     "@types/node": "^25.5.0",
     "@types/supertest": "^7",
     "supertest": "^7",
+    "tsx": "^4",
     "typescript": "^6",
     "vitest": "^4"
   }

--- a/apps/engine/.dockerignore
+++ b/apps/engine/.dockerignore
@@ -1,0 +1,31 @@
+# Python artifacts
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.hypothesis/
+.pytest_cache/
+.ruff_cache/
+
+# Test suite (not needed in production image)
+tests/
+
+# Coverage and profiling
+.coverage
+htmlcov/
+coverage.xml
+
+# IDE and OS
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Docs
+*.md
+
+# Local env
+.env
+.env.*
+!.env.example

--- a/apps/engine/Dockerfile
+++ b/apps/engine/Dockerfile
@@ -24,9 +24,9 @@ FROM base AS deps
 
 COPY pyproject.toml ./
 
-# Create venv and install all dependencies including Gunicorn
+# Create venv and install production dependencies only
 RUN uv venv .venv \
-  && uv pip install --python .venv/bin/python --no-cache ".[dev]"
+  && uv pip install --python .venv/bin/python --no-cache "."
 
 # ─── Runtime image ────────────────────────────────────────────────────────────
 FROM base AS runner
@@ -36,9 +36,13 @@ WORKDIR /app
 # Copy virtual environment from deps stage
 COPY --from=deps /app/.venv ./.venv
 
+# Put venv on PATH so gunicorn/uvicorn are directly invocable
+ENV PATH="/app/.venv/bin:$PATH"
+
 # Copy application code
 COPY src ./src
-COPY gunicorn_conf.py ./
+COPY gunicorn_conf.py start.sh ./
+RUN chmod +x start.sh
 
 # Create non-root user for security
 RUN addgroup --system --gid 1001 sentinel \
@@ -51,12 +55,10 @@ USER sentinel
 
 EXPOSE 8000
 
-# Health check for container orchestration
+# Health check for container orchestration (shell form for PORT variable)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
   CMD sh -c "curl -f http://localhost:${PORT:-8000}/health || exit 1"
 
-# Production command: Gunicorn with Uvicorn workers
-# This automatically uses uvloop and httptools (installed via uvicorn[standard])
-# Workers are auto-calculated in gunicorn_conf.py based on CPU count
-CMD ["sh", "-c", ".venv/bin/gunicorn src.api.main:app -c gunicorn_conf.py"]
+# Exec form: signals propagate directly to gunicorn (no shell wrapper)
+CMD ["gunicorn", "src.api.main:app", "-c", "gunicorn_conf.py"]
 

--- a/apps/engine/railway.toml
+++ b/apps/engine/railway.toml
@@ -4,7 +4,8 @@ watchPatterns = [
   "src/**",
   "pyproject.toml",
   "gunicorn_conf.py",
-  "start.sh"
+  "start.sh",
+  "Dockerfile"
 ]
 
 [deploy]
@@ -12,4 +13,4 @@ healthcheckPath = "/health"
 healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5
-startCommand = "gunicorn src.api.main:app -c gunicorn_conf.py"
+numReplicas = 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       node-cron:
         specifier: ^4
         version: 4.2.1
-      tsx:
-        specifier: ^4
-        version: 4.21.0
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -99,6 +96,9 @@ importers:
       supertest:
         specifier: ^7
         version: 7.2.2
+      tsx:
+        specifier: ^4
+        version: 4.21.0
       typescript:
         specifier: ^6
         version: 6.0.2

--- a/railway.toml
+++ b/railway.toml
@@ -21,4 +21,4 @@ healthcheckPath = "/health"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5
-startCommand = "pnpm --filter @sentinel/agents start"
+startCommand = "node apps/agents/dist/index.js"


### PR DESCRIPTION
## Changes

### Engine Dockerfile
- Install production deps only (remove \.[dev]\ bloat: pytest, ruff, hypothesis)
- Add venv to PATH so gunicorn/uvicorn are directly invocable
- Use exec-form CMD for proper signal propagation (graceful shutdown)
- Copy start.sh for flexible deployment modes
- Add .dockerignore to exclude .venv, tests, __pycache__ from build context

### Agents Dockerfile
- Add --ignore-scripts && pnpm rebuild for reliable native dep builds
- Move tsx from dependencies to devDependencies (only needed for dev)

### Railway Configs
- **Agents**: fix startCommand to use compiled output (\
ode dist/index.js\) instead of \pnpm→tsx\ which isn't available in the production runner
- **Engine**: remove startCommand (Dockerfile CMD handles it with PATH set), add Dockerfile to watchPatterns, set numReplicas=1

### Validation
- \pnpm lint\ ✅
- \pnpm test\ ✅ (220 tests passed)
- \pnpm --filter @sentinel/agents build\ ✅