### PR TITLE
fix: prevent SSR hydration mismatch for device detection

### DIFF
--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -43,9 +43,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <div
       className={cn(
         'flex h-screen overflow-hidden',
-        device.isTouch && 'touch-device',
+        device.isHydrated && device.isTouch && 'touch-device',
       )}
-      data-device={device.type}
+      {...(device.isHydrated ? { 'data-device': device.type } : {})}
     >
       {/* Desktop sidebar — always visible on lg+ screens */}
       <div className="hidden lg:block">
@@ -73,7 +73,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           id="main-content"
           className={cn(
             'flex-1 overflow-auto',
-            device.isTouch && 'overscroll-contain',
+            device.isHydrated && device.isTouch && 'overscroll-contain',
           )}
         >
           {children}


### PR DESCRIPTION
## Summary

Fixes SSR hydration mismatch discovered during Opus 4.6 enhancement testing fleet.

### Problem
The `data-device` attribute and `touch-device` class were rendered during SSR with desktop defaults (`data-device="desktop"`). On mobile clients, React hydration would detect a different device type, causing a potential layout flash and hydration warning.

### Fix
Gate `data-device` attribute and `touch-device`/`overscroll-contain` classes behind `device.isHydrated`:
- SSR HTML now renders **no** device-specific attributes (clean `<div class="flex h-screen overflow-hidden">`)
- After client hydration, the correct device type is detected and attributes are applied
- Zero flash — CSS media queries handle responsive layout until JS hydrates

### Validation
- `pnpm lint` — 3/3 pass
- `pnpm test` — 363 tests pass
- `pnpm build` — 30/30 pages, 3/3 packages

### Test Fleet Results (5 Opus 4.6 agents)
| Agent | Result |
|-------|--------|
| Device Detection | 5/6 PASS (this PR fixes the 1 FAIL) |
| Responsive Grids | 6/6 PASS |
| CSS & Touch | 5/5 PASS |
| Navigation & Layout | In progress (55+ checks) |
| Build/Lint/Test | All PASS |
