### PR TITLE
fix: notification touch target and roles table responsive padding

### DIFF
--- a/apps/web/src/app/(dashboard)/roles/page.tsx
+++ b/apps/web/src/app/(dashboard)/roles/page.tsx
@@ -131,9 +131,9 @@ function RolePermissionsGrid() {
         <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
           {permissions.map((perm) => (
             <tr key={perm.action} className="hover:bg-gray-50 dark:hover:bg-gray-800/30">
-              <td className="p-3 text-gray-700 dark:text-gray-300">{perm.action}</td>
+              <td className="p-2 text-gray-700 dark:text-gray-300 sm:p-3">{perm.action}</td>
               {ALL_ROLES.map((role) => (
-                <td key={role} className="p-3 text-center">
+                <td key={role} className="p-2 text-center sm:p-3">
                   {perm[role] ? (
                     <CheckCircle2 className="inline h-4 w-4 text-green-500" />
                   ) : (

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -95,7 +95,7 @@ export function NotificationCenter() {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="relative flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+        className="relative flex h-9 w-9 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground transition-colors active:scale-95"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
       >
         <Bell className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Fixes 2 remaining issues found by the Opus 4.6 enhancement testing fleet.

### Fixes
1. **Notification button touch target** — enlarged from h-7 w-7 (28px) to h-9 w-9 (36px) to meet minimum touch target requirements. Added active:scale-95 press feedback.
2. **Roles table responsive padding** — td cells changed from p-3 to p-2 sm:p-3 (8px on mobile, 12px on sm+), matching the th header pattern.

### Validation
- `pnpm lint` — 3/3 pass
- `pnpm test` — 363 tests pass
- `pnpm build` — 30/30 pages, 3/3 packages

### Full Test Fleet Summary (5 Opus 4.6 agents, 31 checks)
| Agent | Checks | Result |
|-------|--------|--------|
| Device Detection | 6 | 6/6 PASS (SSR fix in #104) |
| Responsive Grids | 11 | 6/6 PASS, 5 N/A |
| CSS & Touch | 5 | 5/5 PASS |
| Navigation & Layout | 7 | 7/7 PASS (this PR fixes last 2) |
| Build/Lint/Test | 3 | 3/3 PASS |
