### PR TITLE
fix: agents healthcheck, test assertion, and env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ ENGINE_API_KEY=                              # [REQUIRED] internal API key for w
 
 # ─── Agents ────────────────────────────────────────────────────────────────
 AGENTS_URL=http://localhost:3001             # agent orchestrator base URL
+AGENTS_API_KEY=                              # [OPTIONAL] API key for web → agents auth
 AGENTS_PORT=3001                             # local agents server port
 WEB_URL=http://localhost:3000                # allowed browser origin for local agents CORS
 

--- a/apps/agents/Dockerfile
+++ b/apps/agents/Dockerfile
@@ -47,6 +47,6 @@ USER sentinel
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD sh -c "wget -qO- http://localhost:${PORT:-3001}/health || exit 1"
+  CMD node -e "const http = require('http'); http.get('http://localhost:' + (process.env.PORT || 3001) + '/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
 CMD ["node", "apps/agents/dist/index.js"]

--- a/apps/agents/tests/server.test.ts
+++ b/apps/agents/tests/server.test.ts
@@ -93,9 +93,9 @@ describe('GET /health', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('ok');
     expect(res.body.dependencies).toEqual({
-      engine: false,
-      anthropic: false,
-      supabase: false,
+      engine: 'not_configured',
+      anthropic: 'not_configured',
+      supabase: 'not_configured',
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes the only failing test in the suite and hardens the agents Docker image.

## Changes
1. Dockerfile HEALTHCHECK - Replace wget with node built-in http module
2. Health test assertion - Update expected values from false to not_configured
3. Environment docs - Add AGENTS_API_KEY to .env.example

## Verification
- Lint passes
- Build passes
- Tests pass (656/656 including the fixed agents test)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>