### PR TITLE
fix: CI pipeline, RLS security & performance, FK indexes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/supabase/migrations/00027_tighten_system_table_rls.sql
+++ b/supabase/migrations/00027_tighten_system_table_rls.sql
@@ -1,0 +1,60 @@
+-- Migration 00027: Tighten permissive RLS on system/agent tables
+-- 
+-- Problem: 12 RLS policies on system tables use WITH CHECK (true) or
+-- USING (true) for INSERT/UPDATE/ALL operations for the authenticated role.
+-- This lets ANY authenticated user write to agent_alerts, agent_recommendations,
+-- backtest_results, cycle_history, orchestrator_locks, workflow_jobs,
+-- workflow_runs, and workflow_step_log. Only service_role should write.
+--
+-- Fix: Drop the overly-permissive authenticated write policies.
+-- Keep authenticated SELECT (read-only) and service_role ALL intact.
+
+BEGIN;
+
+-- ============================================================
+-- agent_alerts: remove authenticated INSERT + UPDATE (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "agent_alerts_authenticated_insert" ON public.agent_alerts;
+DROP POLICY IF EXISTS "agent_alerts_authenticated_update" ON public.agent_alerts;
+
+-- ============================================================
+-- agent_recommendations: remove authenticated INSERT + UPDATE (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "agent_recommendations_authenticated_insert" ON public.agent_recommendations;
+DROP POLICY IF EXISTS "agent_recommendations_authenticated_update" ON public.agent_recommendations;
+
+-- ============================================================
+-- backtest_results: remove authenticated INSERT + UPDATE (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "backtest_results_authenticated_write" ON public.backtest_results;
+DROP POLICY IF EXISTS "backtest_results_authenticated_update" ON public.backtest_results;
+
+-- ============================================================
+-- cycle_history: remove authenticated INSERT (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "auth_insert_cycles" ON public.cycle_history;
+
+-- ============================================================
+-- orchestrator_locks: remove the overly-permissive ALL policy
+-- Replace with service_role-only write + authenticated read-only
+-- (auth_read_locks SELECT policy already exists)
+-- ============================================================
+DROP POLICY IF EXISTS "auth_manage_locks" ON public.orchestrator_locks;
+
+-- ============================================================
+-- workflow_jobs: remove authenticated INSERT + UPDATE (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "Authenticated users can insert workflow jobs" ON public.workflow_jobs;
+DROP POLICY IF EXISTS "Authenticated users can update workflow jobs" ON public.workflow_jobs;
+
+-- ============================================================
+-- workflow_runs: remove authenticated INSERT (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "workflow_runs_authenticated_insert" ON public.workflow_runs;
+
+-- ============================================================
+-- workflow_step_log: remove authenticated INSERT (keep SELECT)
+-- ============================================================
+DROP POLICY IF EXISTS "Authenticated users can insert step logs" ON public.workflow_step_log;
+
+COMMIT;

--- a/supabase/migrations/00028_optimize_rls_initplan.sql
+++ b/supabase/migrations/00028_optimize_rls_initplan.sql
@@ -1,0 +1,410 @@
+-- Migration 00028: Optimize RLS initplan — wrap auth.uid() in (select ...)
+--
+-- Problem: 59 RLS policies across 29 tables call auth.uid() directly,
+-- causing PostgreSQL to re-evaluate the function for EVERY row.
+-- Wrapping in (select auth.uid()) makes it a one-time InitPlan evaluation.
+--
+-- Reference: https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select
+
+BEGIN;
+
+-- ============================================================
+-- advisor_memory_events (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own memory events" ON public.advisor_memory_events;
+CREATE POLICY "Users can view own memory events"
+  ON public.advisor_memory_events FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own memory events" ON public.advisor_memory_events;
+CREATE POLICY "Users can insert own memory events"
+  ON public.advisor_memory_events FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- advisor_messages (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own advisor messages" ON public.advisor_messages;
+CREATE POLICY "Users can view own advisor messages"
+  ON public.advisor_messages FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own advisor messages" ON public.advisor_messages;
+CREATE POLICY "Users can insert own advisor messages"
+  ON public.advisor_messages FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- advisor_preferences (4 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own advisor preferences" ON public.advisor_preferences;
+CREATE POLICY "Users can view own advisor preferences"
+  ON public.advisor_preferences FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own advisor preferences" ON public.advisor_preferences;
+CREATE POLICY "Users can insert own advisor preferences"
+  ON public.advisor_preferences FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own advisor preferences" ON public.advisor_preferences;
+CREATE POLICY "Users can update own advisor preferences"
+  ON public.advisor_preferences FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can delete own advisor preferences" ON public.advisor_preferences;
+CREATE POLICY "Users can delete own advisor preferences"
+  ON public.advisor_preferences FOR DELETE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- advisor_profiles (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own advisor profile" ON public.advisor_profiles;
+CREATE POLICY "Users can view own advisor profile"
+  ON public.advisor_profiles FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own advisor profile" ON public.advisor_profiles;
+CREATE POLICY "Users can insert own advisor profile"
+  ON public.advisor_profiles FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own advisor profile" ON public.advisor_profiles;
+CREATE POLICY "Users can update own advisor profile"
+  ON public.advisor_profiles FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- advisor_threads (4 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own advisor threads" ON public.advisor_threads;
+CREATE POLICY "Users can view own advisor threads"
+  ON public.advisor_threads FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own advisor threads" ON public.advisor_threads;
+CREATE POLICY "Users can insert own advisor threads"
+  ON public.advisor_threads FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own advisor threads" ON public.advisor_threads;
+CREATE POLICY "Users can update own advisor threads"
+  ON public.advisor_threads FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can delete own advisor threads" ON public.advisor_threads;
+CREATE POLICY "Users can delete own advisor threads"
+  ON public.advisor_threads FOR DELETE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- bank_links (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own bank links" ON public.bank_links;
+CREATE POLICY "Users can view own bank links"
+  ON public.bank_links FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own bank links" ON public.bank_links;
+CREATE POLICY "Users can insert own bank links"
+  ON public.bank_links FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own bank links" ON public.bank_links;
+CREATE POLICY "Users can update own bank links"
+  ON public.bank_links FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- broker_accounts (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own broker accounts" ON public.broker_accounts;
+CREATE POLICY "Users can view own broker accounts"
+  ON public.broker_accounts FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own broker accounts" ON public.broker_accounts;
+CREATE POLICY "Users can insert own broker accounts"
+  ON public.broker_accounts FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own broker accounts" ON public.broker_accounts;
+CREATE POLICY "Users can update own broker accounts"
+  ON public.broker_accounts FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- catalyst_events (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can delete own catalysts" ON public.catalyst_events;
+CREATE POLICY "Users can delete own catalysts"
+  ON public.catalyst_events FOR DELETE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own catalysts" ON public.catalyst_events;
+CREATE POLICY "Users can insert own catalysts"
+  ON public.catalyst_events FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own catalysts" ON public.catalyst_events;
+CREATE POLICY "Users can update own catalysts"
+  ON public.catalyst_events FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- consents (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "users_read_own_consents" ON public.consents;
+CREATE POLICY "users_read_own_consents"
+  ON public.consents FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_insert_own_consents" ON public.consents;
+CREATE POLICY "users_insert_own_consents"
+  ON public.consents FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- customer_profiles (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "users_read_own_customer_profile" ON public.customer_profiles;
+CREATE POLICY "users_read_own_customer_profile"
+  ON public.customer_profiles FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_insert_own_customer_profile" ON public.customer_profiles;
+CREATE POLICY "users_insert_own_customer_profile"
+  ON public.customer_profiles FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_update_own_customer_profile" ON public.customer_profiles;
+CREATE POLICY "users_update_own_customer_profile"
+  ON public.customer_profiles FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- data_quality_events (1 policy)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can manage own data quality events" ON public.data_quality_events;
+CREATE POLICY "Users can manage own data quality events"
+  ON public.data_quality_events FOR ALL TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- decision_journal (1 policy)
+-- ============================================================
+DROP POLICY IF EXISTS "Users own their journal entries" ON public.decision_journal;
+CREATE POLICY "Users own their journal entries"
+  ON public.decision_journal FOR ALL TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- experiment_orders (3 policies — auth.uid() inside subquery)
+-- ============================================================
+DROP POLICY IF EXISTS "experiment_orders_select" ON public.experiment_orders;
+CREATE POLICY "experiment_orders_select"
+  ON public.experiment_orders FOR SELECT TO authenticated
+  USING (experiment_id IN (SELECT id FROM experiments WHERE created_by = (select auth.uid())));
+
+DROP POLICY IF EXISTS "experiment_orders_insert" ON public.experiment_orders;
+CREATE POLICY "experiment_orders_insert"
+  ON public.experiment_orders FOR INSERT TO authenticated
+  WITH CHECK (experiment_id IN (SELECT id FROM experiments WHERE created_by = (select auth.uid())));
+
+DROP POLICY IF EXISTS "experiment_orders_update" ON public.experiment_orders;
+CREATE POLICY "experiment_orders_update"
+  ON public.experiment_orders FOR UPDATE TO authenticated
+  USING (experiment_id IN (SELECT id FROM experiments WHERE created_by = (select auth.uid())));
+
+-- ============================================================
+-- experiment_snapshots (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "experiment_snapshots_select" ON public.experiment_snapshots;
+CREATE POLICY "experiment_snapshots_select"
+  ON public.experiment_snapshots FOR SELECT TO authenticated
+  USING (experiment_id IN (SELECT id FROM experiments WHERE created_by = (select auth.uid())));
+
+DROP POLICY IF EXISTS "experiment_snapshots_insert" ON public.experiment_snapshots;
+CREATE POLICY "experiment_snapshots_insert"
+  ON public.experiment_snapshots FOR INSERT TO authenticated
+  WITH CHECK (experiment_id IN (SELECT id FROM experiments WHERE created_by = (select auth.uid())));
+
+-- ============================================================
+-- experiments (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "experiments_select" ON public.experiments;
+CREATE POLICY "experiments_select"
+  ON public.experiments FOR SELECT TO authenticated
+  USING (created_by = (select auth.uid()));
+
+DROP POLICY IF EXISTS "experiments_insert" ON public.experiments;
+CREATE POLICY "experiments_insert"
+  ON public.experiments FOR INSERT TO authenticated
+  WITH CHECK (created_by = (select auth.uid()));
+
+DROP POLICY IF EXISTS "experiments_update" ON public.experiments;
+CREATE POLICY "experiments_update"
+  ON public.experiments FOR UPDATE TO authenticated
+  USING (created_by = (select auth.uid()));
+
+-- ============================================================
+-- external_portfolio_links (4 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "users_read_own_external_links" ON public.external_portfolio_links;
+CREATE POLICY "users_read_own_external_links"
+  ON public.external_portfolio_links FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_insert_own_external_links" ON public.external_portfolio_links;
+CREATE POLICY "users_insert_own_external_links"
+  ON public.external_portfolio_links FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_update_own_external_links" ON public.external_portfolio_links;
+CREATE POLICY "users_update_own_external_links"
+  ON public.external_portfolio_links FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_delete_own_external_links" ON public.external_portfolio_links;
+CREATE POLICY "users_delete_own_external_links"
+  ON public.external_portfolio_links FOR DELETE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- funding_transactions (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own funding transactions" ON public.funding_transactions;
+CREATE POLICY "Users can view own funding transactions"
+  ON public.funding_transactions FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own funding transactions" ON public.funding_transactions;
+CREATE POLICY "Users can insert own funding transactions"
+  ON public.funding_transactions FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- market_regime_history (1 policy)
+-- ============================================================
+DROP POLICY IF EXISTS "Users own their regime history" ON public.market_regime_history;
+CREATE POLICY "Users own their regime history"
+  ON public.market_regime_history FOR ALL TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- onboarding_audit_log (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "users_read_own_onboarding_audit" ON public.onboarding_audit_log;
+CREATE POLICY "users_read_own_onboarding_audit"
+  ON public.onboarding_audit_log FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "users_insert_own_onboarding_audit" ON public.onboarding_audit_log;
+CREATE POLICY "users_insert_own_onboarding_audit"
+  ON public.onboarding_audit_log FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- operator_actions (1 policy — uses operator_id)
+-- ============================================================
+DROP POLICY IF EXISTS "Authenticated users can insert operator actions" ON public.operator_actions;
+CREATE POLICY "Authenticated users can insert operator actions"
+  ON public.operator_actions FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = operator_id);
+
+-- ============================================================
+-- policy_change_log (1 policy)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can read own audit log" ON public.policy_change_log;
+CREATE POLICY "Users can read own audit log"
+  ON public.policy_change_log FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- recommendation_explanations (2 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view own recommendation explanations" ON public.recommendation_explanations;
+CREATE POLICY "Users can view own recommendation explanations"
+  ON public.recommendation_explanations FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own recommendation explanations" ON public.recommendation_explanations;
+CREATE POLICY "Users can insert own recommendation explanations"
+  ON public.recommendation_explanations FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- regime_playbooks (1 policy)
+-- ============================================================
+DROP POLICY IF EXISTS "Users own their playbooks" ON public.regime_playbooks;
+CREATE POLICY "Users own their playbooks"
+  ON public.regime_playbooks FOR ALL TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- shadow_portfolios (1 policy)
+-- ============================================================
+DROP POLICY IF EXISTS "Users manage own shadow portfolios" ON public.shadow_portfolios;
+CREATE POLICY "Users manage own shadow portfolios"
+  ON public.shadow_portfolios FOR ALL TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ============================================================
+-- shadow_portfolio_snapshots (1 policy — uses subquery)
+-- ============================================================
+DROP POLICY IF EXISTS "Users see own shadow snapshots" ON public.shadow_portfolio_snapshots;
+CREATE POLICY "Users see own shadow snapshots"
+  ON public.shadow_portfolio_snapshots FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM shadow_portfolios sp
+    WHERE sp.id = shadow_portfolio_snapshots.shadow_portfolio_id
+      AND sp.user_id = (select auth.uid())
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM shadow_portfolios sp
+    WHERE sp.id = shadow_portfolio_snapshots.shadow_portfolio_id
+      AND sp.user_id = (select auth.uid())
+  ));
+
+-- ============================================================
+-- user_profiles (1 policy — uses id, not user_id)
+-- ============================================================
+DROP POLICY IF EXISTS "users_update_own_profile" ON public.user_profiles;
+CREATE POLICY "users_update_own_profile"
+  ON public.user_profiles FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = id)
+  WITH CHECK ((select auth.uid()) = id);
+
+-- ============================================================
+-- user_trading_policy (3 policies)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can read own policy" ON public.user_trading_policy;
+CREATE POLICY "Users can read own policy"
+  ON public.user_trading_policy FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own policy" ON public.user_trading_policy;
+CREATE POLICY "Users can insert own policy"
+  ON public.user_trading_policy FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own policy" ON public.user_trading_policy;
+CREATE POLICY "Users can update own policy"
+  ON public.user_trading_policy FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+COMMIT;

--- a/supabase/migrations/00029_optimize_role_initplan_fk_indexes.sql
+++ b/supabase/migrations/00029_optimize_role_initplan_fk_indexes.sql
@@ -1,0 +1,137 @@
+-- Migration 00029: Optimize auth.role() initplan + add missing FK indexes
+--
+-- Part A: Replace auth.role() with (select auth.role()) in 20 policies
+-- across 10 tables to prevent per-row re-evaluation.
+--
+-- Part B: Add missing indexes on 3 foreign key columns.
+
+BEGIN;
+
+-- ============================================================
+-- PART A: auth.role() initplan optimization
+-- ============================================================
+
+-- fills (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read fills" ON public.fills;
+CREATE POLICY "Authenticated users can read fills"
+  ON public.fills FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can insert fills" ON public.fills;
+CREATE POLICY "Authenticated users can insert fills"
+  ON public.fills FOR INSERT TO authenticated
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- market_snapshots (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read market snapshots" ON public.market_snapshots;
+CREATE POLICY "Authenticated users can read market snapshots"
+  ON public.market_snapshots FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Service role can manage market snapshots" ON public.market_snapshots;
+CREATE POLICY "Service role can manage market snapshots"
+  ON public.market_snapshots FOR ALL TO service_role
+  USING ((select auth.role()) = 'service_role');
+
+-- recommendation_events (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read recommendation events" ON public.recommendation_events;
+CREATE POLICY "Authenticated users can read recommendation events"
+  ON public.recommendation_events FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can insert recommendation events" ON public.recommendation_events;
+CREATE POLICY "Authenticated users can insert recommendation events"
+  ON public.recommendation_events FOR INSERT TO authenticated
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- risk_evaluations (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read risk evaluations" ON public.risk_evaluations;
+CREATE POLICY "Authenticated users can read risk evaluations"
+  ON public.risk_evaluations FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can insert risk evaluations" ON public.risk_evaluations;
+CREATE POLICY "Authenticated users can insert risk evaluations"
+  ON public.risk_evaluations FOR INSERT TO authenticated
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- risk_policies (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read risk policies" ON public.risk_policies;
+CREATE POLICY "Authenticated users can read risk policies"
+  ON public.risk_policies FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can insert risk policies" ON public.risk_policies;
+CREATE POLICY "Authenticated users can insert risk policies"
+  ON public.risk_policies FOR INSERT TO authenticated
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- role_change_log (1 policy — only SELECT uses auth.role())
+DROP POLICY IF EXISTS "authenticated_read_role_changes" ON public.role_change_log;
+CREATE POLICY "authenticated_read_role_changes"
+  ON public.role_change_log FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+-- signal_runs (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read signal runs" ON public.signal_runs;
+CREATE POLICY "Authenticated users can read signal runs"
+  ON public.signal_runs FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can insert signal runs" ON public.signal_runs;
+CREATE POLICY "Authenticated users can insert signal runs"
+  ON public.signal_runs FOR INSERT TO authenticated
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- strategy_health_snapshots (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read strategy health" ON public.strategy_health_snapshots;
+CREATE POLICY "Authenticated users can read strategy health"
+  ON public.strategy_health_snapshots FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Service role can manage strategy health" ON public.strategy_health_snapshots;
+CREATE POLICY "Service role can manage strategy health"
+  ON public.strategy_health_snapshots FOR ALL TO service_role
+  USING ((select auth.role()) = 'service_role');
+
+-- system_controls (2 policies)
+DROP POLICY IF EXISTS "Authenticated users can read system controls" ON public.system_controls;
+CREATE POLICY "Authenticated users can read system controls"
+  ON public.system_controls FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can update system controls" ON public.system_controls;
+CREATE POLICY "Authenticated users can update system controls"
+  ON public.system_controls FOR UPDATE TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+-- universe_restrictions (3 policies)
+DROP POLICY IF EXISTS "Authenticated users can read universe restrictions" ON public.universe_restrictions;
+CREATE POLICY "Authenticated users can read universe restrictions"
+  ON public.universe_restrictions FOR SELECT TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can insert universe restrictions" ON public.universe_restrictions;
+CREATE POLICY "Authenticated users can insert universe restrictions"
+  ON public.universe_restrictions FOR INSERT TO authenticated
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can delete universe restrictions" ON public.universe_restrictions;
+CREATE POLICY "Authenticated users can delete universe restrictions"
+  ON public.universe_restrictions FOR DELETE TO authenticated
+  USING ((select auth.role()) = 'authenticated');
+
+-- ============================================================
+-- PART B: Add missing foreign key indexes
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_advisor_preferences_originating_message_id
+  ON public.advisor_preferences (originating_message_id);
+
+CREATE INDEX IF NOT EXISTS idx_external_portfolio_links_user_id
+  ON public.external_portfolio_links (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_funding_transactions_bank_link_id
+  ON public.funding_transactions (bank_link_id);
+
+COMMIT;

--- a/supabase/migrations/00030_fix_remaining_role_initplan.sql
+++ b/supabase/migrations/00030_fix_remaining_role_initplan.sql
@@ -1,0 +1,14 @@
+-- Migration 00030: Fix 3 remaining auth.role() initplan issues
+-- These were missed in 00029 — user_profiles and operator_actions role-based policies.
+
+-- user_profiles: authenticated_read_profiles
+DROP POLICY IF EXISTS "authenticated_read_profiles" ON public.user_profiles;
+CREATE POLICY "authenticated_read_profiles" ON public.user_profiles FOR SELECT TO authenticated USING ((select auth.role()) = 'authenticated');
+
+-- user_profiles: operators_insert_profiles
+DROP POLICY IF EXISTS "operators_insert_profiles" ON public.user_profiles;
+CREATE POLICY "operators_insert_profiles" ON public.user_profiles FOR INSERT TO authenticated WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- operator_actions: Authenticated users can read operator actions
+DROP POLICY IF EXISTS "Authenticated users can read operator actions" ON public.operator_actions;
+CREATE POLICY "Authenticated users can read operator actions" ON public.operator_actions FOR SELECT TO authenticated USING ((select auth.role()) = 'authenticated');


### PR DESCRIPTION
## Summary

Full platform audit across GitHub Actions, Supabase (API/Auth/Realtime/Storage/Postgres), and database advisors. This PR fixes all actionable issues found.

## Changes

### CI Pipeline Fix
- **Removed FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true** from ci.yml - was forcing Node 24 while .nvmrc specifies Node 22, causing all CI runs to fail

### RLS Security Hardening (Migration 00027)
- **Dropped 12 overly-permissive write policies** on 8 system tables with WITH CHECK (true)

### RLS Performance (Migrations 00028-00030)
- **Optimized 82 RLS policies**: auth.uid()/auth.role() wrapped in (select ...) for InitPlan
- **Added 3 missing FK indexes**

### Database Maintenance
- Ran ANALYZE on all public tables (never run since DB creation)

## Results
| Metric | Before | After |
|--------|--------|-------|
| CI Runs | All failing | Fixed |
| Security Warnings | 13 | 1 (dashboard-only) |
| RLS InitPlan Warnings | 82 | 0 |
| Missing FK Indexes | 3 | 0 |

## Validation
- pnpm lint: 3/3 passed
- pnpm test: 656 tests passed (76 files)
- All migrations applied to live Supabase