### PR TITLE
fix: enforce user data isolation on profiles, roles, and catalysts

### DIFF
--- a/apps/web/src/app/api/catalysts/route.ts
+++ b/apps/web/src/app/api/catalysts/route.ts
@@ -28,7 +28,11 @@ export async function GET(request: Request) {
   const eventType = searchParams.get('type');
   const impact = searchParams.get('impact');
 
-  let query = supabase.from('catalyst_events').select('*').order('event_date', { ascending: true });
+  let query = supabase
+    .from('catalyst_events')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('event_date', { ascending: true });
 
   if (from) query = query.gte('event_date', from);
   if (to) query = query.lte('event_date', to);

--- a/apps/web/src/app/api/roles/route.ts
+++ b/apps/web/src/app/api/roles/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { createClient } from '@supabase/supabase-js';
 import { requireAuth } from '@/lib/auth/require-auth';
 import { parseBody, parseSearchParams } from '@/lib/api/validation';
 import { checkApiRateLimit } from '@/lib/server/rate-limiter';
@@ -7,6 +8,14 @@ import { safeErrorMessage } from '@/lib/api-error';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+/** Service-role client that bypasses RLS — used only for operator admin queries */
+function supabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
 
 type OperatorRole = 'observer' | 'reviewer' | 'approver' | 'operator';
 
@@ -29,7 +38,7 @@ const RoleUpdateSchema = z.object({
   reason: z.string().optional(),
 });
 
-// GET /api/roles — list all user profiles or own profile
+// GET /api/roles — list own profile (scope=me) or all profiles (scope=all, operator only)
 export async function GET(request: Request) {
   const auth = await requireAuth();
   if (auth instanceof NextResponse) return auth;
@@ -68,7 +77,22 @@ export async function GET(request: Request) {
     return NextResponse.json({ profile: data });
   }
 
-  const { data: profiles, error } = await supabase
+  // scope=all requires operator role — verified via user's own profile
+  const { data: callerProfile } = await supabase
+    .from('user_profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  const callerRole = (callerProfile?.role ?? 'operator') as OperatorRole;
+  if (ROLE_LEVELS[callerRole] < ROLE_LEVELS['operator']) {
+    return NextResponse.json({ error: 'Only operators can list all profiles' }, { status: 403 });
+  }
+
+  // Use service_role to bypass RLS for legitimate operator admin query
+  const admin = supabaseAdmin();
+
+  const { data: profiles, error } = await admin
     .from('user_profiles')
     .select('*')
     .order('created_at', { ascending: true });
@@ -80,7 +104,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const { data: history } = await supabase
+  const { data: history } = await admin
     .from('role_change_log')
     .select('*')
     .order('created_at', { ascending: false })
@@ -107,7 +131,7 @@ export async function PATCH(request: Request) {
 
   const { targetUserId, newRole, reason } = body;
 
-  // Check requester is operator
+  // Check requester is operator (via user's own RLS-scoped client)
   const { data: requesterProfile } = await supabase
     .from('user_profiles')
     .select('role')
@@ -119,8 +143,11 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: 'Only operators can change roles' }, { status: 403 });
   }
 
+  // Use service_role for cross-user operations (bypasses user-scoped RLS)
+  const admin = supabaseAdmin();
+
   // Get current role of target user
-  const { data: targetProfile } = await supabase
+  const { data: targetProfile } = await admin
     .from('user_profiles')
     .select('role')
     .eq('id', targetUserId)
@@ -134,7 +161,7 @@ export async function PATCH(request: Request) {
 
   // Prevent removing the last operator
   if (targetUserId === user.id && newRole !== 'operator') {
-    const { count } = await supabase
+    const { count } = await admin
       .from('user_profiles')
       .select('id', { count: 'exact', head: true })
       .eq('role', 'operator');
@@ -144,8 +171,8 @@ export async function PATCH(request: Request) {
     }
   }
 
-  // Update role
-  const { error: updateError } = await supabase.from('user_profiles').upsert({
+  // Update role via admin client
+  const { error: updateError } = await admin.from('user_profiles').upsert({
     id: targetUserId,
     role: newRole,
     updated_at: new Date().toISOString(),
@@ -156,7 +183,7 @@ export async function PATCH(request: Request) {
   }
 
   // Log the change
-  await supabase.from('role_change_log').insert({
+  await admin.from('role_change_log').insert({
     target_user_id: targetUserId,
     changed_by: user.id,
     old_role: oldRole,

--- a/supabase/migrations/00031_lock_user_data_isolation.sql
+++ b/supabase/migrations/00031_lock_user_data_isolation.sql
@@ -1,0 +1,39 @@
+-- Migration 00031: Lock down user_profiles and catalyst_events to owner-only access
+--
+-- BEFORE:
+--   user_profiles SELECT: any authenticated user sees ALL profiles
+--   user_profiles INSERT: any authenticated user can insert for ANY user
+--   catalyst_events SELECT: any authenticated user sees ALL catalysts
+--
+-- AFTER:
+--   user_profiles SELECT: users see only their own profile
+--   user_profiles INSERT: users can only create their own profile
+--   catalyst_events SELECT: users see only their own catalysts
+--
+-- The /api/roles operator endpoint uses service_role to bypass RLS
+-- for legitimate admin operations (role management, listing all users).
+
+BEGIN;
+
+-- ─── user_profiles: restrict SELECT to own profile ─────────────────
+DROP POLICY IF EXISTS "authenticated_read_profiles" ON public.user_profiles;
+CREATE POLICY "users_read_own_profile"
+  ON public.user_profiles
+  FOR SELECT TO authenticated
+  USING ((select auth.uid()) = id);
+
+-- ─── user_profiles: restrict INSERT to own profile ─────────────────
+DROP POLICY IF EXISTS "operators_insert_profiles" ON public.user_profiles;
+CREATE POLICY "users_insert_own_profile"
+  ON public.user_profiles
+  FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = id);
+
+-- ─── catalyst_events: restrict SELECT to own catalysts ─────────────
+DROP POLICY IF EXISTS "Authenticated users can read catalysts" ON public.catalyst_events;
+CREATE POLICY "users_read_own_catalysts"
+  ON public.catalyst_events
+  FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Fixes critical data isolation issues where any authenticated user could read all user profiles and catalyst events.

### Changes

**Migration 00031** - Locks user_profiles SELECT/INSERT and catalyst_events SELECT to owner-only via auth.uid() RLS policies.

**Roles route** - GET scope=all requires operator + service_role client. PATCH uses service_role for cross-user ops.

**Catalysts route** - Added .eq('user_id', user.id) defense-in-depth filter.

### Validation
- pnpm lint: 3/3 passed
- pnpm test: all passed
- Migration applied to live Supabase