### PR TITLE
fix: increase timeout on flaky test suites

### DIFF
--- a/apps/web/tests/unit/advisor-routes-comprehensive.test.ts
+++ b/apps/web/tests/unit/advisor-routes-comprehensive.test.ts
@@ -68,7 +68,7 @@ const params = (id: string) => ({ params: Promise.resolve({ id }) });
 
 // ─── Tests ──────────────────────────────────────────────────────────
 
-describe('Advisor Routes — Threads', () => {
+describe('Advisor Routes — Threads', { timeout: 15_000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fromResults = {};

--- a/apps/web/tests/unit/auth-hardened-routes.test.ts
+++ b/apps/web/tests/unit/auth-hardened-routes.test.ts
@@ -51,7 +51,7 @@ function req(url: string, method = 'GET') {
 
 // ─── Tests ──────────────────────────────────────────────────────────
 
-describe('Auth enforcement on hardened routes', () => {
+describe('Auth enforcement on hardened routes', { timeout: 15_000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     unauthed();

--- a/apps/web/tests/unit/explanation-route.test.ts
+++ b/apps/web/tests/unit/explanation-route.test.ts
@@ -65,7 +65,7 @@ function jsonReq(url: string, body: unknown) {
 
 // ─── Tests ──────────────────────────────────────────────────────────
 
-describe('Explanation Route', () => {
+describe('Explanation Route', { timeout: 15_000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     selectResult = { data: null, error: null };


### PR DESCRIPTION
## Summary
Fixes 3 flaky test files that intermittently timeout during full suite runs due to heavy dynamic \import()\ module loading overhead.

## Changes
- \xplanation-route.test.ts\ — timeout 5s → 15s
- \uth-hardened-routes.test.ts\ — timeout 5s → 15s  
- \dvisor-routes-comprehensive.test.ts\ — timeout 5s → 15s

## Validation
- \pnpm test\: **656 passed, 0 failed** (76 files, 3 packages)
- \pnpm lint\: clean
- No code logic changes — only test timeout configuration