### PR TITLE
ci: run security audit on protected-branch pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,10 @@ jobs:
   # ---------------------------------------------------------------------------
   security-audit:
     name: Security Audit
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' &&
+        (github.base_ref == 'main' || startsWith(github.base_ref, 'release/')))
     needs: [test-web, test-engine, test-agents]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/ai/commands.md
+++ b/docs/ai/commands.md
@@ -61,6 +61,9 @@ Important: `pnpm lint`, `pnpm test`, and `pnpm build` do not cover `apps/engine`
 - `git diff --check`
 - Run the closest local command to the workflow steps you changed
 - `node scripts/security-audit.mjs` when workflow permissions or dependency-audit automation changes
+- CI `security-audit` gate runs after `test-web`, `test-engine`, and `test-agents` on:
+  - pushes to `main`
+  - pull requests targeting `main` or `release/*` branches
 - State clearly what you could not verify locally
 
 ## Handoff Format


### PR DESCRIPTION
### Motivation

- Ensure the repository dependency security audit runs before merge for protected branches instead of only after a push to `main` so PRs targeting protected branches get scanned earlier.  
- Preserve deterministic audit behavior in PR context by keeping existing pnpm and Python setup steps inside the job.  
- Keep runtime cost manageable by scoping PR runs to PRs that target `main` or `release/*` while leaving pushes to `main` unchanged.

### Description

- Relaxed the `security-audit` job condition in `.github/workflows/ci.yml` to run for pushes to `main` and for `pull_request` events where `github.base_ref` is `main` or starts with `release/`.  
- Kept `needs: [test-web, test-engine, test-agents]` so the audit still runs after the primary test jobs.  
- Preserved the existing deterministic setup steps (Node/pnpm and Python venv + engine deps) inside the job so the audit behaves the same in PRs as it does on push.  
- Updated `docs/ai/commands.md` CI section to document the new security gate trigger behavior.

### Testing

- Ran `git diff --check` and it passed.  
- Ran `node scripts/security-audit.mjs` initially and it failed because `pip-audit` was not installed in `apps/engine/.venv`.  
- Installed engine audit tooling with `python3 -m pip install uv` and `uv pip install --python apps/engine/.venv/bin/python pip-audit`, which succeeded.  
- Re-ran `node scripts/security-audit.mjs` and the audit completed successfully (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec6cd5178832cb4ba926ba5ef5c61)