### PR TITLE
feat(web): portfolio page provenance and status clarity (T-B03)

### DIFF
--- a/apps/web/src/app/(dashboard)/portfolio/page.tsx
+++ b/apps/web/src/app/(dashboard)/portfolio/page.tsx
@@ -5,6 +5,8 @@ import { PieChart, RefreshCw } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { OfflineBanner } from '@/components/ui/offline-banner';
+import { DataProvenance } from '@/components/ui/data-provenance';
+import type { DataProvenanceProps } from '@/components/ui/data-provenance';
 import { useAppStore } from '@/stores/app-store';
 import { SnapshotMetrics } from '@/components/portfolio/snapshot-metrics';
 import {
@@ -63,7 +65,11 @@ export default function PortfolioPage() {
   }, []);
 
   // TanStack Query hooks
-  const { data: account, isPending: accountLoading } = useAccountQuery();
+  const {
+    data: account,
+    isPending: accountLoading,
+    dataUpdatedAt: accountUpdatedAt,
+  } = useAccountQuery();
   const { data: brokerPositions } = usePositionsQuery();
   const { data: orderHistory } = useOrderHistoryQuery();
   const submitOrder = useSubmitOrderMutation();
@@ -82,8 +88,20 @@ export default function PortfolioPage() {
     },
   });
 
-  const isLive = engineOnline === true && !!account;
   const loading = engineOnline === null || (engineOnline === true && accountLoading);
+
+  // Derive data provenance mode from engine + query state
+  const provenanceMode: DataProvenanceProps['mode'] = useMemo(() => {
+    if (engineOnline === true && account) return 'live';
+    if (engineOnline === false && account) return 'cached';
+    if (engineOnline === false && !account) return 'simulated';
+    return 'offline';
+  }, [engineOnline, account]);
+
+  const provenanceLastUpdated = useMemo(
+    () => (accountUpdatedAt ? new Date(accountUpdatedAt) : null),
+    [accountUpdatedAt],
+  );
 
   // Enrich positions with live prices
   const positions: Position[] = useMemo(() => {
@@ -209,12 +227,14 @@ export default function PortfolioPage() {
           <div>
             <h1 className="text-heading-page text-foreground">Portfolio</h1>
             <p className="text-xs text-muted-foreground">
-              {positions.length} position{positions.length !== 1 ? 's' : ''} &middot;{' '}
-              <span className={isLive ? 'text-profit' : 'text-muted-foreground'}>
-                {isLive ? 'Live' : 'Offline'}
-              </span>
+              {positions.length} position{positions.length !== 1 ? 's' : ''}
             </p>
           </div>
+          <DataProvenance
+            mode={provenanceMode}
+            lastUpdated={provenanceLastUpdated}
+            staleThresholdMs={60_000}
+          />
         </div>
         <button
           onClick={() => {
@@ -270,11 +290,17 @@ export default function PortfolioPage() {
         </TabsList>
 
         <TabsContent value="positions">
-          {positions.length === 0 && isLive ? (
+          {positions.length === 0 ? (
             <Card className="bg-muted/30 border-border/50">
               <CardContent className="flex flex-col items-center justify-center py-8 text-center">
                 <p className="text-sm text-muted-foreground">
-                  No open positions. Use Quick Order above to place your first trade.
+                  {provenanceMode === 'live' &&
+                    'No open positions. Use Quick Order above to place your first trade.'}
+                  {provenanceMode === 'cached' &&
+                    'Cached data \u2014 no positions found. Reconnect engine for live updates.'}
+                  {provenanceMode === 'simulated' &&
+                    'Showing simulated portfolio \u2014 connect the engine for live data.'}
+                  {provenanceMode === 'offline' && 'No data available \u2014 engine is offline.'}
                 </p>
               </CardContent>
             </Card>

--- a/apps/web/tests/pages/portfolio.test.tsx
+++ b/apps/web/tests/pages/portfolio.test.tsx
@@ -116,10 +116,30 @@ describe('PortfolioPage', () => {
     });
   });
 
-  it('shows Live indicator when engine is connected', async () => {
+  it('shows Live provenance badge when engine is connected', async () => {
     renderWithProviders(<PortfolioPage />);
     await waitFor(() => {
-      expect(screen.getByText('Live')).toBeInTheDocument();
+      const badge = screen.getByRole('status');
+      expect(badge).toHaveAttribute('aria-label', expect.stringContaining('Live'));
+    });
+  });
+
+  it('shows Simulated provenance badge when engine is offline with no cached data', async () => {
+    useAppStore.setState({ engineOnline: false });
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false } as Response)) as typeof fetch;
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      const badge = screen.getByRole('status');
+      expect(badge).toHaveAttribute('aria-label', expect.stringContaining('Simulated'));
+    });
+  });
+
+  it('shows mode-appropriate empty state when offline', async () => {
+    useAppStore.setState({ engineOnline: false });
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false } as Response)) as typeof fetch;
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/simulated portfolio/)).toBeInTheDocument();
     });
   });
 
@@ -230,7 +250,7 @@ describe('PortfolioPage', () => {
     );
   }, 10_000);
 
-  it('shows empty state when no positions from engine', async () => {
+  it('shows empty state when no positions from engine (live mode)', async () => {
     global.fetch = vi.fn((url: string | URL | Request) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
       if (urlStr.includes('/portfolio/account')) {


### PR DESCRIPTION
## T-B03: Portfolio provenance and status clarity

### Changes
- **DataProvenance badge** in portfolio header replaces inline Live/Offline text
- **Mode derivation** from engine state + TanStack Query:
  - \live\ — engine online, account data fetched
  - \cached\ — engine offline but TanStack cache retains data
  - \simulated\ — engine offline, using fallback account
  - \offline\ — fallback when no other state matches
- **\lastUpdated\** sourced from \dataUpdatedAt\ (account query) with 60s stale threshold
- **Empty-state messaging** matches actual data mode (no ambiguous representation)

### Files changed
- \pps/web/src/app/(dashboard)/portfolio/page.tsx\ — integrate DataProvenance, remove \isLive\
- \pps/web/tests/pages/portfolio.test.tsx\ — 3 new tests (Live badge, Simulated badge, mode-aware empty state)

### Validation
- \pnpm --filter web test -- --run tests/pages/portfolio.test.tsx\ — 12/12 pass
- \pnpm lint\ — 0 errors (no new warnings)