### PR TITLE
feat(web): Phase 2 — Layout, navigation & page shell polish

### DIFF
--- a/apps/web/src/app/(dashboard)/advisor/loading.tsx
+++ b/apps/web/src/app/(dashboard)/advisor/loading.tsx
@@ -1,18 +1,48 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export default function AdvisorLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-40 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="space-y-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Skeleton variant="heading" className="w-24" />
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </div>
+          <Skeleton variant="text" className="w-48 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Profile editor skeleton */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-28" />
+        <Skeleton className="h-20 w-full rounded-lg" />
       </div>
-      <SkeletonTable rows={5} cols={4} />
+
+      {/* Tab bar */}
+      <div className="flex gap-2 border-b border-border/50 pb-2">
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="button" className="w-28" />
+      </div>
+
+      {/* Thread list */}
+      <div className="space-y-2">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-foreground/5 bg-card p-3"
+          >
+            <Skeleton variant="avatar" />
+            <div className="flex-1 space-y-1">
+              <Skeleton variant="text" className="w-2/3" />
+              <Skeleton variant="text" className="w-1/3 h-3" />
+            </div>
+            <Skeleton className="h-3 w-16" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/advisor/page.tsx
+++ b/apps/web/src/app/(dashboard)/advisor/page.tsx
@@ -80,7 +80,7 @@ export default function AdvisorPage() {
   );
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 page-enter">
       <div className="flex items-center gap-3">
         <Sparkles className="h-6 w-6 text-primary" />
         <div className="flex-1">

--- a/apps/web/src/app/(dashboard)/agents/loading.tsx
+++ b/apps/web/src/app/(dashboard)/agents/loading.tsx
@@ -1,16 +1,44 @@
-import { SkeletonCard } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonCard } from '@/components/ui/skeleton';
 
 export default function AgentsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <div className="space-y-1">
+            <Skeleton variant="heading" className="w-28" />
+            <Skeleton variant="text" className="w-40 h-3" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Skeleton variant="button" className="w-24" />
+          <Skeleton variant="button" className="w-16" />
+        </div>
       </div>
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }, (_, i) => (
-          <SkeletonCard key={i} className="h-40" />
+
+      {/* Agent status cards grid */}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 5 }, (_, i) => (
+          <SkeletonCard key={i} />
         ))}
+      </div>
+
+      {/* Recommendation card */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-36" />
+        <Skeleton variant="text" lines={3} />
+      </div>
+
+      {/* Agent alert feed */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-28" />
+        <div className="space-y-2">
+          {Array.from({ length: 3 }, (_, i) => (
+            <Skeleton key={i} variant="table-row" />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/page.tsx
@@ -85,7 +85,7 @@ export default function AgentsPage() {
   };
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 p-4 page-enter">
       {agentsOnline === false && <OfflineBanner service="agents" />}
 
       {/* Header */}
@@ -182,7 +182,7 @@ export default function AgentsPage() {
       )}
 
       {/* Agent Cards */}
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3 stagger-grid">
         {agentDefs.map((agent) => {
           const agentStatus = status?.agents[agent.role];
           return (

--- a/apps/web/src/app/(dashboard)/approvals/loading.tsx
+++ b/apps/web/src/app/(dashboard)/approvals/loading.tsx
@@ -1,19 +1,58 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function ApprovalsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-36 rounded" />
-        <div className="skeleton h-8 w-24 rounded-lg" />
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <Skeleton variant="heading" className="w-28" />
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <SkeletonTable rows={8} cols={5} />
+
+      {/* Filter card */}
+      <div className="rounded-xl bg-card p-3 ring-1 ring-foreground/10">
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-9 w-28 rounded-lg" />
+          <Skeleton className="h-9 w-24 rounded-lg" />
+          <Skeleton className="h-9 w-28 rounded-lg" />
+          <div className="flex gap-1 ml-auto">
+            <Skeleton variant="button" className="w-8 h-8" />
+            <Skeleton variant="button" className="w-8 h-8" />
+          </div>
+          <Skeleton className="h-9 w-36 rounded-lg" />
+        </div>
+      </div>
+
+      {/* Recommendation cards */}
+      <div className="space-y-3">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className="rounded-lg border border-foreground/5 bg-card p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-12 rounded" />
+                <Skeleton className="h-5 w-16 rounded-full" />
+                <Skeleton className="h-5 w-14 rounded-full" />
+              </div>
+              <div className="flex gap-2">
+                <Skeleton variant="button" className="w-20" />
+                <Skeleton variant="button" className="w-20" />
+              </div>
+            </div>
+            <div className="flex gap-4">
+              <Skeleton variant="text" className="w-24" />
+              <Skeleton variant="text" className="w-20" />
+              <Skeleton variant="text" className="w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/audit-log/loading.tsx
+++ b/apps/web/src/app/(dashboard)/audit-log/loading.tsx
@@ -1,18 +1,58 @@
-import { SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function AuditLogLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="mx-auto max-w-7xl space-y-6 p-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <Skeleton variant="heading" className="w-28" />
       </div>
-      <div className="flex gap-2">
-        <div className="skeleton h-9 w-32 rounded-lg" />
-        <div className="skeleton h-9 w-32 rounded-lg" />
-        <div className="skeleton h-9 w-32 rounded-lg" />
+
+      {/* Stats row */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <SkeletonTable rows={12} cols={5} />
+
+      {/* Filters card */}
+      <div className="rounded-xl bg-card p-3 ring-1 ring-foreground/10">
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-9 w-32 rounded-lg" />
+          <Skeleton className="h-9 w-28 rounded-lg" />
+          <div className="flex gap-1">
+            {Array.from({ length: 4 }, (_, i) => (
+              <Skeleton key={i} variant="button" className="w-16" />
+            ))}
+          </div>
+          <Skeleton className="h-9 w-44 rounded-lg ml-auto" />
+        </div>
+      </div>
+
+      {/* Actions list */}
+      <div className="space-y-2">
+        {Array.from({ length: 10 }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-foreground/5 bg-card p-3"
+          >
+            <Skeleton className="h-5 w-20 rounded-full shrink-0" />
+            <div className="flex-1 space-y-1">
+              <Skeleton variant="text" className="w-2/3" />
+              <Skeleton variant="text" className="w-1/3 h-3" />
+            </div>
+            <Skeleton className="h-3 w-20 shrink-0" />
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-center gap-2">
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="text" className="w-16" />
+        <Skeleton variant="button" className="w-20" />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/autonomy/loading.tsx
+++ b/apps/web/src/app/(dashboard)/autonomy/loading.tsx
@@ -1,18 +1,69 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export default function AutonomyLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-36 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <Skeleton variant="heading" className="w-28" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+        {/* System Autonomy Control */}
+        <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+          <Skeleton variant="text" className="w-44" />
+          <Skeleton className="h-9 w-full rounded-lg" />
+          <div className="flex gap-2">
+            <Skeleton variant="button" className="w-24" />
+            <Skeleton variant="button" className="w-24" />
+          </div>
+        </div>
+
+        {/* Strategy Autonomy Table */}
+        <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+          <Skeleton variant="text" className="w-40" />
+          <div className="space-y-2">
+            {Array.from({ length: 5 }, (_, i) => (
+              <div key={i} className="flex items-center justify-between py-2">
+                <Skeleton variant="text" className="w-32" />
+                <Skeleton className="h-6 w-12 rounded-full" />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
-      <SkeletonTable rows={6} cols={4} />
+
+      {/* Universe Restrictions */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-40" />
+        <div className="flex gap-2">
+          <Skeleton className="h-9 flex-1 rounded-lg" />
+          <Skeleton variant="button" className="w-16" />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} className="h-6 w-16 rounded-full" />
+          ))}
+        </div>
+      </div>
+
+      {/* Activity log */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-44" />
+        <div className="space-y-2">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} variant="table-row" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/backtest/loading.tsx
+++ b/apps/web/src/app/(dashboard)/backtest/loading.tsx
@@ -1,17 +1,42 @@
-import { SkeletonCard, SkeletonChart } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
 
 export default function BacktestLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <div className="space-y-1">
+            <Skeleton variant="heading" className="w-28" />
+            <Skeleton variant="text" className="w-64 h-3" />
+          </div>
+        </div>
+        <Skeleton variant="button" className="w-20" />
       </div>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Backtest form skeleton */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-4">
+        <Skeleton variant="text" className="w-32" />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="space-y-1.5">
+              <Skeleton variant="text" className="w-20 h-3" />
+              <Skeleton className="h-9 w-full rounded-lg" />
+            </div>
+          ))}
+        </div>
+        <Skeleton variant="button" className="w-28" />
+      </div>
+
+      {/* Results metrics table */}
+      <SkeletonTable rows={4} cols={4} />
+
+      {/* Results tab bar + chart */}
+      <div className="flex gap-2 border-b border-border/50 pb-2">
+        <Skeleton variant="button" className="w-24" />
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="button" className="w-24" />
       </div>
       <SkeletonChart />
     </div>

--- a/apps/web/src/app/(dashboard)/backtest/page.tsx
+++ b/apps/web/src/app/(dashboard)/backtest/page.tsx
@@ -89,8 +89,7 @@ export default function BacktestPage() {
       ran = true;
       setExecutionSource('engine');
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Engine unavailable — unknown error';
+      const message = error instanceof Error ? error.message : 'Engine unavailable — unknown error';
       setEngineError(message);
     }
 
@@ -117,7 +116,7 @@ export default function BacktestPage() {
   const s = result?.summary;
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 p-4 page-enter">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">

--- a/apps/web/src/app/(dashboard)/catalysts/loading.tsx
+++ b/apps/web/src/app/(dashboard)/catalysts/loading.tsx
@@ -1,18 +1,54 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function CatalystsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-6 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <Skeleton variant="heading" className="w-36" />
+        </div>
+        <Skeleton variant="button" className="w-24" />
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Date range and filters */}
+      <div className="rounded-xl border border-foreground/5 bg-card p-4 space-y-3">
+        <div className="flex flex-wrap gap-3">
+          <Skeleton className="h-9 w-36 rounded-lg" />
+          <Skeleton className="h-9 w-36 rounded-lg" />
+          <Skeleton className="h-9 w-28 rounded-lg" />
+          <Skeleton className="h-9 w-28 rounded-lg" />
+        </div>
       </div>
-      <SkeletonTable rows={8} cols={4} />
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
+        {Array.from({ length: 6 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
+      </div>
+
+      {/* Event timeline grouped by date */}
+      <div className="space-y-4">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="space-y-2">
+            <Skeleton variant="text" className="w-32 h-4" />
+            {Array.from({ length: 2 }, (_, j) => (
+              <div key={j} className="rounded-lg border border-foreground/5 bg-card p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                    <Skeleton variant="text" className="w-40" />
+                  </div>
+                  <Skeleton className="h-5 w-14 rounded-full" />
+                </div>
+                <Skeleton variant="text" className="w-2/3 h-3" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/counterfactuals/loading.tsx
+++ b/apps/web/src/app/(dashboard)/counterfactuals/loading.tsx
@@ -1,18 +1,50 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function CounterfactualsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-44 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="max-w-6xl space-y-6 p-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-44" />
+          <Skeleton variant="text" className="w-64 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        {Array.from({ length: 6 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <SkeletonTable rows={6} cols={5} />
+
+      {/* Filter buttons */}
+      <div className="flex gap-2">
+        {Array.from({ length: 3 }, (_, i) => (
+          <Skeleton key={i} variant="button" className="w-24" />
+        ))}
+      </div>
+
+      {/* Result cards list */}
+      <div className="space-y-2">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className="rounded-lg border border-foreground/5 bg-card p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-12 rounded" />
+                <Skeleton className="h-5 w-20 rounded-full" />
+              </div>
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <div className="flex gap-4">
+              <Skeleton variant="text" className="w-20" />
+              <Skeleton variant="text" className="w-20" />
+              <Skeleton variant="text" className="w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/data-quality/loading.tsx
+++ b/apps/web/src/app/(dashboard)/data-quality/loading.tsx
@@ -1,19 +1,49 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function DataQualityLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="mx-auto max-w-6xl space-y-6 p-6 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-36 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <Skeleton variant="heading" className="w-32" />
+        </div>
+        <Skeleton variant="button" className="w-24" />
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <SkeletonTable rows={10} cols={5} />
+
+      {/* Filters row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Skeleton className="h-9 w-32 rounded-lg" />
+        <Skeleton className="h-9 w-28 rounded-lg" />
+        <Skeleton className="h-6 w-32 rounded" />
+        <Skeleton variant="button" className="w-20 ml-auto" />
+      </div>
+
+      {/* Events list */}
+      <div className="rounded-xl border border-foreground/5 bg-card ring-1 ring-foreground/10">
+        <div className="flex items-center gap-3 border-b border-foreground/5 p-3">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton variant="text" className="w-40" />
+        </div>
+        <div className="divide-y divide-foreground/5">
+          {Array.from({ length: 8 }, (_, i) => (
+            <div key={i} className="flex items-center gap-3 p-3">
+              <Skeleton className="h-4 w-4 rounded" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton variant="text" className="flex-1" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/experiment/loading.tsx
+++ b/apps/web/src/app/(dashboard)/experiment/loading.tsx
@@ -1,18 +1,58 @@
-import { SkeletonCard, SkeletonChart } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function ExperimentLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-40 rounded" />
-        <div className="skeleton h-8 w-32 rounded-lg" />
+    <div className="space-y-6 p-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-52" />
+          <Skeleton variant="text" className="w-40 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Status bar */}
+      <div className="flex items-center justify-between rounded-lg border border-foreground/5 bg-card p-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton variant="text" className="w-32" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton variant="button" className="w-20" />
+          <Skeleton variant="button" className="w-16" />
+        </div>
       </div>
-      <SkeletonChart />
+
+      {/* Metrics grid */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
+        {Array.from({ length: 6 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
+      </div>
+
+      {/* Collapsible sections */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-28" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="space-y-1">
+              <Skeleton variant="text" className="w-20 h-3" />
+              <Skeleton variant="metric" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-32" />
+        <div className="space-y-2">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} variant="table-row" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/journal/loading.tsx
+++ b/apps/web/src/app/(dashboard)/journal/loading.tsx
@@ -1,19 +1,44 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function JournalLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-40 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="space-y-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <Skeleton variant="heading" className="w-40" />
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        {Array.from({ length: 6 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <SkeletonTable rows={8} cols={5} />
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Skeleton variant="button" className="w-32" />
+        <Skeleton className="h-8 w-36 rounded-lg" />
+        <Skeleton variant="button" className="w-20" />
+      </div>
+
+      {/* Journal cards */}
+      <div className="space-y-3">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className="rounded-lg border border-foreground/5 bg-card p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-14 rounded-full" />
+                <Skeleton className="h-4 w-12" />
+              </div>
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton variant="text" className="w-2/3" />
+            <Skeleton variant="text" className="w-1/2 h-3" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/journal/page.tsx
+++ b/apps/web/src/app/(dashboard)/journal/page.tsx
@@ -105,7 +105,7 @@ function StatsCards() {
   ];
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 stagger-grid">
       {cells.map((c) => (
         <Card key={c.label} className="border-zinc-800 bg-zinc-900/50">
           <CardContent className="p-4">
@@ -359,7 +359,7 @@ export default function JournalPage() {
   const totalPages = Math.ceil(totalEntries / PAGE_SIZE_JOURNAL);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 page-enter">
       {/* Page header */}
       <div className="flex items-center gap-3">
         <BookOpen className="h-6 w-6 text-zinc-400" />

--- a/apps/web/src/app/(dashboard)/loading.tsx
+++ b/apps/web/src/app/(dashboard)/loading.tsx
@@ -1,14 +1,13 @@
 import {
-  SkeletonMetricCard,
-  SkeletonAlertFeed,
-  SkeletonSignalCard,
-  SkeletonChart,
   Skeleton,
+  SkeletonMetricCard,
+  SkeletonSignalCard,
+  SkeletonAlertFeed,
 } from '@/components/ui/skeleton';
 
 export default function DashboardLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-4 p-4 page-enter">
       {/* System health strip */}
       <div className="flex items-center gap-3">
         <Skeleton className="h-5 w-5 rounded-full" />
@@ -18,34 +17,27 @@ export default function DashboardLoading() {
       </div>
 
       {/* Metric cards grid */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonMetricCard />
-        <SkeletonMetricCard />
-        <SkeletonMetricCard />
-        <SkeletonMetricCard />
+      <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
 
       {/* Price ticker */}
-      <div className="flex gap-3 overflow-hidden">
+      <div className="flex gap-3 overflow-hidden rounded-xl bg-card p-3 ring-1 ring-foreground/10">
         {Array.from({ length: 6 }, (_, i) => (
-          <div
-            key={i}
-            className="flex items-center gap-2 rounded-lg bg-card p-3 ring-1 ring-foreground/10 shrink-0 w-36"
-          >
+          <div key={i} className="flex items-center gap-2 shrink-0">
             <Skeleton className="h-4 w-10" />
             <Skeleton className="h-4 w-14" />
           </div>
         ))}
       </div>
 
-      {/* Main content — signals + alerts side by side */}
-      <div className="grid gap-4 lg:grid-cols-2">
+      {/* Signals + Alert feed */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <SkeletonSignalCard />
         <SkeletonAlertFeed />
       </div>
-
-      {/* Chart section */}
-      <SkeletonChart />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/markets/loading.tsx
+++ b/apps/web/src/app/(dashboard)/markets/loading.tsx
@@ -1,21 +1,30 @@
-import { SkeletonCard, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonChart } from '@/components/ui/skeleton';
 
 export default function MarketsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-24 rounded-lg" />
-      </div>
-      <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
-        <SkeletonTable rows={8} cols={3} />
-        <SkeletonChart />
-      </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+    <div className="flex h-full flex-col gap-4 p-3 sm:p-4 page-enter">
+      {/* Header */}
+      <Skeleton variant="heading" className="w-28" />
+
+      {/* Two column: watchlist + chart */}
+      <div className="flex flex-1 flex-col gap-4 min-h-0 lg:flex-row">
+        {/* Watchlist sidebar */}
+        <div className="w-full shrink-0 rounded-xl bg-card p-4 ring-1 ring-foreground/10 lg:w-72">
+          <div className="flex items-center justify-between mb-3">
+            <Skeleton variant="text" className="w-24" />
+            <Skeleton variant="avatar" className="h-4 w-4 rounded" />
+          </div>
+          <div className="space-y-1">
+            {Array.from({ length: 10 }, (_, i) => (
+              <Skeleton key={i} variant="text" className="h-9 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+
+        {/* Chart area */}
+        <div className="flex-1">
+          <SkeletonChart className="h-full" />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/markets/page.tsx
+++ b/apps/web/src/app/(dashboard)/markets/page.tsx
@@ -103,7 +103,7 @@ export default function MarketsPage() {
   const selectedStock = watchlist.find((w) => w.ticker === selectedTicker);
 
   return (
-    <div className="flex h-full flex-col gap-4 p-3 sm:p-4">
+    <div className="flex h-full flex-col gap-4 p-3 sm:p-4 page-enter">
       {engineOnline === false && <OfflineBanner service="engine" />}
       <div className="flex flex-1 flex-col gap-4 min-h-0 lg:flex-row">
         {/* Watchlist panel */}

--- a/apps/web/src/app/(dashboard)/orders/loading.tsx
+++ b/apps/web/src/app/(dashboard)/orders/loading.tsx
@@ -1,20 +1,51 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function OrdersLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-28 rounded" />
-        <div className="flex gap-2">
-          <div className="skeleton h-8 w-24 rounded-lg" />
+    <div className="space-y-4 sm:space-y-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-36" />
+          <Skeleton variant="text" className="w-48 h-3" />
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Stats row */}
+      <div className="grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <SkeletonTable rows={8} cols={6} />
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex gap-1">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} variant="button" className="w-16" />
+          ))}
+        </div>
+        <Skeleton variant="button" className="w-24" />
+        <Skeleton className="h-8 w-48 rounded-lg" />
+      </div>
+
+      {/* Timeline cards */}
+      <div className="space-y-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-foreground/5 bg-card p-3"
+          >
+            <Skeleton className="h-5 w-14 rounded-full shrink-0" />
+            <div className="flex-1 space-y-1">
+              <Skeleton variant="text" className="w-3/4" />
+              <Skeleton variant="text" className="w-1/3 h-3" />
+            </div>
+            <Skeleton className="h-3 w-16 shrink-0" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -792,7 +792,7 @@ export default function OrdersPage() {
   const hasFilters = dateRange !== 'all' || typeFilter !== 'all' || symbolSearch !== '';
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="space-y-4 sm:space-y-6 page-enter">
       {/* Page header */}
       <div className="flex items-center gap-3">
         <ArrowUpDown className="h-5 w-5 sm:h-6 sm:w-6 text-zinc-400" />

--- a/apps/web/src/app/(dashboard)/portfolio/loading.tsx
+++ b/apps/web/src/app/(dashboard)/portfolio/loading.tsx
@@ -1,25 +1,36 @@
-import { SkeletonCard, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard, SkeletonTable } from '@/components/ui/skeleton';
 
 export default function PortfolioLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-36 rounded" />
-        <div className="flex gap-2">
-          <div className="skeleton h-8 w-20 rounded-lg" />
-          <div className="skeleton h-8 w-20 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <div className="space-y-1">
+            <Skeleton variant="heading" className="w-32" />
+            <Skeleton variant="text" className="w-20 h-3" />
+          </div>
         </div>
+        <Skeleton variant="button" className="w-24" />
       </div>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Snapshot metrics */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {Array.from({ length: 5 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
       </div>
-      <div className="grid gap-4 lg:grid-cols-2">
-        <SkeletonTable rows={6} cols={5} />
-        <SkeletonChart className="h-72" />
+
+      {/* Tab bar */}
+      <div className="flex gap-2 border-b border-border/50 pb-2">
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="button" className="w-24" />
+        <Skeleton variant="button" className="w-16" />
       </div>
+
+      {/* Positions table */}
+      <SkeletonTable rows={8} cols={6} />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/portfolio/page.tsx
+++ b/apps/web/src/app/(dashboard)/portfolio/page.tsx
@@ -264,7 +264,7 @@ export default function PortfolioPage() {
   }
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 p-4 page-enter">
       {engineOnline === false && <OfflineBanner service="engine" />}
 
       {/* Header */}

--- a/apps/web/src/app/(dashboard)/regime/loading.tsx
+++ b/apps/web/src/app/(dashboard)/regime/loading.tsx
@@ -1,19 +1,49 @@
-import { SkeletonCard, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonCard } from '@/components/ui/skeleton';
 
 export default function RegimeLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-40 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="mx-auto max-w-6xl space-y-6 p-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-24" />
+          <Skeleton variant="text" className="w-56 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Current regime card */}
+      <SkeletonCard />
+
+      {/* Regime recording buttons */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-36" />
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Skeleton key={i} variant="button" className="w-full h-9" />
+          ))}
+        </div>
       </div>
-      <SkeletonChart />
-      <SkeletonTable rows={6} cols={4} />
+
+      {/* Playbook cards */}
+      <div className="space-y-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+            <div className="flex items-center justify-between">
+              <Skeleton variant="text" className="w-32" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {Array.from({ length: 4 }, (_, j) => (
+                <div key={j} className="space-y-1">
+                  <Skeleton variant="text" className="w-16 h-3" />
+                  <Skeleton variant="metric" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/replay/loading.tsx
+++ b/apps/web/src/app/(dashboard)/replay/loading.tsx
@@ -1,19 +1,27 @@
-import { SkeletonCard, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
 
 export default function ReplayLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="space-y-6 p-4 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-40" />
+          <Skeleton variant="text" className="w-56 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Mode tabs */}
+      <div className="flex gap-1 rounded-lg bg-muted/30 p-1 w-fit">
+        <Skeleton variant="button" className="w-40" />
+        <Skeleton variant="button" className="w-32" />
       </div>
+
+      {/* Chart */}
       <SkeletonChart />
+
+      {/* Table */}
       <SkeletonTable rows={8} cols={5} />
     </div>
   );

--- a/apps/web/src/app/(dashboard)/roles/loading.tsx
+++ b/apps/web/src/app/(dashboard)/roles/loading.tsx
@@ -1,18 +1,73 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export default function RolesLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-28 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="space-y-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-36" />
+          <Skeleton variant="text" className="w-28 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Your role summary card */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-2">
+        <Skeleton variant="text" className="w-28" />
+        <Skeleton variant="metric" className="w-20" />
+        <Skeleton variant="text" className="w-48 h-3" />
       </div>
-      <SkeletonTable rows={6} cols={4} />
+
+      {/* Permissions matrix table */}
+      <div className="rounded-xl bg-card ring-1 ring-foreground/10 overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-foreground/5">
+              <th className="p-3">
+                <Skeleton variant="text" className="w-24" />
+              </th>
+              {Array.from({ length: 4 }, (_, i) => (
+                <th key={i} className="p-3">
+                  <Skeleton variant="text" className="w-16 mx-auto" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 6 }, (_, i) => (
+              <tr key={i} className="border-b border-foreground/5">
+                <td className="p-3">
+                  <Skeleton variant="text" className="w-32" />
+                </td>
+                {Array.from({ length: 4 }, (_, j) => (
+                  <td key={j} className="p-3 text-center">
+                    <Skeleton className="h-4 w-4 rounded mx-auto" />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Team members */}
+      <div className="space-y-3">
+        <Skeleton variant="text" className="w-32" />
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-foreground/5 bg-card p-3"
+          >
+            <Skeleton variant="avatar" />
+            <div className="flex-1 space-y-1">
+              <Skeleton variant="text" className="w-28" />
+              <Skeleton variant="text" className="w-40 h-3" />
+            </div>
+            <Skeleton className="h-8 w-24 rounded-lg" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/settings/loading.tsx
+++ b/apps/web/src/app/(dashboard)/settings/loading.tsx
@@ -1,16 +1,56 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export default function SettingsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-28 rounded" />
+    <div className="space-y-4 px-4 py-3 md:p-4 page-enter">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <div className="space-y-1">
+            <Skeleton variant="heading" className="w-28" />
+            <Skeleton variant="text" className="w-64 h-3" />
+          </div>
+        </div>
+        <Skeleton variant="button" className="w-20" />
       </div>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Connection status panel */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10">
+        <div className="flex items-center gap-3">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Skeleton className="h-3 w-3 rounded-full" />
+              <Skeleton variant="text" className="w-20" />
+            </div>
+          ))}
+        </div>
       </div>
-      <SkeletonTable rows={6} cols={3} />
+
+      {/* Tab bar */}
+      <div className="flex gap-2 border-b border-border/50 pb-2">
+        <Skeleton variant="button" className="w-16" />
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="button" className="w-20" />
+      </div>
+
+      {/* Settings form sections */}
+      <div className="space-y-4">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+            <Skeleton variant="text" className="w-32" />
+            <div className="space-y-3">
+              {Array.from({ length: 3 }, (_, j) => (
+                <div key={j} className="flex items-center justify-between">
+                  <Skeleton variant="text" className="w-40" />
+                  <Skeleton className="h-6 w-12 rounded-full" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -187,7 +187,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="space-y-4 px-4 py-3 md:p-4">
+    <div className="space-y-4 px-4 py-3 md:p-4 page-enter">
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">

--- a/apps/web/src/app/(dashboard)/shadow-portfolios/loading.tsx
+++ b/apps/web/src/app/(dashboard)/shadow-portfolios/loading.tsx
@@ -1,19 +1,46 @@
-import { SkeletonCard, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function ShadowPortfoliosLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="mx-auto max-w-6xl space-y-6 p-6 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-48 rounded" />
-        <div className="skeleton h-8 w-32 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <Skeleton variant="heading" className="w-44" />
+        </div>
+        <Skeleton variant="button" className="w-32" />
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Info banner */}
+      <div className="rounded-lg border border-foreground/5 bg-card p-3">
+        <Skeleton variant="text" lines={2} />
       </div>
-      <SkeletonChart />
-      <SkeletonTable rows={6} cols={5} />
+
+      {/* Portfolio cards */}
+      <div className="space-y-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton variant="text" className="w-32" />
+                <Skeleton className="h-5 w-16 rounded-full" />
+              </div>
+              <Skeleton variant="button" className="w-16" />
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {Array.from({ length: 4 }, (_, j) => (
+                <SkeletonMetricCard key={j} />
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 3 }, (_, j) => (
+                <Skeleton key={j} className="h-6 w-20 rounded-full" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/signals/loading.tsx
+++ b/apps/web/src/app/(dashboard)/signals/loading.tsx
@@ -1,18 +1,45 @@
-import { SkeletonCard } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonMetricCard } from '@/components/ui/skeleton';
 
 export default function SignalsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-28 rounded" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <Skeleton variant="heading" className="w-24" />
+          <Skeleton variant="button" className="w-12" />
+        </div>
         <div className="flex gap-2">
-          <div className="skeleton h-8 w-24 rounded-lg" />
-          <div className="skeleton h-8 w-20 rounded-lg" />
+          <Skeleton variant="button" className="w-20" />
+          <Skeleton variant="button" className="w-24" />
         </div>
       </div>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <SkeletonMetricCard key={i} />
+        ))}
+      </div>
+
+      {/* Signal timeline */}
+      <div className="space-y-2">
         {Array.from({ length: 6 }, (_, i) => (
-          <SkeletonCard key={i} className="h-36" />
+          <div
+            key={i}
+            className="flex items-center justify-between rounded-lg border border-foreground/5 bg-card p-3"
+          >
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-5 w-12 rounded" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-5 w-14 rounded-full" />
+            </div>
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/apps/web/src/app/(dashboard)/signals/page.tsx
+++ b/apps/web/src/app/(dashboard)/signals/page.tsx
@@ -129,7 +129,7 @@ export default function SignalsPage() {
       : 0;
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 p-4 page-enter">
       {engineOnline === false && <OfflineBanner service="engine" />}
 
       {/* Header */}
@@ -213,7 +213,7 @@ export default function SignalsPage() {
 
       {/* Summary Cards */}
       {signals.length > 0 && (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 stagger-grid">
           <Card className="bg-card border-border">
             <CardContent className="flex items-center justify-between py-3 px-4">
               <span className="text-xs text-muted-foreground">Signals</span>

--- a/apps/web/src/app/(dashboard)/strategies/loading.tsx
+++ b/apps/web/src/app/(dashboard)/strategies/loading.tsx
@@ -1,18 +1,34 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonCard } from '@/components/ui/skeleton';
 
 export default function StrategiesLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-32" />
+          <Skeleton variant="text" className="w-24 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Tab bar */}
+      <div className="flex gap-1 rounded-lg border border-border/50 bg-muted/30 p-1 w-fit">
+        <Skeleton variant="button" className="w-20" />
+        <Skeleton variant="button" className="w-28" />
       </div>
-      <SkeletonTable rows={6} cols={5} />
+
+      {/* Strategy family sections */}
+      {Array.from({ length: 3 }, (_, i) => (
+        <div key={i} className="space-y-3">
+          <Skeleton variant="text" className="h-5 w-40" />
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 3 }, (_, j) => (
+              <SkeletonCard key={j} />
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/strategies/page.tsx
+++ b/apps/web/src/app/(dashboard)/strategies/page.tsx
@@ -105,7 +105,7 @@ export default function StrategiesPage() {
   const criticalCount = healthSnapshots?.filter((s) => s.health_label === 'critical').length ?? 0;
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 p-4 page-enter">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -211,7 +211,7 @@ export default function StrategiesPage() {
 
                     {/* Strategy Cards */}
                     {isExpanded && (
-                      <div className="grid grid-cols-1 gap-3 pl-0 sm:pl-4 lg:grid-cols-2 xl:grid-cols-3">
+                      <div className="grid grid-cols-1 gap-3 pl-0 sm:pl-4 lg:grid-cols-2 xl:grid-cols-3 stagger-grid">
                         {family.strategies.map((strategy) => {
                           const health = healthMap.get(strategy.id);
                           return (

--- a/apps/web/src/app/(dashboard)/system-controls/loading.tsx
+++ b/apps/web/src/app/(dashboard)/system-controls/loading.tsx
@@ -1,19 +1,50 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton, SkeletonCard } from '@/components/ui/skeleton';
 
 export default function SystemControlsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-44 rounded" />
-        <div className="skeleton h-8 w-28 rounded-lg" />
+    <div className="mx-auto max-w-5xl space-y-6 p-4 sm:p-6 page-enter">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton variant="avatar" />
+        <div className="space-y-1">
+          <Skeleton variant="heading" className="w-40" />
+          <Skeleton variant="text" className="w-32 h-3" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Trading mode card */}
+      <div className="rounded-xl bg-card p-6 ring-1 ring-foreground/10 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <Skeleton variant="text" className="w-28" />
+            <Skeleton className="h-8 w-36 rounded-lg" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton variant="button" className="w-28" />
+            <Skeleton variant="button" className="w-28" />
+          </div>
+        </div>
       </div>
-      <SkeletonTable rows={8} cols={5} />
+
+      {/* System configuration cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }, (_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+
+      {/* Strategy autonomy table */}
+      <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10 space-y-3">
+        <Skeleton variant="text" className="w-40" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }, (_, i) => (
+            <div key={i} className="flex items-center justify-between py-2">
+              <Skeleton variant="text" className="w-32" />
+              <Skeleton className="h-6 w-12 rounded-full" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/template.tsx
+++ b/apps/web/src/app/(dashboard)/template.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function DashboardTemplate({ children }: { children: React.ReactNode }) {
+  return <div className="animate-sentinel-in">{children}</div>;
+}

--- a/apps/web/src/app/(dashboard)/workflows/loading.tsx
+++ b/apps/web/src/app/(dashboard)/workflows/loading.tsx
@@ -1,18 +1,56 @@
-import { SkeletonCard, SkeletonTable } from '@/components/ui/skeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export default function WorkflowsLoading() {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6">
+    <div className="space-y-4 p-4 page-enter">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="skeleton h-7 w-32 rounded" />
-        <div className="skeleton h-8 w-32 rounded-lg" />
+        <div className="flex items-center gap-3">
+          <Skeleton variant="avatar" />
+          <Skeleton variant="heading" className="w-28" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-28 rounded-lg" />
+          <Skeleton className="h-9 w-24 rounded-lg" />
+          <Skeleton className="h-9 w-20 rounded-lg" />
+        </div>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+
+      {/* Stats summary */}
+      <div className="flex gap-3">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-2 rounded-lg bg-card px-3 py-2 ring-1 ring-foreground/10"
+          >
+            <Skeleton className="h-3 w-3 rounded-full" />
+            <Skeleton variant="text" className="w-12" />
+            <Skeleton variant="metric" className="w-6" />
+          </div>
+        ))}
       </div>
-      <SkeletonTable rows={8} cols={5} />
+
+      {/* Job list header */}
+      <div className="rounded-xl bg-card ring-1 ring-foreground/10">
+        <div className="grid grid-cols-[1fr_80px_80px_120px_1fr] gap-2 border-b border-foreground/5 p-3">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Skeleton key={i} variant="text" className="h-3" />
+          ))}
+        </div>
+
+        {/* Job rows */}
+        <div className="divide-y divide-foreground/5">
+          {Array.from({ length: 8 }, (_, i) => (
+            <div key={i} className="grid grid-cols-[1fr_80px_80px_120px_1fr] gap-2 p-3">
+              <Skeleton variant="text" className="w-3/4" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton variant="text" className="w-12" />
+              <Skeleton variant="text" className="w-20" />
+              <Skeleton variant="text" className="w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, type CSSProperties } from 'react';
+import { useEffect, useRef, type CSSProperties } from 'react';
 import { usePathname } from 'next/navigation';
 import { Sidebar } from '@/components/layout/sidebar';
 import { Header } from '@/components/layout/header';
@@ -42,6 +42,40 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     closeMobileSidebar();
   }, [pathname, closeMobileSidebar]);
 
+  // Mobile sidebar: Escape key + focus trap
+  const mobileSidebarRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!mobileSidebarOpen) return;
+    const container = mobileSidebarRef.current;
+    if (!container) return;
+
+    const focusableSelector = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const firstFocusable = container.querySelector<HTMLElement>(focusableSelector);
+    firstFocusable?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeMobileSidebar();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusables = Array.from(container.querySelectorAll<HTMLElement>(focusableSelector));
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [mobileSidebarOpen, closeMobileSidebar]);
+
   const shellLayoutVars = {
     '--shell-nav-height': '4rem',
     '--shell-bottom-offset': 'var(--shell-nav-height)',
@@ -62,17 +96,23 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
       {/* Mobile sidebar overlay — visible only on <lg when toggled */}
       {mobileSidebarOpen && (
-        <>
+        <div
+          ref={mobileSidebarRef}
+          role="dialog"
+          aria-label="Navigation menu"
+          aria-modal="true"
+          className="lg:hidden"
+        >
           <div
-            className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+            className="fixed inset-0 z-40 bg-black/50"
             onClick={closeMobileSidebar}
             onTouchEnd={closeMobileSidebar}
             aria-hidden="true"
           />
-          <div className="fixed inset-y-0 left-0 z-50 w-56 lg:hidden animate-in slide-in-from-left duration-200">
+          <div className="fixed inset-y-0 left-0 z-50 w-56 animate-in slide-in-from-left duration-200">
             <Sidebar collapsed={false} onToggle={closeMobileSidebar} />
           </div>
-        </>
+        </div>
       )}
 
       <div className="flex flex-1 flex-col overflow-hidden" style={shellLayoutVars}>

--- a/apps/web/src/components/layout/breadcrumbs.tsx
+++ b/apps/web/src/components/layout/breadcrumbs.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-const ROUTE_LABELS: Record<string, string> = {
+export const ROUTE_LABELS: Record<string, string> = {
   '/': 'Dashboard',
   '/markets': 'Markets',
   '/strategies': 'Strategies',
@@ -15,14 +15,14 @@ const ROUTE_LABELS: Record<string, string> = {
   '/journal': 'Journal',
   '/advisor': 'Advisor',
   '/counterfactuals': 'What If',
-  '/shadow-portfolios': 'Shadow',
+  '/shadow-portfolios': 'Shadow Portfolios',
   '/regime': 'Regime',
   '/data-quality': 'Data Quality',
   '/replay': 'Replay',
   '/catalysts': 'Catalysts',
   '/backtest': 'Backtest',
   '/agents': 'Agents',
-  '/experiment': 'Experiment',
+  '/experiment': 'Experiments',
   '/approvals': 'Approvals',
   '/workflows': 'Workflows',
   '/system-controls': 'Controls',
@@ -31,22 +31,46 @@ const ROUTE_LABELS: Record<string, string> = {
   '/audit-log': 'Audit Log',
   '/settings': 'Settings',
   '/recommendations': 'Recommendations',
+  '/onboarding': 'Onboarding',
+  '/onboarding/live-account': 'Live Account',
 };
 
-export function Breadcrumbs({ className }: { className?: string }) {
-  const pathname = usePathname();
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-  if (pathname === '/') return null;
+/** Returns true for UUIDs, numeric IDs, and short hex IDs (≥6 chars) */
+export function isDynamicSegment(segment: string): boolean {
+  if (UUID_RE.test(segment)) return true;
+  if (/^\d+$/.test(segment)) return true;
+  if (/^[0-9a-f]{6,}$/i.test(segment) && !/^[a-z-]+$/i.test(segment)) return true;
+  return false;
+}
 
+/** Build breadcrumb entries from a pathname */
+export function buildCrumbs(pathname: string): { label: string; href: string }[] {
   const segments = pathname.split('/').filter(Boolean);
   const crumbs: { label: string; href: string }[] = [];
 
   let currentPath = '';
   for (const segment of segments) {
     currentPath += `/${segment}`;
-    const label = ROUTE_LABELS[currentPath] ?? segment.replace(/-/g, ' ');
-    crumbs.push({ label, href: currentPath });
+
+    if (isDynamicSegment(segment)) {
+      crumbs.push({ label: 'Details', href: currentPath });
+    } else {
+      const label = ROUTE_LABELS[currentPath] ?? segment.replace(/-/g, ' ');
+      crumbs.push({ label, href: currentPath });
+    }
   }
+
+  return crumbs;
+}
+
+export function Breadcrumbs({ className }: { className?: string }) {
+  const pathname = usePathname();
+
+  if (pathname === '/') return null;
+
+  const crumbs = buildCrumbs(pathname);
 
   return (
     <nav aria-label="Breadcrumb" className={cn('flex items-center gap-1 text-xs', className)}>

--- a/apps/web/src/components/layout/mobile-nav.tsx
+++ b/apps/web/src/components/layout/mobile-nav.tsx
@@ -33,7 +33,7 @@ export function MobileNav() {
               className={cn(
                 'flex flex-col items-center justify-center gap-1 rounded-xl px-4 py-2 transition-colors min-w-[56px]',
                 isActive
-                  ? 'bg-primary/10 text-primary'
+                  ? 'bg-primary/10 text-primary font-semibold'
                   : 'text-muted-foreground active:bg-accent/50',
               )}
             >

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -159,6 +159,7 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
             collapsed && 'mx-auto mt-1',
           )}
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
         >
           {collapsed ? (
             <ChevronRight className="h-3.5 w-3.5" />
@@ -171,7 +172,7 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
       {/* Navigation */}
       <nav aria-label="Main navigation" className="flex-1 overflow-y-auto px-2 py-3">
         {navSections.map((section) => (
-          <div key={section.section} className="mb-4">
+          <div key={section.section} role="group" aria-label={section.section} className="mb-4">
             {!collapsed && (
               <p className="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/50">
                 {section.section}

--- a/apps/web/tests/components/layout/breadcrumbs.test.tsx
+++ b/apps/web/tests/components/layout/breadcrumbs.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  Breadcrumbs,
+  ROUTE_LABELS,
+  isDynamicSegment,
+  buildCrumbs,
+} from '@/components/layout/breadcrumbs';
+
+// Mock next/navigation
+let mockPathname = '/';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+function setPathname(p: string) {
+  mockPathname = p;
+}
+
+// ─── isDynamicSegment ────────────────────────────────────────────────
+describe('isDynamicSegment', () => {
+  it('detects UUID v4 strings', () => {
+    expect(isDynamicSegment('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(true);
+  });
+
+  it('detects numeric IDs', () => {
+    expect(isDynamicSegment('42')).toBe(true);
+    expect(isDynamicSegment('123456')).toBe(true);
+  });
+
+  it('detects long hex IDs', () => {
+    expect(isDynamicSegment('abc123def456')).toBe(true);
+  });
+
+  it('rejects normal route segments', () => {
+    expect(isDynamicSegment('portfolio')).toBe(false);
+    expect(isDynamicSegment('audit-log')).toBe(false);
+    expect(isDynamicSegment('shadow-portfolios')).toBe(false);
+    expect(isDynamicSegment('data-quality')).toBe(false);
+  });
+});
+
+// ─── buildCrumbs ─────────────────────────────────────────────────────
+describe('buildCrumbs', () => {
+  it('returns empty array for root path', () => {
+    expect(buildCrumbs('/')).toEqual([]);
+  });
+
+  it('resolves a known static route', () => {
+    const crumbs = buildCrumbs('/portfolio');
+    expect(crumbs).toEqual([{ label: 'Portfolio', href: '/portfolio' }]);
+  });
+
+  it('shows parent label + "Details" for /recommendations/<uuid>', () => {
+    const crumbs = buildCrumbs('/recommendations/a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[0]).toEqual({ label: 'Recommendations', href: '/recommendations' });
+    expect(crumbs[1]).toEqual({
+      label: 'Details',
+      href: '/recommendations/a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+  });
+
+  it('shows parent label + "Details" for /experiment/<numeric-id>', () => {
+    const crumbs = buildCrumbs('/experiment/99');
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[0]).toEqual({ label: 'Experiments', href: '/experiment' });
+    expect(crumbs[1]).toEqual({ label: 'Details', href: '/experiment/99' });
+  });
+
+  it('handles nested static routes like /onboarding/live-account', () => {
+    const crumbs = buildCrumbs('/onboarding/live-account');
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[0]).toEqual({ label: 'Onboarding', href: '/onboarding' });
+    expect(crumbs[1]).toEqual({ label: 'Live Account', href: '/onboarding/live-account' });
+  });
+
+  it('falls back to formatted segment name for unknown routes', () => {
+    const crumbs = buildCrumbs('/some-unknown-route');
+    expect(crumbs).toEqual([{ label: 'some unknown route', href: '/some-unknown-route' }]);
+  });
+});
+
+// ─── ROUTE_LABELS completeness ───────────────────────────────────────
+describe('ROUTE_LABELS', () => {
+  const expectedRoutes = [
+    '/',
+    '/markets',
+    '/strategies',
+    '/signals',
+    '/portfolio',
+    '/orders',
+    '/journal',
+    '/advisor',
+    '/counterfactuals',
+    '/shadow-portfolios',
+    '/regime',
+    '/data-quality',
+    '/replay',
+    '/catalysts',
+    '/backtest',
+    '/agents',
+    '/experiment',
+    '/approvals',
+    '/workflows',
+    '/system-controls',
+    '/autonomy',
+    '/roles',
+    '/audit-log',
+    '/settings',
+    '/recommendations',
+  ];
+
+  it.each(expectedRoutes)('has a label for %s', (route) => {
+    expect(ROUTE_LABELS[route]).toBeDefined();
+    expect(ROUTE_LABELS[route].length).toBeGreaterThan(0);
+  });
+
+  it('contains at least 25 entries', () => {
+    expect(Object.keys(ROUTE_LABELS).length).toBeGreaterThanOrEqual(25);
+  });
+});
+
+// ─── Breadcrumbs component rendering ─────────────────────────────────
+describe('Breadcrumbs component', () => {
+  it('renders nothing for the root path', () => {
+    setPathname('/');
+    const { container } = render(<Breadcrumbs />);
+    expect(container.querySelector('nav')).toBeNull();
+  });
+
+  it('renders "Home > Portfolio" for /portfolio', () => {
+    setPathname('/portfolio');
+    render(<Breadcrumbs />);
+    expect(screen.getByText('Home')).toBeDefined();
+    expect(screen.getByText('Portfolio')).toBeDefined();
+  });
+
+  it('renders "Home > Recommendations > Details" for /recommendations/<uuid>', () => {
+    setPathname('/recommendations/a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    render(<Breadcrumbs />);
+    expect(screen.getByText('Home')).toBeDefined();
+    expect(screen.getByText('Recommendations')).toBeDefined();
+    expect(screen.getByText('Details')).toBeDefined();
+  });
+
+  it('renders "Home > Experiments > Details" for /experiment/<id>', () => {
+    setPathname('/experiment/42');
+    render(<Breadcrumbs />);
+    expect(screen.getByText('Home')).toBeDefined();
+    expect(screen.getByText('Experiments')).toBeDefined();
+    expect(screen.getByText('Details')).toBeDefined();
+  });
+
+  it('makes the parent a link and the last crumb plain text', () => {
+    setPathname('/recommendations/a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    render(<Breadcrumbs />);
+    const recommendationsLink = screen.getByText('Recommendations');
+    expect(recommendationsLink.closest('a')).toBeDefined();
+    expect(recommendationsLink.closest('a')?.getAttribute('href')).toBe('/recommendations');
+
+    const details = screen.getByText('Details');
+    expect(details.tagName).toBe('SPAN');
+  });
+
+  it('has an accessible nav landmark', () => {
+    setPathname('/portfolio');
+    render(<Breadcrumbs />);
+    expect(screen.getByLabelText('Breadcrumb')).toBeDefined();
+  });
+});

--- a/apps/web/tests/components/layout/sidebar-a11y.test.tsx
+++ b/apps/web/tests/components/layout/sidebar-a11y.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPathname = vi.fn(() => '/');
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.PropsWithChildren<React.AnchorHTMLAttributes<HTMLAnchorElement>>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ clear: vi.fn() }),
+}));
+
+// ---------------------------------------------------------------------------
+// Components under test
+// ---------------------------------------------------------------------------
+
+import { Sidebar } from '@/components/layout/sidebar';
+import { MobileNav } from '@/components/layout/mobile-nav';
+
+// ===========================================================================
+// Sidebar tests
+// ===========================================================================
+
+describe('Sidebar accessibility', () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue('/');
+  });
+
+  it('renders with nav element and aria-label', () => {
+    render(<Sidebar />);
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('active link has aria-current="page"', () => {
+    mockPathname.mockReturnValue('/strategies');
+    render(<Sidebar />);
+    const link = screen.getByRole('link', { name: /Strategies/i });
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('inactive link does not have aria-current', () => {
+    mockPathname.mockReturnValue('/');
+    render(<Sidebar />);
+    const link = screen.getByRole('link', { name: /Markets/i });
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('collapse button has aria-expanded when expanded', () => {
+    render(<Sidebar collapsed={false} />);
+    const btn = screen.getByRole('button', { name: /Collapse sidebar/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapse button has aria-expanded when collapsed', () => {
+    render(<Sidebar collapsed={true} />);
+    const btn = screen.getByRole('button', { name: /Expand sidebar/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('nav sections have group role with aria-label', () => {
+    render(<Sidebar />);
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBe(5);
+    expect(groups[0]).toHaveAttribute('aria-label', 'Overview');
+    expect(groups[1]).toHaveAttribute('aria-label', 'Trading');
+    expect(groups[2]).toHaveAttribute('aria-label', 'Analysis');
+    expect(groups[3]).toHaveAttribute('aria-label', 'Operations');
+    expect(groups[4]).toHaveAttribute('aria-label', 'Governance');
+  });
+});
+
+// ===========================================================================
+// MobileNav tests
+// ===========================================================================
+
+describe('MobileNav accessibility', () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue('/');
+  });
+
+  it('has aria-label on nav element', () => {
+    render(<MobileNav />);
+    const nav = screen.getByRole('navigation', { name: 'Mobile navigation' });
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('active item has aria-current="page"', () => {
+    mockPathname.mockReturnValue('/');
+    render(<MobileNav />);
+    const link = screen.getByRole('link', { name: /Dashboard/i });
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('inactive item does not have aria-current', () => {
+    mockPathname.mockReturnValue('/');
+    render(<MobileNav />);
+    const link = screen.getByRole('link', { name: /Markets/i });
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+});


### PR DESCRIPTION
## Phase 2 — Layout, Navigation & Page Shell Polish

### Summary
Accessibility, navigation UX, page transitions, and loading skeleton improvements across the entire dashboard.

### Changes

**Sidebar Accessibility** (sidebar.tsx, app-shell.tsx, mobile-nav.tsx)
- aria-expanded on collapse toggle, role=group with section labels
- Mobile sidebar: dialog role, aria-modal, focus trap, Escape key dismiss
- Active nav item: font-semibold for visual distinction

**Dynamic Breadcrumbs** (breadcrumbs.tsx)
- UUID/numeric/hex segment detection renders as "Details"
- 27 route labels covering all dashboard routes
- 42 tests covering all scenarios

**Page Transitions** (template.tsx + 10 pages)
- CSS-only animate-sentinel-in on route changes via template.tsx
- page-enter class on all 10 dashboard page root containers
- stagger-grid on 4 card grid layouts (strategies, signals, agents, journal)

**Loading Skeletons** (24 loading.tsx files)
- Improved skeleton layouts across all dashboard routes
- Better mobile responsiveness and visual consistency

### Testing
- **1097 tests passing** (104 files) — up from 1046 after Phase 1
- **51 new tests**: 42 breadcrumb + 9 sidebar accessibility
- Lint: all 3 packages clean
