### PR TITLE
feat(web): Phase 3 — Core dashboard pages polish

### DIFF
--- a/apps/web/src/app/(dashboard)/markets/page.tsx
+++ b/apps/web/src/app/(dashboard)/markets/page.tsx
@@ -12,11 +12,28 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { OfflineBanner } from '@/components/ui/offline-banner';
 import { DataProvenance } from '@/components/ui/data-provenance';
 import { ConfigBanner } from '@/components/ui/config-banner';
+import { ErrorBoundary } from '@/components/error-boundary';
+import { ErrorState } from '@/components/ui/error-state';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 import { useAppStore } from '@/stores/app-store';
 import { cn } from '@/lib/utils';
+import { getStatusColors } from '@/lib/status-colors';
 import type { OHLCV } from '@sentinel/shared';
 import { useQuotesQuery, useBarsQuery } from '@/hooks/queries';
-import { WATCHLIST_TICKERS, FALLBACK_PRICES, FALLBACK_CHANGES } from '@/lib/constants';
+import {
+  TICKER_SYMBOLS,
+  WATCHLIST_TICKERS,
+  FALLBACK_PRICES,
+  FALLBACK_CHANGES,
+} from '@/lib/constants';
 
 const TICKER_NAMES = WATCHLIST_TICKERS.map((w) => w.ticker);
 
@@ -61,19 +78,25 @@ function generateSampleData(basePrice: number): OHLCV[] {
   return data;
 }
 
-export default function MarketsPage() {
+function MarketsContent() {
   const engineOnline = useAppStore((s) => s.engineOnline);
-  const [selectedTicker, setSelectedTicker] = useState('AAPL');
+  const [selectedTicker, setSelectedTicker] = useState(TICKER_SYMBOLS[0]);
 
   const {
     data: quotes,
     isPending: quotesLoading,
+    isError: quotesError,
+    error: quotesErrorObj,
+    refetch: refetchQuotes,
     dataUpdatedAt: quotesUpdatedAt,
   } = useQuotesQuery(TICKER_NAMES);
   const {
     data: bars,
     isPending: chartLoading,
     isFetching: chartFetching,
+    isError: barsError,
+    error: barsErrorObj,
+    refetch: refetchBars,
     dataUpdatedAt: barsUpdatedAt,
   } = useBarsQuery(selectedTicker);
 
@@ -96,12 +119,23 @@ export default function MarketsPage() {
 
   const chartData: OHLCV[] = useMemo(() => {
     if (bars && bars.length > 0) return bars;
-    // Fallback: synthetic data when engine offline or no bars
     const stock = watchlist.find((w) => w.ticker === selectedTicker);
     return generateSampleData(stock?.price || 150);
   }, [bars, watchlist, selectedTicker]);
 
   const selectedStock = watchlist.find((w) => w.ticker === selectedTicker);
+
+  if (quotesError && engineOnline === true) {
+    return (
+      <div className="flex h-full flex-col gap-4 p-3 sm:p-4 page-enter">
+        <ErrorState
+          title="Failed to load market data"
+          message={quotesErrorObj?.message ?? 'Could not fetch quotes from the engine.'}
+          onRetry={() => refetchQuotes()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full flex-col gap-4 p-3 sm:p-4 page-enter">
@@ -113,13 +147,19 @@ export default function MarketsPage() {
           linkLabel="Go to Settings"
         />
       )}
-      <div className="flex flex-1 flex-col gap-4 min-h-0 lg:flex-row">
+      <div className="flex flex-1 flex-col gap-4 min-h-0 lg:flex-row stagger-grid">
         {/* Watchlist panel */}
-        <Card className="w-full shrink-0 bg-card border-border lg:w-72">
+        <Card
+          className="w-full shrink-0 bg-card border-border lg:w-72"
+          role="region"
+          aria-label="Watchlist panel"
+        >
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between">
               <CardTitle className="text-sm font-medium text-muted-foreground">Watchlist</CardTitle>
-              {!loading && (
+              {loading ? (
+                <Spinner size="sm" className="text-muted-foreground" />
+              ) : (
                 <DataProvenance
                   mode={quotesMode}
                   lastUpdated={quotesUpdatedAt ? new Date(quotesUpdatedAt) : null}
@@ -130,46 +170,67 @@ export default function MarketsPage() {
           </CardHeader>
           <CardContent className="p-0">
             <ScrollArea className="h-48 lg:h-[calc(100vh-12rem)]">
-              <div className="space-y-0.5 px-2 pb-2">
-                {watchlist.map((stock) => (
-                  <button
-                    key={stock.ticker}
-                    onClick={() => setSelectedTicker(stock.ticker)}
-                    className={cn(
-                      'flex w-full items-center justify-between rounded-md px-3 py-2.5 text-left transition-colors',
-                      selectedTicker === stock.ticker
-                        ? 'bg-accent text-foreground'
-                        : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
-                    )}
-                  >
-                    <div>
-                      <p className="text-sm font-medium">{stock.ticker}</p>
-                      <p className="text-[11px] text-muted-foreground">{stock.name}</p>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-sm font-medium">
-                        {stock.price > 0 ? `$${stock.price.toFixed(2)}` : '--'}
-                      </p>
-                      <p
+              <Table aria-label="Watchlist stocks">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-xs">Symbol</TableHead>
+                    <TableHead className="text-right text-xs">Price</TableHead>
+                    <TableHead className="text-right text-xs">Change</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {watchlist.map((stock) => {
+                    const changeColors = getStatusColors(stock.change >= 0 ? 'success' : 'error');
+
+                    return (
+                      <TableRow
+                        key={stock.ticker}
+                        onClick={() => setSelectedTicker(stock.ticker)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setSelectedTicker(stock.ticker);
+                          }
+                        }}
+                        tabIndex={0}
+                        aria-label={`View chart for ${stock.ticker}`}
+                        aria-current={selectedTicker === stock.ticker || undefined}
                         className={cn(
-                          'text-[11px] font-medium',
-                          stock.change >= 0 ? 'text-profit' : 'text-loss',
+                          'cursor-pointer transition-colors',
+                          selectedTicker === stock.ticker
+                            ? 'bg-accent text-foreground'
+                            : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
                         )}
                       >
-                        {stock.price > 0
-                          ? `${stock.change >= 0 ? '+' : ''}${stock.change.toFixed(2)}%`
-                          : '--'}
-                      </p>
-                    </div>
-                  </button>
-                ))}
-              </div>
+                        <TableCell className="py-2.5">
+                          <p className="text-sm font-medium">{stock.ticker}</p>
+                          <p className="text-[11px] text-muted-foreground">{stock.name}</p>
+                        </TableCell>
+                        <TableCell numeric className="py-2.5 text-right text-sm font-medium">
+                          {stock.price > 0 ? `$${stock.price.toFixed(2)}` : '--'}
+                        </TableCell>
+                        <TableCell
+                          numeric
+                          className={cn(
+                            'py-2.5 text-right text-[11px] font-medium',
+                            changeColors.text,
+                          )}
+                        >
+                          {stock.price > 0
+                            ? `${stock.change >= 0 ? '+' : ''}${stock.change.toFixed(2)}%`
+                            : '--'}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
             </ScrollArea>
           </CardContent>
         </Card>
 
         {/* Chart panel */}
-        <Card className="flex-1 bg-card border-border">
+        <Card className="flex-1 bg-card border-border" role="region" aria-label="Price chart panel">
           <CardHeader className="pb-2">
             <div className="flex items-center gap-3">
               <CardTitle className="text-lg font-bold">{selectedTicker}</CardTitle>
@@ -183,7 +244,7 @@ export default function MarketsPage() {
                     <span
                       className={cn(
                         'text-sm font-medium',
-                        selectedStock.change >= 0 ? 'text-profit' : 'text-loss',
+                        getStatusColors(selectedStock.change >= 0 ? 'success' : 'error').text,
                       )}
                     >
                       {selectedStock.change >= 0 ? '+' : ''}
@@ -192,9 +253,7 @@ export default function MarketsPage() {
                   )}
                 </>
               )}
-              {chartFetching && (
-                <span className="text-xs text-muted-foreground animate-pulse">Loading...</span>
-              )}
+              {chartFetching && <Spinner size="sm" className="text-muted-foreground" />}
               {!chartFetching && (
                 <DataProvenance
                   mode={chartMode}
@@ -205,10 +264,31 @@ export default function MarketsPage() {
             </div>
           </CardHeader>
           <CardContent className="h-[calc(100vh-14rem)] p-0 px-4 pb-4">
-            <PriceChart data={chartData} loading={chartLoading || loading} className="rounded-md" />
+            {barsError && engineOnline === true ? (
+              <ErrorState
+                title="Chart data unavailable"
+                message={barsErrorObj?.message ?? 'Could not load price history.'}
+                onRetry={() => refetchBars()}
+                className="flex h-full items-center justify-center"
+              />
+            ) : (
+              <PriceChart
+                data={chartData}
+                loading={chartLoading || loading}
+                className="rounded-md"
+              />
+            )}
           </CardContent>
         </Card>
       </div>
     </div>
+  );
+}
+
+export default function MarketsPage() {
+  return (
+    <ErrorBoundary>
+      <MarketsContent />
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -15,17 +15,31 @@ import {
   BarChart3,
   ExternalLink,
   FileText,
-  AlertCircle,
   XCircle,
   TrendingUp,
   TrendingDown,
 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  SortableTableHead,
+} from '@/components/ui/table';
+import type { SortState } from '@/components/ui/table';
+import { Select } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { ErrorState } from '@/components/ui/error-state';
+import { ErrorBoundary } from '@/components/error-boundary';
+import { Spinner } from '@/components/ui/spinner';
 import { useFillsQuery, useRiskEvaluationsQuery, useOrderHistoryQuery } from '@/hooks/queries';
 import type { Fill, RiskEvaluation, RiskCheck } from '@sentinel/shared';
 import type { OrderHistoryEntry } from '@/hooks/queries/use-order-history-query';
 import { cn } from '@/lib/utils';
-import { orderStatusColors, DEFAULT_ORDER_STYLE } from '@/lib/status-colors';
+import { orderStatusColors, DEFAULT_ORDER_STYLE, sideColors } from '@/lib/status-colors';
 import { PAGE_SIZE_ORDERS } from '@/lib/constants';
 
 // ─── Types ──────────────────────────────────────────────────────────────
@@ -126,12 +140,11 @@ function StatsRow({
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
+      <div className="stagger-grid grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <Card key={i} className="border-zinc-800 bg-zinc-900/50">
-            <CardContent className="p-4">
-              <div className="h-4 w-16 animate-pulse rounded bg-zinc-800" />
-              <div className="mt-2 h-6 w-10 animate-pulse rounded bg-zinc-800" />
+            <CardContent className="flex items-center justify-center p-4">
+              <Spinner size="sm" />
             </CardContent>
           </Card>
         ))}
@@ -163,7 +176,7 @@ function StatsRow({
   ];
 
   return (
-    <div className="grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
+    <div className="stagger-grid grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
       {cells.map((c) => {
         const Icon = c.icon;
         return (
@@ -179,32 +192,6 @@ function StatsRow({
         );
       })}
     </div>
-  );
-}
-
-// ─── Entry Badge ────────────────────────────────────────────────────────
-
-function EntryBadge({ entry }: { entry: TimelineEntry }) {
-  const meta = ENTRY_META[entry.type];
-  const color = getEntryBadgeColor(entry);
-  const Icon = meta.icon;
-
-  let label = meta.label;
-  if (entry.type === 'risk') {
-    label = (entry.data as RiskEvaluation).allowed ? 'Allowed' : 'Blocked';
-  } else if (entry.type === 'order') {
-    label =
-      (entry.data as OrderHistoryEntry).status.charAt(0).toUpperCase() +
-      (entry.data as OrderHistoryEntry).status.slice(1);
-  }
-
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${color}`}
-    >
-      <Icon className="h-3 w-3" />
-      {label}
-    </span>
   );
 }
 
@@ -465,7 +452,10 @@ function OrderDetail({ order }: { order: OrderHistoryEntry }) {
         <div>
           <span className="text-zinc-500">Side</span>
           <p
-            className={cn('font-medium', order.side === 'buy' ? 'text-green-400' : 'text-red-400')}
+            className={cn(
+              'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+              sideColors[order.side] ?? 'text-zinc-400',
+            )}
           >
             {order.side.toUpperCase()}
           </p>
@@ -514,133 +504,6 @@ function OrderDetail({ order }: { order: OrderHistoryEntry }) {
   );
 }
 
-// ─── Timeline Card ──────────────────────────────────────────────────────
-
-function TimelineCard({ entry }: { entry: TimelineEntry }) {
-  const [expanded, setExpanded] = useState(false);
-
-  const summary = useMemo(() => {
-    if (entry.type === 'fill') {
-      const fill = entry.data as Fill;
-      return {
-        primary: `${fill.fill_qty} @ ${formatCurrency(fill.fill_price)}`,
-        secondary: fill.order_id ? `Order ${fill.order_id.slice(0, 8)}…` : null,
-      };
-    }
-    if (entry.type === 'order') {
-      const order = entry.data as OrderHistoryEntry;
-      const sideLabel = order.side === 'buy' ? 'BUY' : 'SELL';
-      return {
-        primary: `${sideLabel} ${order.symbol} × ${order.qty}`,
-        secondary:
-          order.fill_price != null
-            ? `Filled @ ${formatCurrency(order.fill_price)}`
-            : order.status === 'cancelled'
-              ? 'Cancelled'
-              : order.status === 'rejected'
-                ? 'Rejected'
-                : null,
-      };
-    }
-    const risk = entry.data as RiskEvaluation;
-    return {
-      primary: risk.allowed
-        ? `Approved${risk.adjusted_quantity != null ? ` (qty: ${risk.adjusted_quantity})` : ''}`
-        : 'Blocked',
-      secondary: risk.reason,
-    };
-  }, [entry]);
-
-  return (
-    <Card className="border-zinc-800 bg-zinc-900/50">
-      <CardContent className="p-4">
-        {/* Header */}
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex flex-wrap items-center gap-2 min-w-0">
-            <EntryBadge entry={entry} />
-            <span className="text-sm font-semibold text-zinc-100">{summary.primary}</span>
-            {summary.secondary && (
-              <span className="text-xs text-zinc-500 truncate max-w-[200px] sm:max-w-xs">
-                {summary.secondary}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2 shrink-0 text-xs text-zinc-500">
-            <Clock className="h-3 w-3" />
-            <time dateTime={entry.timestamp}>{formatTimestamp(entry.timestamp)}</time>
-            <button
-              onClick={() => setExpanded(!expanded)}
-              className="text-zinc-500 hover:text-zinc-300 transition-colors"
-            >
-              {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-            </button>
-          </div>
-        </div>
-
-        {/* Quick stats */}
-        {entry.type === 'fill' && (
-          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
-            {(entry.data as Fill).commission != null && (
-              <span>Commission: {formatCurrency((entry.data as Fill).commission ?? 0)}</span>
-            )}
-            {(entry.data as Fill).slippage != null && (
-              <span>Slippage: {((entry.data as Fill).slippage as number).toFixed(4)}</span>
-            )}
-          </div>
-        )}
-
-        {entry.type === 'order' && (
-          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
-            <span className="flex items-center gap-1">
-              {(entry.data as OrderHistoryEntry).side === 'buy' ? (
-                <TrendingUp className="h-3 w-3 text-green-400" />
-              ) : (
-                <TrendingDown className="h-3 w-3 text-red-400" />
-              )}
-              {(entry.data as OrderHistoryEntry).order_type}
-            </span>
-            {(entry.data as OrderHistoryEntry).filled_qty > 0 && (
-              <span>
-                Filled: {(entry.data as OrderHistoryEntry).filled_qty}/
-                {(entry.data as OrderHistoryEntry).qty}
-              </span>
-            )}
-            {(entry.data as OrderHistoryEntry).risk_note && (
-              <span className="flex items-center gap-1">
-                <AlertCircle className="h-3 w-3" />
-                {(entry.data as OrderHistoryEntry).risk_note}
-              </span>
-            )}
-          </div>
-        )}
-
-        {entry.type === 'risk' && (
-          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
-            {(entry.data as RiskEvaluation).checks_performed.length > 0 && (
-              <span>
-                {(entry.data as RiskEvaluation).checks_performed.filter((c) => c.passed).length}/
-                {(entry.data as RiskEvaluation).checks_performed.length} checks passed
-              </span>
-            )}
-            {(entry.data as RiskEvaluation).policy_version && (
-              <span>Policy: {(entry.data as RiskEvaluation).policy_version}</span>
-            )}
-          </div>
-        )}
-
-        {/* Expanded detail */}
-        {expanded && (
-          <div className="mt-3 border-t border-zinc-800 pt-3">
-            {entry.type === 'fill' && <FillDetail fill={entry.data as Fill} />}
-            {entry.type === 'risk' && <RiskEvalDetail evaluation={entry.data as RiskEvaluation} />}
-            {entry.type === 'order' && <OrderDetail order={entry.data as OrderHistoryEntry} />}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
 // ─── Date Range Buttons ─────────────────────────────────────────────────
 
 const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
@@ -657,6 +520,57 @@ const TYPE_FILTER_OPTIONS: { value: TypeFilter; label: string }[] = [
   { value: 'risk', label: 'Risk Evals' },
 ];
 
+// ─── Sort Helpers ───────────────────────────────────────────────────────
+
+function getEntrySymbol(entry: TimelineEntry): string {
+  if (entry.type === 'order') return (entry.data as OrderHistoryEntry).symbol;
+  if (entry.type === 'fill') return (entry.data as Fill).order_id.slice(0, 8);
+  return (entry.data as RiskEvaluation).recommendation_id.slice(0, 8);
+}
+
+function getEntryStatus(entry: TimelineEntry): string {
+  if (entry.type === 'fill') return 'filled';
+  if (entry.type === 'order') return (entry.data as OrderHistoryEntry).status;
+  return (entry.data as RiskEvaluation).allowed ? 'allowed' : 'blocked';
+}
+
+function getEntrySide(entry: TimelineEntry): string | null {
+  if (entry.type === 'order') return (entry.data as OrderHistoryEntry).side;
+  return null;
+}
+
+function getEntrySummary(entry: TimelineEntry): { primary: string; secondary: string | null } {
+  if (entry.type === 'fill') {
+    const fill = entry.data as Fill;
+    return {
+      primary: `${fill.fill_qty} @ ${formatCurrency(fill.fill_price)}`,
+      secondary: fill.order_id ? `Order ${fill.order_id.slice(0, 8)}…` : null,
+    };
+  }
+  if (entry.type === 'order') {
+    const order = entry.data as OrderHistoryEntry;
+    const sideLabel = order.side === 'buy' ? 'BUY' : 'SELL';
+    return {
+      primary: `${sideLabel} ${order.symbol} × ${order.qty}`,
+      secondary:
+        order.fill_price != null
+          ? `Filled @ ${formatCurrency(order.fill_price)}`
+          : order.status === 'cancelled'
+            ? 'Cancelled'
+            : order.status === 'rejected'
+              ? 'Rejected'
+              : null,
+    };
+  }
+  const risk = entry.data as RiskEvaluation;
+  return {
+    primary: risk.allowed
+      ? `Approved${risk.adjusted_quantity != null ? ` (qty: ${risk.adjusted_quantity})` : ''}`
+      : 'Blocked',
+    secondary: risk.reason,
+  };
+}
+
 // ─── Main Page ──────────────────────────────────────────────────────────
 
 export default function OrdersPage() {
@@ -664,6 +578,8 @@ export default function OrdersPage() {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [symbolSearch, setSymbolSearch] = useState('');
   const [page, setPage] = useState(0);
+  const [sortState, setSortState] = useState<SortState>({ column: 'timestamp', direction: 'desc' });
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const pageSize = PAGE_SIZE_ORDERS;
 
   const from = useMemo(() => getDateRangeFrom(dateRange), [dateRange]);
@@ -767,10 +683,47 @@ export default function OrdersPage() {
     return entries;
   }, [fills, riskEvals, orders, typeFilter, from, symbolSearch]);
 
+  // Sort timeline
+  const sortedTimeline = useMemo(() => {
+    if (!sortState.direction) return timeline;
+    const dir = sortState.direction === 'asc' ? 1 : -1;
+    return [...timeline].sort((a, b) => {
+      switch (sortState.column) {
+        case 'timestamp':
+          return dir * (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+        case 'type':
+          return dir * a.type.localeCompare(b.type);
+        case 'symbol': {
+          const symA = getEntrySymbol(a);
+          const symB = getEntrySymbol(b);
+          return dir * symA.localeCompare(symB);
+        }
+        case 'status': {
+          const stA = getEntryStatus(a);
+          const stB = getEntryStatus(b);
+          return dir * stA.localeCompare(stB);
+        }
+        default:
+          return 0;
+      }
+    });
+  }, [timeline, sortState]);
+
   // Paginate
-  const totalEntries = timeline.length;
+  const totalEntries = sortedTimeline.length;
   const totalPages = Math.max(1, Math.ceil(totalEntries / pageSize));
-  const pagedEntries = timeline.slice(page * pageSize, (page + 1) * pageSize);
+  const pagedEntries = sortedTimeline.slice(page * pageSize, (page + 1) * pageSize);
+
+  const handleSort = useCallback((column: string) => {
+    setSortState((prev) => {
+      if (prev.column === column) {
+        const next = prev.direction === 'asc' ? 'desc' : prev.direction === 'desc' ? null : 'asc';
+        return { column, direction: next };
+      }
+      return { column, direction: 'asc' };
+    });
+    setPage(0);
+  }, []);
 
   const handleDateRange = useCallback((range: DateRange) => {
     setDateRange(range);
@@ -792,151 +745,336 @@ export default function OrdersPage() {
   const hasFilters = dateRange !== 'all' || typeFilter !== 'all' || symbolSearch !== '';
 
   return (
-    <div className="space-y-4 sm:space-y-6 page-enter">
-      {/* Page header */}
-      <div className="flex items-center gap-3">
-        <ArrowUpDown className="h-5 w-5 sm:h-6 sm:w-6 text-zinc-400" />
-        <div>
-          <h1 className="text-heading-page text-zinc-100">Orders &amp; Fills</h1>
-          <p className="text-xs sm:text-sm text-zinc-500">Execution activity timeline</p>
-        </div>
-      </div>
-
-      {/* Stats */}
-      <StatsRow fills={fills} riskEvals={riskEvals} orders={orders} isLoading={isLoading} />
-
-      {/* Filters */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-        <div className="flex items-center gap-2 overflow-x-auto">
-          {/* Date range */}
-          <div className="flex shrink-0 rounded-md border border-zinc-700 overflow-hidden">
-            {DATE_RANGE_OPTIONS.map((opt) => (
-              <button
-                key={opt.value}
-                onClick={() => handleDateRange(opt.value)}
-                className={`px-3 py-1.5 text-xs transition-colors ${
-                  dateRange === opt.value
-                    ? 'bg-zinc-700 text-zinc-100 font-medium'
-                    : 'bg-zinc-900 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800'
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
+    <ErrorBoundary>
+      <div className="space-y-4 sm:space-y-6 page-enter">
+        {/* Page header */}
+        <div className="flex items-center gap-3">
+          <ArrowUpDown className="h-5 w-5 sm:h-6 sm:w-6 text-zinc-400" />
+          <div>
+            <h1 className="text-heading-page text-zinc-100">Orders &amp; Fills</h1>
+            <p className="text-xs sm:text-sm text-zinc-500">Execution activity timeline</p>
           </div>
-
-          {/* Type filter */}
-          <select
-            value={typeFilter}
-            onChange={(e) => handleTypeFilter(e.target.value as TypeFilter)}
-            className="shrink-0 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-sm text-zinc-300 focus:border-zinc-500 focus:outline-none"
-          >
-            {TYPE_FILTER_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
         </div>
 
-        <div className="flex items-center gap-2">
-          {/* Symbol / ID search */}
-          <div className="relative flex-1 sm:flex-initial">
-            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
-            <input
-              type="text"
-              placeholder="Search ID or reason…"
-              value={symbolSearch}
-              onChange={(e) => {
-                setSymbolSearch(e.target.value);
-                setPage(0);
-              }}
-              className="w-full rounded-md border border-zinc-700 bg-zinc-900 py-1.5 pl-8 pr-3 text-sm text-zinc-300 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none sm:w-48"
-            />
-          </div>
+        {/* Stats */}
+        <StatsRow fills={fills} riskEvals={riskEvals} orders={orders} isLoading={isLoading} />
 
-          {hasFilters && (
-            <button
-              onClick={handleClearFilters}
-              className="shrink-0 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+        {/* Filters */}
+        <div
+          className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center"
+          role="search"
+          aria-label="Filter orders"
+        >
+          <div className="flex items-center gap-2 overflow-x-auto">
+            {/* Date range */}
+            <div
+              className="flex shrink-0 rounded-md border border-zinc-700 overflow-hidden"
+              role="group"
+              aria-label="Date range filter"
             >
-              Clear
-            </button>
-          )}
-        </div>
+              {DATE_RANGE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => handleDateRange(opt.value)}
+                  aria-label={`Filter by ${opt.label}`}
+                  aria-pressed={dateRange === opt.value}
+                  className={cn(
+                    'px-3 py-1.5 text-xs transition-colors',
+                    dateRange === opt.value
+                      ? 'bg-zinc-700 text-zinc-100 font-medium'
+                      : 'bg-zinc-900 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800',
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
 
-        <span className="text-xs text-zinc-600 sm:ml-auto">
-          {totalEntries} {totalEntries === 1 ? 'event' : 'events'}
-        </span>
-      </div>
+            {/* Type filter */}
+            <Select
+              value={typeFilter}
+              onChange={(e) => handleTypeFilter(e.target.value as TypeFilter)}
+              aria-label="Filter by event type"
+              className="shrink-0 w-auto"
+            >
+              {TYPE_FILTER_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          </div>
 
-      {/* Timeline */}
-      {isLoading && (
-        <div className="space-y-3">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <Card key={i} className="border-zinc-800 bg-zinc-900/50">
-              <CardContent className="p-4">
-                <div className="flex items-center gap-2">
-                  <div className="h-5 w-16 animate-pulse rounded-full bg-zinc-800" />
-                  <div className="h-4 w-32 animate-pulse rounded bg-zinc-800" />
-                </div>
-                <div className="mt-2 h-3 w-48 animate-pulse rounded bg-zinc-800" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
+          <div className="flex items-center gap-2">
+            {/* Symbol / ID search */}
+            <div className="relative flex-1 sm:flex-initial">
+              <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500 z-10" />
+              <Input
+                type="text"
+                placeholder="Search ID or reason…"
+                value={symbolSearch}
+                onChange={(e) => {
+                  setSymbolSearch(e.target.value);
+                  setPage(0);
+                }}
+                aria-label="Search orders by ID, symbol, or reason"
+                className="w-full pl-8 sm:w-48"
+              />
+            </div>
 
-      {isError && (
-        <Card className="border-red-900/50 bg-red-950/20">
-          <CardContent className="p-6 text-center text-red-400">
-            Failed to load execution data. Please try again.
-          </CardContent>
-        </Card>
-      )}
+            {hasFilters && (
+              <button
+                onClick={handleClearFilters}
+                aria-label="Clear all filters"
+                className="shrink-0 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                Clear
+              </button>
+            )}
+          </div>
 
-      {!isLoading && !isError && pagedEntries.length === 0 && (
-        <Card className="border-zinc-800 bg-zinc-900/50">
-          <CardContent className="p-12 text-center">
-            <Activity className="mx-auto h-10 w-10 text-zinc-700" />
-            <h3 className="mt-4 text-lg font-medium text-zinc-400">No execution activity yet</h3>
-            <p className="mt-1 text-sm text-zinc-600">
-              Fills and risk evaluations will appear here as trades are executed.
-            </p>
-          </CardContent>
-        </Card>
-      )}
-
-      {!isLoading && !isError && pagedEntries.length > 0 && (
-        <div className="space-y-3">
-          {pagedEntries.map((entry) => (
-            <TimelineCard key={entry.id} entry={entry} />
-          ))}
-        </div>
-      )}
-
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2">
-          <button
-            onClick={() => setPage(Math.max(0, page - 1))}
-            disabled={page === 0}
-            className="rounded px-3 py-1 text-sm text-zinc-400 hover:text-zinc-200 disabled:opacity-30"
-          >
-            Previous
-          </button>
-          <span className="text-xs text-zinc-500">
-            Page {page + 1} of {totalPages}
+          <span className="text-xs text-zinc-600 sm:ml-auto">
+            {totalEntries} {totalEntries === 1 ? 'event' : 'events'}
           </span>
-          <button
-            onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
-            disabled={page >= totalPages - 1}
-            className="rounded px-3 py-1 text-sm text-zinc-400 hover:text-zinc-200 disabled:opacity-30"
-          >
-            Next
-          </button>
         </div>
-      )}
-    </div>
+
+        {/* Timeline Table */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        )}
+
+        {isError && (
+          <ErrorState
+            title="Failed to load data"
+            message="Failed to load execution data. Please try again."
+            onRetry={() => {
+              void fillsQuery.refetch();
+              void riskQuery.refetch();
+              void ordersQuery.refetch();
+            }}
+          />
+        )}
+
+        {!isLoading && !isError && pagedEntries.length === 0 && (
+          <Card className="border-zinc-800 bg-zinc-900/50">
+            <CardContent className="p-12 text-center">
+              <Activity className="mx-auto h-10 w-10 text-zinc-700" />
+              <h3 className="mt-4 text-lg font-medium text-zinc-400">No execution activity yet</h3>
+              <p className="mt-1 text-sm text-zinc-600">
+                Fills and risk evaluations will appear here as trades are executed.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {!isLoading && !isError && pagedEntries.length > 0 && (
+          <Card className="border-zinc-800 bg-zinc-900/50 overflow-hidden">
+            <Table aria-label="Orders and execution timeline">
+              <TableHeader>
+                <TableRow>
+                  <SortableTableHead column="type" sortState={sortState} onSort={handleSort}>
+                    Type
+                  </SortableTableHead>
+                  <SortableTableHead column="symbol" sortState={sortState} onSort={handleSort}>
+                    Symbol / ID
+                  </SortableTableHead>
+                  <TableHead>Side</TableHead>
+                  <SortableTableHead column="status" sortState={sortState} onSort={handleSort}>
+                    Status
+                  </SortableTableHead>
+                  <TableHead>Summary</TableHead>
+                  <SortableTableHead column="timestamp" sortState={sortState} onSort={handleSort}>
+                    Time
+                  </SortableTableHead>
+                  <TableHead className="w-10">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {pagedEntries.map((entry) => {
+                  const meta = ENTRY_META[entry.type];
+                  const badgeColor = getEntryBadgeColor(entry);
+                  const Icon = meta.icon;
+                  const side = getEntrySide(entry);
+                  const status = getEntryStatus(entry);
+                  const statusStyle =
+                    entry.type === 'order'
+                      ? (ORDER_STATUS_STYLES[(entry.data as OrderHistoryEntry).status] ??
+                        DEFAULT_ORDER_STYLE)
+                      : null;
+                  const summary = getEntrySummary(entry);
+                  const isExpanded = expandedId === entry.id;
+
+                  return (
+                    <TableRow key={entry.id}>
+                      {/* Type badge */}
+                      <TableCell>
+                        <span
+                          className={cn(
+                            'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                            badgeColor,
+                          )}
+                        >
+                          <Icon className="h-3 w-3" />
+                          {meta.label}
+                        </span>
+                      </TableCell>
+
+                      {/* Symbol / ID */}
+                      <TableCell className="font-mono text-xs">
+                        {entry.type === 'order' ? (
+                          <span className="font-semibold text-zinc-100">
+                            {(entry.data as OrderHistoryEntry).symbol}
+                          </span>
+                        ) : entry.type === 'fill' ? (
+                          <span className="text-zinc-400 truncate max-w-[100px] inline-block">
+                            {(entry.data as Fill).order_id.slice(0, 8)}…
+                          </span>
+                        ) : (
+                          <Link
+                            href={`/recommendations/${(entry.data as RiskEvaluation).recommendation_id}`}
+                            className="text-blue-400 hover:text-blue-300 transition-colors inline-flex items-center gap-1"
+                          >
+                            {(entry.data as RiskEvaluation).recommendation_id.slice(0, 8)}…
+                            <ExternalLink className="h-3 w-3" />
+                          </Link>
+                        )}
+                      </TableCell>
+
+                      {/* Side */}
+                      <TableCell>
+                        {side ? (
+                          <span
+                            className={cn(
+                              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                              sideColors[side] ?? '',
+                            )}
+                          >
+                            {side === 'buy' ? (
+                              <TrendingUp className="h-3 w-3" />
+                            ) : (
+                              <TrendingDown className="h-3 w-3" />
+                            )}
+                            {side.toUpperCase()}
+                          </span>
+                        ) : (
+                          <span className="text-zinc-600">—</span>
+                        )}
+                      </TableCell>
+
+                      {/* Status */}
+                      <TableCell>
+                        {statusStyle ? (
+                          <span
+                            className={cn(
+                              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                              statusStyle.bg,
+                              statusStyle.text,
+                            )}
+                          >
+                            {status.charAt(0).toUpperCase() + status.slice(1)}
+                          </span>
+                        ) : (
+                          <span
+                            className={cn(
+                              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                              badgeColor,
+                            )}
+                          >
+                            {status.charAt(0).toUpperCase() + status.slice(1)}
+                          </span>
+                        )}
+                      </TableCell>
+
+                      {/* Summary */}
+                      <TableCell className="max-w-[200px]">
+                        <span className="text-sm text-zinc-200">{summary.primary}</span>
+                        {summary.secondary && (
+                          <span className="block text-xs text-zinc-500 truncate">
+                            {summary.secondary}
+                          </span>
+                        )}
+                      </TableCell>
+
+                      {/* Time */}
+                      <TableCell className="text-xs text-zinc-500 whitespace-nowrap">
+                        <span className="inline-flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          <time dateTime={entry.timestamp}>{formatTimestamp(entry.timestamp)}</time>
+                        </span>
+                      </TableCell>
+
+                      {/* Expand */}
+                      <TableCell>
+                        <button
+                          onClick={() => setExpandedId(isExpanded ? null : entry.id)}
+                          aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
+                          aria-expanded={isExpanded}
+                          className="text-zinc-500 hover:text-zinc-300 transition-colors"
+                        >
+                          {isExpanded ? (
+                            <ChevronUp className="h-4 w-4" />
+                          ) : (
+                            <ChevronDown className="h-4 w-4" />
+                          )}
+                        </button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+
+            {/* Expanded detail rows */}
+            {expandedId && pagedEntries.some((e) => e.id === expandedId) && (
+              <div className="border-t border-zinc-800 bg-zinc-950/50 p-4">
+                {(() => {
+                  const entry = pagedEntries.find((e) => e.id === expandedId)!;
+                  return (
+                    <>
+                      {entry.type === 'fill' && <FillDetail fill={entry.data as Fill} />}
+                      {entry.type === 'risk' && (
+                        <RiskEvalDetail evaluation={entry.data as RiskEvaluation} />
+                      )}
+                      {entry.type === 'order' && (
+                        <OrderDetail order={entry.data as OrderHistoryEntry} />
+                      )}
+                    </>
+                  );
+                })()}
+              </div>
+            )}
+          </Card>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <nav className="flex items-center justify-center gap-2" aria-label="Pagination">
+            <button
+              onClick={() => setPage(Math.max(0, page - 1))}
+              disabled={page === 0}
+              aria-label="Go to previous page"
+              className="rounded px-3 py-1 text-sm text-zinc-400 hover:text-zinc-200 disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-xs text-zinc-500">
+              Page {page + 1} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
+              disabled={page >= totalPages - 1}
+              aria-label="Go to next page"
+              className="rounded px-3 py-1 text-sm text-zinc-400 hover:text-zinc-200 disabled:opacity-30"
+            >
+              Next
+            </button>
+          </nav>
+        )}
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -21,6 +21,7 @@ import { SetupProgress } from '@/components/dashboard/setup-progress';
 import { OnboardingWizard } from '@/components/onboarding/onboarding-wizard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorBoundary } from '@/components/error-boundary';
 import { OfflineBanner } from '@/components/ui/offline-banner';
 import { SimulatedBadge } from '@/components/ui/simulated-badge';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
@@ -36,9 +37,16 @@ import {
   useAgentStatusQuery,
 } from '@/hooks/queries';
 import { useOnboardingProfile, useInvalidateOnboarding } from '@/hooks/use-onboarding';
-import { TICKER_SYMBOLS, FALLBACK_TICKER_DATA, POLL_INTERVAL } from '@/lib/constants';
+import {
+  TICKER_SYMBOLS,
+  FALLBACK_TICKER_DATA,
+  POLL_INTERVAL,
+  FALLBACK_ACCOUNT,
+  MAX_LIVE_SCAN_TICKERS,
+} from '@/lib/constants';
+import { sideColors, getSignalStrengthColor, getStatusColors } from '@/lib/status-colors';
 
-export default function DashboardPage() {
+function DashboardContent() {
   const engineOnline = useAppStore((s) => s.engineOnline);
   const agentsOnline = useAppStore((s) => s.agentsOnline);
 
@@ -87,7 +95,7 @@ export default function DashboardPage() {
 
   const recentSignals = useMemo(() => {
     if (!filledRecs) return [];
-    return filledRecs.slice(0, 5).map((r) => ({
+    return filledRecs.slice(0, MAX_LIVE_SCAN_TICKERS).map((r) => ({
       ticker: r.ticker,
       side: r.side,
       reason: r.reason ?? '',
@@ -96,178 +104,211 @@ export default function DashboardPage() {
     }));
   }, [filledRecs]);
 
-  const equity = account?.equity ?? 100_000;
-  const pnl = equity - (account?.initial_capital ?? 100_000);
+  const equity = account?.equity ?? FALLBACK_ACCOUNT.equity;
+  const pnl = equity - (account?.initial_capital ?? FALLBACK_ACCOUNT.initial_capital);
   const pnlPct = account?.initial_capital ? (pnl / account.initial_capital) * 100 : 0;
 
+  const tradingColors = getStatusColors(systemControls?.trading_halted ? 'error' : 'success');
+  const pendingColors = getStatusColors('warning');
+  const agentColors = getStatusColors(
+    agentStatus?.halted ? 'error' : agentStatus?.isRunning ? 'success' : 'neutral',
+  );
+
   return (
-    <div className="space-y-4 p-4 page-enter">
+    <div className="space-y-4 p-3 sm:p-4 xl:p-6 page-enter" aria-label="Trading dashboard">
       <h1 className="text-heading-page">Dashboard</h1>
 
       {engineOnline === false && <OfflineBanner service="engine" />}
       {agentsOnline === false && <OfflineBanner service="agents" />}
 
       {/* System Health Strip */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm sm:px-4">
+      <section
+        aria-label="System health status"
+        className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm sm:px-4"
+      >
         <div className="flex items-center gap-1.5">
-          <Shield className="h-3.5 w-3.5" />
-          {systemControls?.trading_halted ? (
-            <span className="font-medium text-loss">Halted</span>
-          ) : (
-            <span className="font-medium text-profit">Active</span>
-          )}
+          <Shield className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className={cn('font-medium', tradingColors.text)}>
+            {systemControls?.trading_halted ? 'Halted' : 'Active'}
+          </span>
         </div>
-        <span className="hidden sm:inline text-border">|</span>
+        <span className="hidden sm:inline text-border" aria-hidden="true">
+          |
+        </span>
         <div className="flex items-center gap-1.5">
-          <Activity className="h-3.5 w-3.5 text-muted-foreground" />
+          <Activity className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase">
             {systemControls?.global_mode ?? 'paper'}
           </span>
         </div>
-        <span className="hidden sm:inline text-border">|</span>
+        <span className="hidden sm:inline text-border" aria-hidden="true">
+          |
+        </span>
         <div className="flex items-center gap-1.5">
-          <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+          <Clock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           <span className="text-muted-foreground">Pending:</span>
           <span
             className={cn(
               'font-medium',
-              (pendingRecs?.length ?? 0) > 0 ? 'text-amber-500' : 'text-muted-foreground',
+              (pendingRecs?.length ?? 0) > 0 ? pendingColors.text : 'text-muted-foreground',
             )}
           >
             {pendingRecs?.length ?? 0}
           </span>
         </div>
-        <span className="hidden sm:inline text-border">|</span>
+        <span className="hidden sm:inline text-border" aria-hidden="true">
+          |
+        </span>
         <div className="flex items-center gap-1.5">
-          <Bot className="h-3.5 w-3.5 text-muted-foreground" />
-          <span
-            className={cn(
-              'font-medium',
-              agentStatus?.halted
-                ? 'text-loss'
-                : agentStatus?.isRunning
-                  ? 'text-profit'
-                  : 'text-muted-foreground',
-            )}
-          >
+          <Bot className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          <span className={cn('font-medium', agentColors.text)}>
             {agentStatus?.halted ? 'Halted' : agentStatus?.isRunning ? 'Running' : 'Idle'}
           </span>
           {agentStatus?.cycleCount != null && (
             <span className="text-xs text-muted-foreground">#{agentStatus.cycleCount}</span>
           )}
         </div>
-      </div>
+      </section>
 
       {/* Incident Controls */}
       <IncidentControls />
 
-      {/* Row 1: Metric Cards */}
-      <div className="@container">
-        <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 stagger-grid">
-          <MetricCard
-            label={
-              <>
-                Total Equity{' '}
-                <InfoTooltip content="Total value of all assets including cash and open positions." />
-              </>
-            }
-            value={<AnimatedNumber value={equity} prefix="$" decimals={2} />}
-            icon={<DollarSign className="h-4 w-4 text-muted-foreground" />}
-          />
-          <MetricCard
-            label={
-              <>
-                Daily P&L{' '}
-                <InfoTooltip content="Today's profit or loss across all positions, updated in real-time during market hours." />
-              </>
-            }
-            value={
-              <AnimatedNumber value={Math.abs(pnl)} prefix={pnl >= 0 ? '+$' : '-$'} decimals={2} />
-            }
-            change={pnlPct}
-            icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
-          />
-          <MetricCard
-            label={
-              <>
-                Cash Available <InfoTooltip content="Uninvested cash available for new trades." />
-              </>
-            }
-            value={<AnimatedNumber value={account?.cash ?? 100_000} prefix="$" decimals={2} />}
-            icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />}
-          />
-          <MetricCard
-            label="Positions Value"
-            value={<AnimatedNumber value={account?.positions_value ?? 0} prefix="$" decimals={2} />}
-            icon={<AlertTriangle className="h-4 w-4 text-muted-foreground" />}
-          />
+      {/* Portfolio Metrics */}
+      <section aria-label="Portfolio metrics">
+        <div className="@container">
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 stagger-grid">
+            <MetricCard
+              label={
+                <>
+                  Total Equity{' '}
+                  <InfoTooltip content="Total value of all assets including cash and open positions." />
+                </>
+              }
+              value={<AnimatedNumber value={equity} prefix="$" decimals={2} />}
+              icon={<DollarSign className="h-4 w-4 text-muted-foreground" />}
+            />
+            <MetricCard
+              label={
+                <>
+                  Daily P&L{' '}
+                  <InfoTooltip content="Today's profit or loss across all positions, updated in real-time during market hours." />
+                </>
+              }
+              value={
+                <AnimatedNumber
+                  value={Math.abs(pnl)}
+                  prefix={pnl >= 0 ? '+$' : '-$'}
+                  decimals={2}
+                />
+              }
+              change={pnlPct}
+              icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
+            />
+            <MetricCard
+              label={
+                <>
+                  Cash Available <InfoTooltip content="Uninvested cash available for new trades." />
+                </>
+              }
+              value={
+                <AnimatedNumber
+                  value={account?.cash ?? FALLBACK_ACCOUNT.cash}
+                  prefix="$"
+                  decimals={2}
+                />
+              }
+              icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />}
+            />
+            <MetricCard
+              label="Positions Value"
+              value={
+                <AnimatedNumber
+                  value={account?.positions_value ?? FALLBACK_ACCOUNT.positions_value}
+                  prefix="$"
+                  decimals={2}
+                />
+              }
+              icon={<AlertTriangle className="h-4 w-4 text-muted-foreground" />}
+            />
+          </div>
         </div>
-      </div>
+      </section>
 
-      {/* Row 2: Price Ticker */}
-      <div className="relative">
+      {/* Price Ticker */}
+      <section aria-label="Market prices" className="relative">
         <PriceTicker items={tickerData} />
         <span className="absolute -top-1.5 right-2">
           {isLive ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-profit/15 px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-profit uppercase">
-              <span className="h-1 w-1 rounded-full bg-profit animate-pulse" />
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-profit/15 px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-profit uppercase"
+              aria-label="Live market data"
+            >
+              <span className="h-1 w-1 rounded-full bg-profit animate-pulse" aria-hidden="true" />
               Live
             </span>
           ) : (
             <SimulatedBadge />
           )}
         </span>
-      </div>
+      </section>
 
-      {/* Row 3: Two columns */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        {/* Active Signals */}
-        <Card className="bg-card border-border">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-heading-card">Active Signals</CardTitle>
-            <Zap className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            {recentSignals.length === 0 ? (
-              <EmptyState
-                icon={Zap}
-                title="No Recent Signals"
-                description="Strategies generate signals during market hours."
-                className="border-0 bg-transparent py-6"
-              />
-            ) : (
-              <div className="space-y-2">
-                {recentSignals.map((s, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center justify-between py-1.5 border-b border-border/50 last:border-0"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          'text-[10px] font-bold px-1.5 py-0.5 rounded',
-                          s.side === 'buy' ? 'bg-profit/15 text-profit' : 'bg-loss/15 text-loss',
-                        )}
-                      >
-                        {s.side.toUpperCase()}
-                      </span>
-                      <span className="text-sm font-semibold text-foreground">{s.ticker}</span>
-                    </div>
-                    {s.strength != null && (
-                      <span className="text-xs font-mono text-muted-foreground">
-                        {(s.strength * 100).toFixed(0)}%
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+      {/* Signals & Alerts */}
+      <section aria-label="Signals and alerts">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {/* Active Signals */}
+          <Card className="bg-card border-border">
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-heading-card">Active Signals</CardTitle>
+              <Zap className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            </CardHeader>
+            <CardContent>
+              {recentSignals.length === 0 ? (
+                <EmptyState
+                  icon={Zap}
+                  title="No Recent Signals"
+                  description="Strategies generate signals during market hours."
+                  className="border-0 bg-transparent py-6"
+                />
+              ) : (
+                <div className="space-y-2" role="list" aria-label="Recent trading signals">
+                  {recentSignals.map((s, i) => (
+                    <article
+                      key={i}
+                      className="flex items-center justify-between py-1.5 border-b border-border/50 last:border-0"
+                      role="listitem"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={cn(
+                            'text-[10px] font-bold px-1.5 py-0.5 rounded',
+                            sideColors[s.side] ?? sideColors.buy,
+                          )}
+                        >
+                          {s.side.toUpperCase()}
+                        </span>
+                        <span className="text-sm font-semibold text-foreground">{s.ticker}</span>
+                      </div>
+                      {s.strength != null && (
+                        <span
+                          className={cn(
+                            'text-xs font-mono px-1.5 py-0.5 rounded border',
+                            getSignalStrengthColor(s.strength),
+                          )}
+                        >
+                          {(s.strength * 100).toFixed(0)}%
+                        </span>
+                      )}
+                    </article>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
-        {/* Alert Feed */}
-        <AlertFeed alerts={alerts} />
-      </div>
+          {/* Alert Feed */}
+          <AlertFeed alerts={alerts} />
+        </div>
+      </section>
 
       {/* Setup Progress */}
       <SetupProgress />
@@ -280,5 +321,13 @@ export default function DashboardPage() {
         />
       )}
     </div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <ErrorBoundary>
+      <DashboardContent />
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/app/(dashboard)/portfolio/page.tsx
+++ b/apps/web/src/app/(dashboard)/portfolio/page.tsx
@@ -8,6 +8,8 @@ import { OfflineBanner } from '@/components/ui/offline-banner';
 import { ConfigBanner } from '@/components/ui/config-banner';
 import { DataProvenance } from '@/components/ui/data-provenance';
 import type { DataProvenanceProps } from '@/components/ui/data-provenance';
+import { ErrorBoundary } from '@/components/error-boundary';
+import { Spinner } from '@/components/ui/spinner';
 import { useAppStore } from '@/stores/app-store';
 import { SnapshotMetrics } from '@/components/portfolio/snapshot-metrics';
 import {
@@ -37,7 +39,12 @@ import {
 } from '@/hooks/queries';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
-import { FALLBACK_ACCOUNT, ORDER_TERMINAL_STATUSES } from '@/lib/constants';
+import {
+  FALLBACK_ACCOUNT,
+  ORDER_TERMINAL_STATUSES,
+  TICKER_SYMBOLS,
+  PAGE_SIZE_ORDERS,
+} from '@/lib/constants';
 
 export default function PortfolioPage() {
   const engineOnline = useAppStore((s) => s.engineOnline);
@@ -70,7 +77,7 @@ export default function PortfolioPage() {
     dataUpdatedAt: accountUpdatedAt,
   } = useAccountQuery();
   const { data: brokerPositions } = usePositionsQuery();
-  const { data: orderHistory } = useOrderHistoryQuery();
+  const { data: orderHistory } = useOrderHistoryQuery(PAGE_SIZE_ORDERS);
   const submitOrder = useSubmitOrderMutation();
 
   // Get tickers for live quote enrichment
@@ -258,143 +265,140 @@ export default function PortfolioPage() {
 
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <span className="text-sm text-muted-foreground animate-pulse">Connecting to engine...</span>
+      <div className="flex h-full items-center justify-center" aria-label="Loading portfolio">
+        <Spinner size="md" />
+        <span className="ml-2 text-sm text-muted-foreground animate-pulse">
+          Connecting to engine...
+        </span>
       </div>
     );
   }
 
   return (
-    <div className="space-y-4 p-4 page-enter">
-      {engineOnline === false && <OfflineBanner service="engine" />}
-      {provenanceMode === 'simulated' && engineOnline === true && (
-        <ConfigBanner
-          message="Showing simulated portfolio. Configure Alpaca API keys for live/paper trading."
-          linkHref="/settings"
-          linkLabel="Go to Settings"
-        />
-      )}
-
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <PieChart className="h-5 w-5 text-primary" />
-          <div>
-            <h1 className="text-heading-page text-foreground">Portfolio</h1>
-            <p className="text-xs text-muted-foreground">
-              {positions.length} position{positions.length !== 1 ? 's' : ''}
-            </p>
-          </div>
-          <DataProvenance
-            mode={provenanceMode}
-            lastUpdated={provenanceLastUpdated}
-            staleThresholdMs={60_000}
+    <ErrorBoundary>
+      <div className="space-y-4 p-4 page-enter">
+        {engineOnline === false && <OfflineBanner service="engine" />}
+        {provenanceMode === 'simulated' && engineOnline === true && (
+          <ConfigBanner
+            message="Showing simulated portfolio. Configure Alpaca API keys for live/paper trading."
+            linkHref="/settings"
+            linkLabel="Go to Settings"
           />
-        </div>
-        <button
-          onClick={() => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.portfolio.account() });
-            queryClient.invalidateQueries({ queryKey: queryKeys.portfolio.positions() });
-          }}
-          disabled={engineOnline !== true}
-          className="flex items-center gap-1.5 rounded-md bg-muted/50 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Refresh
-        </button>
-      </div>
+        )}
 
-      <SnapshotMetrics
-        portfolioTotal={portfolioTotal}
-        totalPnl={totalPnl}
-        totalPnlPct={totalPnlPct}
-        totalCost={totalCost}
-        cashBalance={cashBalance}
-        positionCount={positions.length}
-        totalValue={totalValue}
-      />
-
-      <QuickOrder
-        symbol={orderSymbol}
-        side={orderSide}
-        qty={orderQty}
-        orderType={orderType}
-        timeInForce={timeInForce}
-        limitPrice={limitPrice}
-        status={orderStatus}
-        submitting={submitOrder.isPending}
-        disabled={engineOnline !== true}
-        onSymbolChange={setOrderSymbol}
-        onSideChange={setOrderSide}
-        onQtyChange={setOrderQty}
-        onOrderTypeChange={setOrderType}
-        onTimeInForceChange={setTimeInForce}
-        onLimitPriceChange={setLimitPrice}
-        onSubmit={handleSubmitOrder}
-      />
-
-      <div className="space-y-1">
+        {/* Header */}
         <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            Recent Orders
-            {isPolling && <span className="ml-1.5 text-amber-400 animate-pulse">polling...</span>}
-          </span>
-        </div>
-        <RecentOrders orders={recentOrders} pollingOrderId={pollingOrderId} />
-      </div>
-
-      <Tabs defaultValue="positions" className="space-y-3">
-        <TabsList className="bg-muted/50">
-          <TabsTrigger value="positions">Positions</TabsTrigger>
-          <TabsTrigger value="allocation">Allocation</TabsTrigger>
-          <TabsTrigger value="risk">Risk</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="positions">
-          {positions.length === 0 ? (
-            <Card className="bg-muted/30 border-border/50">
-              <CardContent className="flex flex-col items-center justify-center py-8 text-center">
-                <p className="text-sm text-muted-foreground">
-                  {provenanceMode === 'live' &&
-                    'No open positions. Use Quick Order above to place your first trade.'}
-                  {provenanceMode === 'cached' &&
-                    'Cached data \u2014 no positions found. Reconnect engine for live updates.'}
-                  {provenanceMode === 'simulated' &&
-                    'Showing simulated portfolio \u2014 connect the engine for live data.'}
-                  {provenanceMode === 'offline' && 'No data available \u2014 engine is offline.'}
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <PositionsTable
-              sortedPositions={sortedPositions}
-              sortField={sortField}
-              sortDir={sortDir}
-              onToggleSort={toggleSort}
+          <div className="flex items-center gap-3">
+            <PieChart className="h-5 w-5 text-primary" aria-hidden="true" />
+            <div>
+              <h1 className="text-heading-page text-foreground">Portfolio</h1>
+              <p className="text-xs text-muted-foreground">
+                {positions.length} position{positions.length !== 1 ? 's' : ''}
+              </p>
+            </div>
+            <DataProvenance
+              mode={provenanceMode}
+              lastUpdated={provenanceLastUpdated}
+              staleThresholdMs={60_000}
             />
-          )}
-        </TabsContent>
+          </div>
+          <button
+            aria-label="Refresh portfolio data"
+            onClick={() => {
+              queryClient.invalidateQueries({ queryKey: queryKeys.portfolio.account() });
+              queryClient.invalidateQueries({ queryKey: queryKeys.portfolio.positions() });
+            }}
+            disabled={engineOnline !== true}
+            className="flex items-center gap-1.5 rounded-md bg-muted/50 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+            Refresh
+          </button>
+        </div>
 
-        <TabsContent value="allocation">
-          <AllocationChart
-            positions={positions}
-            allocations={allocations}
-            totalValue={totalValue}
-            loading={loading}
-          />
-        </TabsContent>
+        <SnapshotMetrics
+          portfolioTotal={portfolioTotal}
+          totalPnl={totalPnl}
+          totalPnlPct={totalPnlPct}
+          totalCost={totalCost}
+          cashBalance={cashBalance}
+          positionCount={positions.length}
+          totalValue={totalValue}
+        />
 
-        <TabsContent value="risk">
-          <RiskSummary
-            positions={positions}
-            portfolioTotal={portfolioTotal}
-            totalValue={totalValue}
-            totalCost={totalCost}
-            totalPnlPct={totalPnlPct}
-            allocations={allocations}
-          />
-          <div className="mt-4">
-            <OrderHistory
+        <QuickOrder
+          symbol={orderSymbol}
+          side={orderSide}
+          qty={orderQty}
+          orderType={orderType}
+          timeInForce={timeInForce}
+          limitPrice={limitPrice}
+          status={orderStatus}
+          submitting={submitOrder.isPending}
+          disabled={engineOnline !== true}
+          tickerSuggestions={TICKER_SYMBOLS}
+          onSymbolChange={setOrderSymbol}
+          onSideChange={setOrderSide}
+          onQtyChange={setOrderQty}
+          onOrderTypeChange={setOrderType}
+          onTimeInForceChange={setTimeInForce}
+          onLimitPriceChange={setLimitPrice}
+          onSubmit={handleSubmitOrder}
+        />
+
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Recent Orders
+              {isPolling && <span className="ml-1.5 text-amber-400 animate-pulse">polling...</span>}
+            </span>
+          </div>
+          <RecentOrders orders={recentOrders} pollingOrderId={pollingOrderId} />
+        </div>
+
+        <Tabs defaultValue="positions" className="space-y-3">
+          <TabsList className="bg-muted/50">
+            <TabsTrigger value="positions">Positions</TabsTrigger>
+            <TabsTrigger value="allocation">Allocation</TabsTrigger>
+            <TabsTrigger value="risk">Risk</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="positions">
+            {positions.length === 0 ? (
+              <Card className="bg-muted/30 border-border/50">
+                <CardContent className="flex flex-col items-center justify-center py-8 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    {provenanceMode === 'live' &&
+                      'No open positions. Use Quick Order above to place your first trade.'}
+                    {provenanceMode === 'cached' &&
+                      'Cached data \u2014 no positions found. Reconnect engine for live updates.'}
+                    {provenanceMode === 'simulated' &&
+                      'Showing simulated portfolio \u2014 connect the engine for live data.'}
+                    {provenanceMode === 'offline' && 'No data available \u2014 engine is offline.'}
+                  </p>
+                </CardContent>
+              </Card>
+            ) : (
+              <PositionsTable
+                sortedPositions={sortedPositions}
+                sortField={sortField}
+                sortDir={sortDir}
+                onToggleSort={toggleSort}
+              />
+            )}
+          </TabsContent>
+
+          <TabsContent value="allocation">
+            <AllocationChart
+              positions={positions}
+              allocations={allocations}
+              totalValue={totalValue}
+              loading={loading}
+            />
+          </TabsContent>
+
+          <TabsContent value="risk">
+            <RiskSummary
               positions={positions}
               portfolioTotal={portfolioTotal}
               totalValue={totalValue}
@@ -402,9 +406,19 @@ export default function PortfolioPage() {
               totalPnlPct={totalPnlPct}
               allocations={allocations}
             />
-          </div>
-        </TabsContent>
-      </Tabs>
-    </div>
+            <div className="mt-4">
+              <OrderHistory
+                positions={positions}
+                portfolioTotal={portfolioTotal}
+                totalValue={totalValue}
+                totalCost={totalCost}
+                totalPnlPct={totalPnlPct}
+                allocations={allocations}
+              />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -2,22 +2,14 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { cn } from '@/lib/utils';
-import {
-  Settings,
-  Shield,
-  Bell,
-  Activity,
-  Lock,
-  Save,
-  Check,
-  Info,
-  Loader2,
-  AlertCircle,
-} from 'lucide-react';
+import { Settings, Shield, Bell, Activity, Lock, Save, Check, Info } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Spinner } from '@/components/ui/spinner';
+import { LoadingButton } from '@/components/ui/loading-button';
+import { ErrorState } from '@/components/ui/error-state';
+import { ErrorBoundary } from '@/components/error-boundary';
 import {
   ConnectionStatusPanel,
   type ServiceStatuses,
@@ -187,32 +179,27 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="space-y-4 px-4 py-3 md:p-4 page-enter">
-      {/* Header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <Settings className="h-5 w-5 text-primary" />
-          <div>
-            <h1 className="text-heading-page text-foreground">Settings</h1>
-            <p className="text-xs text-muted-foreground">
-              Service connections, risk parameters, and preferences
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          {policyError && (
-            <div className="flex items-center gap-1 text-xs text-destructive">
-              <AlertCircle className="h-3.5 w-3.5" />
-              <span>{policyError}</span>
+    <ErrorBoundary>
+      <div className="space-y-4 px-4 py-3 md:p-4 page-enter">
+        {/* Header */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <Settings className="h-5 w-5 text-primary" />
+            <div>
+              <h1 className="text-heading-page text-foreground">Settings</h1>
+              <p className="text-xs text-muted-foreground">
+                Service connections, risk parameters, and preferences
+              </p>
             </div>
-          )}
-          <Button onClick={handleSave} size="sm" disabled={policyLoading || policySaving}>
-            {policySaving ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span className="ml-1.5">Saving…</span>
-              </>
-            ) : saved ? (
+          </div>
+          <LoadingButton
+            onClick={handleSave}
+            size="sm"
+            loading={policySaving}
+            disabled={policyLoading}
+            aria-label="Save settings"
+          >
+            {saved ? (
               <>
                 <Check className="h-4 w-4 text-profit" />
                 <span className="ml-1.5">Saved</span>
@@ -223,222 +210,224 @@ export default function SettingsPage() {
                 <span className="ml-1.5">Save Changes</span>
               </>
             )}
-          </Button>
+          </LoadingButton>
         </div>
-      </div>
 
-      <ConnectionStatusPanel
-        serviceStatus={serviceStatus}
-        checkingConnections={checkingConnections}
-        onCheckConnections={checkConnections}
-      />
+        {policyError && <ErrorState variant="inline" title="Policy Error" message={policyError} />}
 
-      {policyLoading ? (
-        <div className="flex items-center justify-center py-12 text-muted-foreground">
-          <Loader2 className="h-5 w-5 animate-spin mr-2" />
-          <span className="text-sm">Loading settings…</span>
-        </div>
-      ) : (
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-3 px-4 md:px-0">
-          <div className="md:hidden">
-            <div className="-mx-3 overflow-x-auto px-3 pb-1 whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              <div
-                role="tablist"
-                aria-label="Settings categories"
-                className="inline-flex min-w-full gap-2"
-              >
-                {[
-                  { value: 'risk', label: 'Risk', icon: Shield },
-                  { value: 'notifications', label: 'Alerts', icon: Bell },
-                  { value: 'trading', label: 'Trading', icon: Activity },
-                  { value: 'security', label: 'Security', icon: Lock },
-                ].map(({ value, label, icon: Icon }) => {
-                  const isActive = activeTab === value;
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      role="tab"
-                      aria-selected={isActive}
-                      onClick={() => setActiveTab(value)}
-                      className={cn(
-                        'inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-full border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                        isActive
-                          ? 'border-primary bg-primary text-primary-foreground'
-                          : 'border-border/70 bg-card text-muted-foreground hover:bg-muted/60 hover:text-foreground',
-                      )}
-                    >
-                      <Icon className="h-4 w-4" />
-                      <span>{label}</span>
-                    </button>
-                  );
-                })}
+        <ConnectionStatusPanel
+          serviceStatus={serviceStatus}
+          checkingConnections={checkingConnections}
+          onCheckConnections={checkConnections}
+        />
+
+        {policyLoading ? (
+          <div className="flex items-center justify-center py-12 text-muted-foreground">
+            <Spinner size="md" className="mr-2" />
+            <span className="text-sm">Loading settings…</span>
+          </div>
+        ) : (
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-3 px-4 md:px-0">
+            <div className="md:hidden">
+              <div className="-mx-3 overflow-x-auto px-3 pb-1 whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <div
+                  role="tablist"
+                  aria-label="Settings categories"
+                  className="inline-flex min-w-full gap-2"
+                >
+                  {[
+                    { value: 'risk', label: 'Risk', icon: Shield },
+                    { value: 'notifications', label: 'Alerts', icon: Bell },
+                    { value: 'trading', label: 'Trading', icon: Activity },
+                    { value: 'security', label: 'Security', icon: Lock },
+                  ].map(({ value, label, icon: Icon }) => {
+                    const isActive = activeTab === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        onClick={() => setActiveTab(value)}
+                        className={cn(
+                          'inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-full border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                          isActive
+                            ? 'border-primary bg-primary text-primary-foreground'
+                            : 'border-border/70 bg-card text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                        )}
+                      >
+                        <Icon className="h-4 w-4" />
+                        <span>{label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
             </div>
-          </div>
 
-          <TabsList className="hidden w-full bg-muted/50 md:inline-flex md:w-fit">
-            <TabsTrigger value="risk" className="gap-1 text-xs sm:text-sm">
-              <Shield className="h-3.5 w-3.5" />
-              <span className="sm:inline">Risk</span>
-            </TabsTrigger>
-            <TabsTrigger value="notifications" className="gap-1 text-xs sm:text-sm">
-              <Bell className="h-3.5 w-3.5" />
-              <span className="sm:inline">Alerts</span>
-            </TabsTrigger>
-            <TabsTrigger value="trading" className="gap-1 text-xs sm:text-sm">
-              <Activity className="h-3.5 w-3.5" />
-              <span className="sm:inline">Trading</span>
-            </TabsTrigger>
-            <TabsTrigger value="security" className="gap-1 text-xs sm:text-sm">
-              <Lock className="h-3.5 w-3.5" />
-              <span className="sm:inline">Security</span>
-            </TabsTrigger>
-          </TabsList>
+            <TabsList className="hidden w-full bg-muted/50 md:inline-flex md:w-fit">
+              <TabsTrigger value="risk" className="gap-1 text-xs sm:text-sm">
+                <Shield className="h-3.5 w-3.5" />
+                <span className="sm:inline">Risk</span>
+              </TabsTrigger>
+              <TabsTrigger value="notifications" className="gap-1 text-xs sm:text-sm">
+                <Bell className="h-3.5 w-3.5" />
+                <span className="sm:inline">Alerts</span>
+              </TabsTrigger>
+              <TabsTrigger value="trading" className="gap-1 text-xs sm:text-sm">
+                <Activity className="h-3.5 w-3.5" />
+                <span className="sm:inline">Trading</span>
+              </TabsTrigger>
+              <TabsTrigger value="security" className="gap-1 text-xs sm:text-sm">
+                <Lock className="h-3.5 w-3.5" />
+                <span className="sm:inline">Security</span>
+              </TabsTrigger>
+            </TabsList>
 
-          <TabsContent value="risk">
-            <RiskSettings
-              maxPosition={maxPosition}
-              onMaxPosition={setMaxPosition}
-              maxSector={maxSector}
-              onMaxSector={setMaxSector}
-              dailyLossLimit={dailyLossLimit}
-              onDailyLossLimit={setDailyLossLimit}
-              softDrawdown={softDrawdown}
-              onSoftDrawdown={setSoftDrawdown}
-              hardDrawdown={hardDrawdown}
-              onHardDrawdown={setHardDrawdown}
-              maxPositions={maxPositions}
-              onMaxPositions={setMaxPositions}
-            />
-          </TabsContent>
+            <TabsContent value="risk">
+              <RiskSettings
+                maxPosition={maxPosition}
+                onMaxPosition={setMaxPosition}
+                maxSector={maxSector}
+                onMaxSector={setMaxSector}
+                dailyLossLimit={dailyLossLimit}
+                onDailyLossLimit={setDailyLossLimit}
+                softDrawdown={softDrawdown}
+                onSoftDrawdown={setSoftDrawdown}
+                hardDrawdown={hardDrawdown}
+                onHardDrawdown={setHardDrawdown}
+                maxPositions={maxPositions}
+                onMaxPositions={setMaxPositions}
+              />
+            </TabsContent>
 
-          <TabsContent value="notifications">
-            <ScheduleSettings
-              alertCritical={alertCritical}
-              onAlertCritical={setAlertCritical}
-              alertWarning={alertWarning}
-              onAlertWarning={setAlertWarning}
-              alertInfo={alertInfo}
-              onAlertInfo={setAlertInfo}
-              alertSound={alertSound}
-              onAlertSound={setAlertSound}
-              agentNotifications={agentNotifications}
-              onAgentNotifications={setAgentNotifications}
-              tradeNotifications={tradeNotifications}
-              onTradeNotifications={setTradeNotifications}
-            />
-          </TabsContent>
+            <TabsContent value="notifications">
+              <ScheduleSettings
+                alertCritical={alertCritical}
+                onAlertCritical={setAlertCritical}
+                alertWarning={alertWarning}
+                onAlertWarning={setAlertWarning}
+                alertInfo={alertInfo}
+                onAlertInfo={setAlertInfo}
+                alertSound={alertSound}
+                onAlertSound={setAlertSound}
+                agentNotifications={agentNotifications}
+                onAgentNotifications={setAgentNotifications}
+                tradeNotifications={tradeNotifications}
+                onTradeNotifications={setTradeNotifications}
+              />
+            </TabsContent>
 
-          {/* ── Trading ──────────────────────────────────────────────── */}
-          <TabsContent value="trading">
-            {/* System-wide mode banner */}
-            {systemControls && (
-              <div className="mb-4 flex items-start gap-2 rounded-md border border-border/40 bg-muted/30 px-3 py-3">
-                <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
-                <p className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
-                  System-wide mode is{' '}
-                  <span className="font-semibold text-foreground">
-                    {systemControls.global_mode.toUpperCase()}
-                  </span>
-                  {systemControls.trading_halted && (
-                    <span className="text-red-500 font-semibold"> (HALTED)</span>
-                  )}
-                  . This is managed on the{' '}
-                  <a
-                    href="/system-controls"
-                    className="underline text-primary hover:text-primary/80"
-                  >
-                    System Controls
-                  </a>{' '}
-                  page and takes precedence over per-user settings below.
-                </p>
-              </div>
-            )}
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <Card className="w-full max-w-none border-border/60 bg-card ring-foreground/5 sm:ring-foreground/10">
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-xl font-semibold leading-tight text-foreground sm:text-[1.375rem]">
-                    Trading Mode
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-1 divide-y divide-border/25">
-                  <ToggleField
-                    label="Paper Trading Mode"
-                    description="Use simulated orders instead of real broker. Recommended during development."
-                    checked={paperMode}
-                    onChange={setPaperMode}
-                  />
-                  <ToggleField
-                    label="Auto Trading"
-                    description="Allow agents to submit orders automatically. When off, orders require manual approval."
-                    checked={autoTrading}
-                    onChange={setAutoTrading}
-                  />
-                  <ToggleField
-                    label="Require Confirmation"
-                    description="Show confirmation dialog before executing trades."
-                    checked={requireConfirmation}
-                    onChange={setRequireConfirmation}
-                  />
-                </CardContent>
-              </Card>
+            {/* ── Trading ──────────────────────────────────────────────── */}
+            <TabsContent value="trading">
+              {/* System-wide mode banner */}
+              {systemControls && (
+                <div className="mb-4 flex items-start gap-2 rounded-md border border-border/40 bg-muted/30 px-3 py-3">
+                  <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
+                  <p className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
+                    System-wide mode is{' '}
+                    <span className="font-semibold text-foreground">
+                      {systemControls.global_mode.toUpperCase()}
+                    </span>
+                    {systemControls.trading_halted && (
+                      <span className="text-red-500 font-semibold"> (HALTED)</span>
+                    )}
+                    . This is managed on the{' '}
+                    <a
+                      href="/system-controls"
+                      className="underline text-primary hover:text-primary/80"
+                    >
+                      System Controls
+                    </a>{' '}
+                    page and takes precedence over per-user settings below.
+                  </p>
+                </div>
+              )}
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 stagger-grid">
+                <Card className="w-full max-w-none border-border/60 bg-card ring-foreground/5 sm:ring-foreground/10">
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-xl font-semibold leading-tight text-foreground sm:text-[1.375rem]">
+                      Trading Mode
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-1 divide-y divide-border/25">
+                    <ToggleField
+                      label="Paper Trading Mode"
+                      description="Use simulated orders instead of real broker. Recommended during development."
+                      checked={paperMode}
+                      onChange={setPaperMode}
+                    />
+                    <ToggleField
+                      label="Auto Trading"
+                      description="Allow agents to submit orders automatically. When off, orders require manual approval."
+                      checked={autoTrading}
+                      onChange={setAutoTrading}
+                    />
+                    <ToggleField
+                      label="Require Confirmation"
+                      description="Show confirmation dialog before executing trades."
+                      checked={requireConfirmation}
+                      onChange={setRequireConfirmation}
+                    />
+                  </CardContent>
+                </Card>
 
-              <Card className="w-full max-w-none border-border/60 bg-card ring-foreground/5 sm:ring-foreground/10">
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-xl font-semibold leading-tight text-foreground sm:text-[1.375rem]">
-                    Environment
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <div className="overflow-hidden rounded-md border border-border/30">
-                    <div className="bg-muted/30 px-3 py-1.5">
-                      <p className="text-[10px] font-medium tracking-wider text-muted-foreground uppercase">
-                        System Information
+                <Card className="w-full max-w-none border-border/60 bg-card ring-foreground/5 sm:ring-foreground/10">
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-xl font-semibold leading-tight text-foreground sm:text-[1.375rem]">
+                      Environment
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="overflow-hidden rounded-md border border-border/30">
+                      <div className="bg-muted/30 px-3 py-1.5">
+                        <p className="text-[10px] font-medium tracking-wider text-muted-foreground uppercase">
+                          System Information
+                        </p>
+                      </div>
+                      <div className="divide-y divide-border/25">
+                        {[
+                          ['Platform', 'Sentinel Trading v0.1.0'],
+                          ['Engine', 'FastAPI (Python 3.12)'],
+                          ['Dashboard', 'Next.js 16 + React 19'],
+                          ['Agents', 'Claude SDK (TypeScript)'],
+                          ['Database', 'Supabase (PostgreSQL 15)'],
+                          ['Broker', 'Alpaca Markets API'],
+                          ['Market Data', 'Polygon.io REST + WebSocket'],
+                        ].map(([label, value]) => (
+                          <div
+                            key={label}
+                            className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                          >
+                            <span className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
+                              {label}
+                            </span>
+                            <span className="text-sm font-mono leading-relaxed text-foreground sm:text-right sm:text-[0.9375rem]">
+                              {value}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-2 rounded-md bg-muted/30 px-3 py-2">
+                      <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
+                      <p className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
+                        API keys are configured via environment variables in{' '}
+                        <code className="font-mono text-foreground">.env</code>. Risk limits and
+                        trading mode are saved to the database and synced across devices.
                       </p>
                     </div>
-                    <div className="divide-y divide-border/25">
-                      {[
-                        ['Platform', 'Sentinel Trading v0.1.0'],
-                        ['Engine', 'FastAPI (Python 3.12)'],
-                        ['Dashboard', 'Next.js 16 + React 19'],
-                        ['Agents', 'Claude SDK (TypeScript)'],
-                        ['Database', 'Supabase (PostgreSQL 15)'],
-                        ['Broker', 'Alpaca Markets API'],
-                        ['Market Data', 'Polygon.io REST + WebSocket'],
-                      ].map(([label, value]) => (
-                        <div
-                          key={label}
-                          className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
-                        >
-                          <span className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
-                            {label}
-                          </span>
-                          <span className="text-sm font-mono leading-relaxed text-foreground sm:text-right sm:text-[0.9375rem]">
-                            {value}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2 rounded-md bg-muted/30 px-3 py-2">
-                    <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
-                    <p className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
-                      API keys are configured via environment variables in{' '}
-                      <code className="font-mono text-foreground">.env</code>. Risk limits and
-                      trading mode are saved to the database and synced across devices.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
+                  </CardContent>
+                </Card>
+              </div>
+            </TabsContent>
 
-          <TabsContent value="security">
-            <SecuritySettings />
-          </TabsContent>
-        </Tabs>
-      )}
-    </div>
+            <TabsContent value="security">
+              <SecuritySettings />
+            </TabsContent>
+          </Tabs>
+        )}
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/components/portfolio/positions-table.tsx
+++ b/apps/web/src/components/portfolio/positions-table.tsx
@@ -1,9 +1,19 @@
 'use client';
 
 import { memo } from 'react';
-import { ArrowUpDown, ChevronUp, ChevronDown, PieChart } from 'lucide-react';
+import { PieChart } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  SortableTableHead,
+  type SortState,
+} from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 
 export interface Position {
@@ -72,138 +82,111 @@ export const PositionsTable = memo(function PositionsTable({
     );
   }
 
+  const sortState: SortState = { column: sortField, direction: sortDir };
+
   return (
     <Card className="bg-card border-border overflow-hidden">
       <CardContent className="p-0">
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-border">
-                {(
-                  [
-                    ['ticker', 'Ticker'],
-                    ['marketValue', 'Market Value'],
-                    ['pnl', 'P&L'],
-                    ['pnlPct', 'P&L %'],
-                  ] as [SortField, string][]
-                ).map(([field, label]) => (
-                  <th key={field} className="px-4 py-2.5 text-left">
-                    <button
-                      onClick={() => onToggleSort(field)}
+        <Table aria-label="Open positions">
+          <TableHeader>
+            <TableRow>
+              {(
+                [
+                  ['ticker', 'Ticker'],
+                  ['marketValue', 'Market Value'],
+                  ['pnl', 'P&L'],
+                  ['pnlPct', 'P&L %'],
+                ] as [SortField, string][]
+              ).map(([field, label]) => (
+                <SortableTableHead
+                  key={field}
+                  column={field}
+                  sortState={sortState}
+                  onSort={(col) => onToggleSort(col as SortField)}
+                  className="text-[11px] uppercase tracking-wider"
+                >
+                  {label}
+                </SortableTableHead>
+              ))}
+              <TableHead className="text-[11px] uppercase tracking-wider">Shares</TableHead>
+              <TableHead className="text-[11px] uppercase tracking-wider">Avg Entry</TableHead>
+              <TableHead className="text-[11px] uppercase tracking-wider">Current</TableHead>
+              <TableHead className="text-[11px] uppercase tracking-wider">Sector</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedPositions.map((p) => {
+              const pl = pnl(p);
+              const plPct = pnlPct(p);
+              return (
+                <TableRow key={p.ticker}>
+                  <TableCell className="px-4 py-3">
+                    <div>
+                      <span className="text-sm font-semibold text-foreground">{p.ticker}</span>
+                      <p className="text-[11px] text-muted-foreground">{p.name}</p>
+                    </div>
+                  </TableCell>
+                  <TableCell numeric className="px-4 py-3">
+                    <span className="text-sm font-mono text-foreground">
+                      $
+                      {marketValue(p).toLocaleString('en-US', {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </span>
+                  </TableCell>
+                  <TableCell numeric className="px-4 py-3">
+                    <span
+                      className={cn('text-sm font-mono', pl >= 0 ? 'text-profit' : 'text-loss')}
+                    >
+                      {pl >= 0 ? '+' : ''}$
+                      {pl.toLocaleString('en-US', {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </span>
+                  </TableCell>
+                  <TableCell numeric className="px-4 py-3">
+                    <Badge
                       className={cn(
-                        'flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider transition-colors hover:text-foreground',
-                        sortField === field ? 'text-primary' : 'text-muted-foreground',
+                        'border text-[10px] font-semibold font-mono',
+                        plPct >= 0
+                          ? 'bg-profit/15 text-profit border-profit/30'
+                          : 'bg-loss/15 text-loss border-loss/30',
                       )}
                     >
-                      {label}
-                      {sortField === field ? (
-                        sortDir === 'asc' ? (
-                          <ChevronUp className="h-3 w-3" />
-                        ) : (
-                          <ChevronDown className="h-3 w-3" />
-                        )
-                      ) : (
-                        <ArrowUpDown className="h-3 w-3 opacity-40" />
+                      {plPct >= 0 ? '+' : ''}
+                      {plPct.toFixed(2)}%
+                    </Badge>
+                  </TableCell>
+                  <TableCell numeric className="px-4 py-3">
+                    <span className="text-sm font-mono text-muted-foreground">{p.shares}</span>
+                  </TableCell>
+                  <TableCell numeric className="px-4 py-3">
+                    <span className="text-sm font-mono text-muted-foreground">
+                      ${p.avgEntry.toFixed(2)}
+                    </span>
+                  </TableCell>
+                  <TableCell numeric className="px-4 py-3">
+                    <span className="text-sm font-mono text-foreground">
+                      ${p.currentPrice.toFixed(2)}
+                    </span>
+                  </TableCell>
+                  <TableCell className="px-4 py-3">
+                    <Badge
+                      className={cn(
+                        'border text-[10px]',
+                        sectorBadges[p.sector] ?? 'bg-muted text-muted-foreground border-border',
                       )}
-                    </button>
-                  </th>
-                ))}
-                <th className="px-4 py-2.5 text-left">
-                  <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Shares
-                  </span>
-                </th>
-                <th className="px-4 py-2.5 text-left">
-                  <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Avg Entry
-                  </span>
-                </th>
-                <th className="px-4 py-2.5 text-left">
-                  <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Current
-                  </span>
-                </th>
-                <th className="px-4 py-2.5 text-left">
-                  <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Sector
-                  </span>
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/50">
-              {sortedPositions.map((p) => {
-                const pl = pnl(p);
-                const plPct = pnlPct(p);
-                return (
-                  <tr key={p.ticker} className="transition-colors hover:bg-accent/30">
-                    <td className="px-4 py-3">
-                      <div>
-                        <span className="text-sm font-semibold text-foreground">{p.ticker}</span>
-                        <p className="text-[11px] text-muted-foreground">{p.name}</p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="text-sm font-mono text-foreground">
-                        $
-                        {marketValue(p).toLocaleString('en-US', {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span
-                        className={cn('text-sm font-mono', pl >= 0 ? 'text-profit' : 'text-loss')}
-                      >
-                        {pl >= 0 ? '+' : ''}$
-                        {pl.toLocaleString('en-US', {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge
-                        className={cn(
-                          'border text-[10px] font-semibold font-mono',
-                          plPct >= 0
-                            ? 'bg-profit/15 text-profit border-profit/30'
-                            : 'bg-loss/15 text-loss border-loss/30',
-                        )}
-                      >
-                        {plPct >= 0 ? '+' : ''}
-                        {plPct.toFixed(2)}%
-                      </Badge>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="text-sm font-mono text-muted-foreground">{p.shares}</span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="text-sm font-mono text-muted-foreground">
-                        ${p.avgEntry.toFixed(2)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="text-sm font-mono text-foreground">
-                        ${p.currentPrice.toFixed(2)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge
-                        className={cn(
-                          'border text-[10px]',
-                          sectorBadges[p.sector] ?? 'bg-muted text-muted-foreground border-border',
-                        )}
-                      >
-                        {p.sector}
-                      </Badge>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                    >
+                      {p.sector}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/portfolio/quick-order.tsx
+++ b/apps/web/src/components/portfolio/quick-order.tsx
@@ -2,6 +2,10 @@
 
 import { SendHorizonal } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { LoadingButton } from '@/components/ui/loading-button';
 import { cn } from '@/lib/utils';
 
 export type OrderType = 'market' | 'limit';
@@ -24,6 +28,7 @@ interface QuickOrderProps {
   status: string | null;
   submitting: boolean;
   disabled?: boolean;
+  tickerSuggestions?: readonly string[];
   onSymbolChange: (v: string) => void;
   onSideChange: (v: 'buy' | 'sell') => void;
   onQtyChange: (v: string) => void;
@@ -58,6 +63,7 @@ export function QuickOrder({
   status,
   submitting,
   disabled = false,
+  tickerSuggestions = [],
   onSymbolChange,
   onSideChange,
   onQtyChange,
@@ -84,10 +90,15 @@ export function QuickOrder({
           </span>
           <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
             {/* Side toggle */}
-            <div className="flex items-center gap-1.5 rounded-md bg-muted/50 p-0.5">
+            <div
+              className="flex items-center gap-1.5 rounded-md bg-muted/50 p-0.5"
+              role="group"
+              aria-label="Order side"
+            >
               <button
                 onClick={() => onSideChange('buy')}
                 aria-label="Buy"
+                aria-pressed={side === 'buy'}
                 className={cn(
                   'rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
                   side === 'buy'
@@ -100,6 +111,7 @@ export function QuickOrder({
               <button
                 onClick={() => onSideChange('sell')}
                 aria-label="Sell"
+                aria-pressed={side === 'sell'}
                 className={cn(
                   'rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
                   side === 'sell'
@@ -112,10 +124,15 @@ export function QuickOrder({
             </div>
 
             {/* Order type toggle */}
-            <div className="flex items-center gap-1.5 rounded-md bg-muted/50 p-0.5">
+            <div
+              className="flex items-center gap-1.5 rounded-md bg-muted/50 p-0.5"
+              role="group"
+              aria-label="Order type"
+            >
               <button
                 onClick={() => onOrderTypeChange('market')}
                 aria-label="Market order"
+                aria-pressed={orderType === 'market'}
                 className={cn(
                   'rounded px-2.5 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
                   orderType === 'market'
@@ -128,6 +145,7 @@ export function QuickOrder({
               <button
                 onClick={() => onOrderTypeChange('limit')}
                 aria-label="Limit order"
+                aria-pressed={orderType === 'limit'}
                 className={cn(
                   'rounded px-2.5 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
                   orderType === 'limit'
@@ -141,21 +159,27 @@ export function QuickOrder({
 
             {/* Symbol */}
             <div className="flex flex-col">
-              <label htmlFor="quick-order-symbol" className="sr-only">
+              <Label htmlFor="quick-order-symbol" className="sr-only">
                 Symbol
-              </label>
-              <input
+              </Label>
+              <Input
                 id="quick-order-symbol"
                 type="text"
+                list="ticker-suggestions"
                 value={symbol}
                 onChange={(e) => onSymbolChange(e.target.value.toUpperCase())}
                 placeholder="Symbol"
+                aria-label="Ticker symbol"
                 aria-invalid={symbol !== '' && !validSymbol ? true : undefined}
-                className={cn(
-                  'w-20 sm:w-24 rounded-md border bg-background px-2.5 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary',
-                  symbol !== '' && !validSymbol ? 'border-loss' : 'border-border',
-                )}
+                className={cn('h-auto w-20 sm:w-24 px-2.5 py-1.5 text-xs font-mono')}
               />
+              {tickerSuggestions.length > 0 && (
+                <datalist id="ticker-suggestions">
+                  {tickerSuggestions.map((t) => (
+                    <option key={t} value={t} />
+                  ))}
+                </datalist>
+              )}
               {symbol !== '' && !validSymbol && (
                 <span className="text-[10px] text-loss mt-0.5">1-5 letters</span>
               )}
@@ -163,21 +187,19 @@ export function QuickOrder({
 
             {/* Quantity */}
             <div className="flex flex-col">
-              <label htmlFor="quick-order-qty" className="sr-only">
+              <Label htmlFor="quick-order-qty" className="sr-only">
                 Quantity
-              </label>
-              <input
+              </Label>
+              <Input
                 id="quick-order-qty"
                 type="number"
                 value={qty}
                 onChange={(e) => onQtyChange(e.target.value)}
                 placeholder="Qty"
                 min="1"
+                aria-label="Order quantity"
                 aria-invalid={qty !== '' && !validQty ? true : undefined}
-                className={cn(
-                  'w-16 sm:w-20 rounded-md border bg-background px-2.5 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary',
-                  qty !== '' && !validQty ? 'border-loss' : 'border-border',
-                )}
+                className={cn('h-auto w-16 sm:w-20 px-2.5 py-1.5 text-xs font-mono')}
               />
               {qty !== '' && !validQty && (
                 <span className="text-[10px] text-loss mt-0.5">Positive int</span>
@@ -187,10 +209,10 @@ export function QuickOrder({
             {/* Limit price (visible only for limit orders) */}
             {orderType === 'limit' && (
               <div className="flex flex-col">
-                <label htmlFor="quick-order-limit-price" className="sr-only">
+                <Label htmlFor="quick-order-limit-price" className="sr-only">
                   Limit Price
-                </label>
-                <input
+                </Label>
+                <Input
                   id="quick-order-limit-price"
                   type="number"
                   value={limitPrice}
@@ -198,11 +220,9 @@ export function QuickOrder({
                   placeholder="Price"
                   min="0.01"
                   step="0.01"
+                  aria-label="Limit price"
                   aria-invalid={limitPrice !== '' && !validLimitPrice ? true : undefined}
-                  className={cn(
-                    'w-20 sm:w-24 rounded-md border bg-background px-2.5 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary',
-                    limitPrice !== '' && !validLimitPrice ? 'border-loss' : 'border-border',
-                  )}
+                  className={cn('h-auto w-20 sm:w-24 px-2.5 py-1.5 text-xs font-mono')}
                 />
                 {limitPrice !== '' && !validLimitPrice && (
                   <span className="text-[10px] text-loss mt-0.5">Positive number</span>
@@ -212,31 +232,36 @@ export function QuickOrder({
 
             {/* Time in force */}
             <div className="flex flex-col">
-              <label htmlFor="quick-order-tif" className="sr-only">
+              <Label htmlFor="quick-order-tif" className="sr-only">
                 Time in Force
-              </label>
-              <select
+              </Label>
+              <Select
                 id="quick-order-tif"
                 value={timeInForce}
                 onChange={(e) => onTimeInForceChange(e.target.value as TimeInForce)}
-                className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                aria-label="Time in Force"
+                className="h-auto px-2 py-1.5 text-xs"
               >
                 {(Object.keys(TIF_LABELS) as TimeInForce[]).map((tif) => (
                   <option key={tif} value={tif}>
                     {TIF_LABELS[tif]}
                   </option>
                 ))}
-              </select>
+              </Select>
             </div>
 
-            <button
+            <LoadingButton
               onClick={onSubmit}
               disabled={!canSubmit}
-              className="flex items-center gap-1.5 rounded-md bg-primary/15 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/25 transition-colors disabled:opacity-40"
+              loading={submitting}
+              size="sm"
+              variant="ghost"
+              aria-label="Submit"
+              className="gap-1.5 bg-primary/15 text-xs font-medium text-primary hover:bg-primary/25"
             >
-              <SendHorizonal className="h-3.5 w-3.5" />
-              {submitting ? 'Sending...' : 'Submit'}
-            </button>
+              <SendHorizonal className="h-3.5 w-3.5" aria-hidden="true" />
+              Submit
+            </LoadingButton>
           </div>
           <span aria-live="polite" className={cn('text-xs font-mono', statusColorClass(status))}>
             {status ?? ''}

--- a/apps/web/src/components/portfolio/recent-orders.tsx
+++ b/apps/web/src/components/portfolio/recent-orders.tsx
@@ -1,18 +1,17 @@
 'use client';
 
 import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
 import { cn } from '@/lib/utils';
+import { orderStatusColors, DEFAULT_ORDER_STYLE, sideColors } from '@/lib/status-colors';
 import type { OrderHistoryEntry } from '@/hooks/use-order-history';
-
-const STATUS_STYLES: Record<string, string> = {
-  filled: 'bg-profit/15 text-profit',
-  accepted: 'bg-amber-500/15 text-amber-400',
-  partially_filled: 'bg-amber-500/15 text-amber-400',
-  rejected: 'bg-loss/15 text-loss',
-  cancelled: 'bg-loss/15 text-loss',
-  expired: 'bg-loss/15 text-loss',
-  pending_new: 'bg-amber-500/15 text-amber-400',
-};
 
 const STATUS_LABELS: Record<string, string> = {
   filled: 'Filled',
@@ -52,67 +51,70 @@ export function RecentOrders({ orders, pollingOrderId }: RecentOrdersProps) {
   return (
     <Card className="bg-card border-border">
       <CardContent className="p-0">
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-border text-muted-foreground">
-                <th className="px-3 py-2 text-left font-medium">Symbol</th>
-                <th className="px-3 py-2 text-left font-medium">Side</th>
-                <th className="px-3 py-2 text-right font-medium">Qty</th>
-                <th className="px-3 py-2 text-left font-medium">Status</th>
-                <th className="px-3 py-2 text-right font-medium">Fill Price</th>
-                <th className="px-3 py-2 text-right font-medium">Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {orders.map((order) => {
-                const isPolling = order.order_id === pollingOrderId;
-                return (
-                  <tr
-                    key={order.order_id}
-                    className="border-b border-border/50 last:border-0 hover:bg-muted/30"
-                  >
-                    <td className="px-3 py-2 font-mono font-medium text-foreground">
-                      {order.symbol}
-                    </td>
-                    <td className="px-3 py-2">
+        <Table aria-label="Recent orders" className="text-xs">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="px-3 py-2 text-left font-medium">Symbol</TableHead>
+              <TableHead className="px-3 py-2 text-left font-medium">Side</TableHead>
+              <TableHead className="px-3 py-2 text-right font-medium">Qty</TableHead>
+              <TableHead className="px-3 py-2 text-left font-medium">Status</TableHead>
+              <TableHead className="px-3 py-2 text-right font-medium">Fill Price</TableHead>
+              <TableHead className="px-3 py-2 text-right font-medium">Time</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {orders.map((order) => {
+              const isPolling = order.order_id === pollingOrderId;
+              const statusStyle = orderStatusColors[order.status] ?? DEFAULT_ORDER_STYLE;
+              const sideStyle = sideColors[order.side] ?? '';
+              return (
+                <TableRow key={order.order_id} className="hover:bg-muted/30">
+                  <TableCell className="px-3 py-2 font-mono font-medium text-foreground">
+                    {order.symbol}
+                  </TableCell>
+                  <TableCell className="px-3 py-2">
+                    <span
+                      className={cn(
+                        'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase',
+                        sideStyle,
+                      )}
+                    >
+                      {order.side}
+                    </span>
+                  </TableCell>
+                  <TableCell numeric className="px-3 py-2 text-right font-mono text-foreground">
+                    {order.qty}
+                  </TableCell>
+                  <TableCell className="px-3 py-2">
+                    <span className="flex items-center gap-1.5">
+                      {isPolling && (
+                        <span
+                          className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse"
+                          aria-label="Polling order status"
+                        />
+                      )}
                       <span
                         className={cn(
-                          'font-medium uppercase',
-                          order.side === 'buy' ? 'text-profit' : 'text-loss',
+                          'rounded px-1.5 py-0.5 text-[10px] font-medium',
+                          statusStyle.bg,
+                          statusStyle.text,
                         )}
                       >
-                        {order.side}
+                        {STATUS_LABELS[order.status] ?? order.status}
                       </span>
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono text-foreground">{order.qty}</td>
-                    <td className="px-3 py-2">
-                      <span className="flex items-center gap-1.5">
-                        {isPolling && (
-                          <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
-                        )}
-                        <span
-                          className={cn(
-                            'rounded px-1.5 py-0.5 text-[10px] font-medium',
-                            STATUS_STYLES[order.status] ?? 'bg-muted text-muted-foreground',
-                          )}
-                        >
-                          {STATUS_LABELS[order.status] ?? order.status}
-                        </span>
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono text-foreground">
-                      {order.fill_price != null ? `$${order.fill_price.toFixed(2)}` : '—'}
-                    </td>
-                    <td className="px-3 py-2 text-right text-muted-foreground">
-                      {formatTime(order.submitted_at)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                    </span>
+                  </TableCell>
+                  <TableCell numeric className="px-3 py-2 text-right font-mono text-foreground">
+                    {order.fill_price != null ? `$${order.fill_price.toFixed(2)}` : '—'}
+                  </TableCell>
+                  <TableCell className="px-3 py-2 text-right text-muted-foreground">
+                    {formatTime(order.submitted_at)}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/portfolio/snapshot-metrics.tsx
+++ b/apps/web/src/components/portfolio/snapshot-metrics.tsx
@@ -25,7 +25,7 @@ export function SnapshotMetrics({
   totalValue,
 }: SnapshotMetricsProps) {
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 stagger-grid">
       <Card className="bg-card border-border">
         <CardContent className="py-3 px-4">
           <div className="flex items-center justify-between">

--- a/apps/web/src/components/settings/broker-settings.tsx
+++ b/apps/web/src/components/settings/broker-settings.tsx
@@ -2,6 +2,8 @@
 
 import { Globe, Shield, Bot, Database } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useState } from 'react';
 
 function SettingsField({
@@ -22,28 +24,36 @@ function SettingsField({
   masked?: boolean;
 }) {
   const [showValue, setShowValue] = useState(!masked);
+  const fieldId = label.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <label className="text-sm font-medium text-foreground">{label}</label>
+        <Label htmlFor={fieldId}>{label}</Label>
         {masked && (
           <button
             onClick={() => setShowValue((v) => !v)}
             className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
-            aria-label={showValue ? 'Hide value' : 'Show value'}
+            aria-label={showValue ? `Hide ${label}` : `Show ${label}`}
           >
             {showValue ? 'Hide' : 'Show'}
           </button>
         )}
       </div>
-      {description && <p className="text-xs text-muted-foreground">{description}</p>}
-      <input
+      {description && (
+        <p id={`${fieldId}-desc`} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      <Input
+        id={fieldId}
         type={masked && !showValue ? 'password' : type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        aria-label={label}
+        aria-describedby={description ? `${fieldId}-desc` : undefined}
+        className="font-mono"
       />
     </div>
   );
@@ -79,7 +89,7 @@ export function BrokerSettings({
   onSupabaseKey,
 }: BrokerSettingsProps) {
   return (
-    <div className="grid gap-4 lg:grid-cols-2">
+    <div className="grid gap-4 lg:grid-cols-2 stagger-grid">
       <Card className="bg-card border-border">
         <CardHeader className="pb-3">
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/settings/connection-status.tsx
+++ b/apps/web/src/components/settings/connection-status.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Server, Globe, Database, Bot, Brain, Shield, RefreshCw, Loader2 } from 'lucide-react';
+import { Server, Globe, Database, Bot, Brain, Shield, RefreshCw } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
 
 export type ServiceStatus = 'connected' | 'disconnected' | 'not_configured' | 'checking';
@@ -88,7 +89,7 @@ function ConnectionStatusRow({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           {status === 'checking' ? (
-            <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
+            <Spinner size="sm" className="text-muted-foreground" />
           ) : (
             <Icon className={cn('h-4 w-4', c.color)} />
           )}
@@ -127,7 +128,7 @@ function ConnectionStatusCell({
   return (
     <div className="flex items-center gap-2 rounded-md border border-border/25 bg-muted/15 px-3 py-3">
       {status === 'checking' ? (
-        <Loader2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground animate-spin" />
+        <Spinner size="sm" className="shrink-0 text-muted-foreground" />
       ) : (
         <Icon className={cn('h-3.5 w-3.5 shrink-0', c.color)} />
       )}
@@ -170,6 +171,7 @@ export function ConnectionStatusPanel({
           <button
             onClick={onCheckConnections}
             disabled={checkingConnections}
+            aria-label="Test service connections"
             className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
           >
             <RefreshCw className={cn('h-3 w-3', checkingConnections && 'animate-spin')} />

--- a/apps/web/src/components/settings/risk-settings.tsx
+++ b/apps/web/src/components/settings/risk-settings.tsx
@@ -2,6 +2,8 @@
 
 import { AlertTriangle } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 function SettingsField({
   label,
@@ -16,21 +18,26 @@ function SettingsField({
   onChange: (v: string) => void;
   type?: string;
 }) {
+  const fieldId = label.toLowerCase().replace(/[^a-z0-9]+/g, '-');
   return (
     <div className="space-y-2">
-      <label className="text-base font-medium leading-tight text-foreground sm:text-[1.125rem]">
-        {label}
-      </label>
+      <Label htmlFor={fieldId}>{label}</Label>
       {description && (
-        <p className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]">
+        <p
+          id={`${fieldId}-desc`}
+          className="text-sm leading-relaxed text-muted-foreground sm:text-[0.9375rem]"
+        >
           {description}
         </p>
       )}
-      <input
+      <Input
+        id={fieldId}
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="h-10 w-full rounded-md border border-input/70 bg-background px-3 text-sm font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:h-9"
+        aria-label={label}
+        aria-describedby={description ? `${fieldId}-desc` : undefined}
+        className="font-mono"
       />
     </div>
   );
@@ -66,7 +73,7 @@ export function RiskSettings({
   onMaxPositions,
 }: RiskSettingsProps) {
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 stagger-grid">
       <Card className="w-full max-w-none border-border/60 bg-card ring-foreground/5 sm:ring-foreground/10">
         <CardHeader className="pb-3">
           <CardTitle className="text-xl font-semibold leading-tight text-foreground sm:text-[1.375rem]">

--- a/apps/web/src/components/settings/security-settings.tsx
+++ b/apps/web/src/components/settings/security-settings.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Shield, Smartphone, Key, Loader2, Check, X, AlertCircle } from 'lucide-react';
+import { Shield, Smartphone, Key, Check, X, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { LoadingButton } from '@/components/ui/loading-button';
 import { createClient } from '@/lib/supabase/client';
 
 interface MfaFactor {
@@ -154,14 +158,14 @@ export function SecuritySettings() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin mr-2" />
+        <Spinner size="md" className="mr-2" />
         <span className="text-sm">Loading security settings…</span>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 stagger-grid">
       {/* MFA Card */}
       <Card className="w-full max-w-none border-border/60 bg-card ring-foreground/5 sm:ring-foreground/10">
         <CardHeader className="pb-3">
@@ -191,19 +195,16 @@ export function SecuritySettings() {
                         Added {new Date(f.created_at).toLocaleDateString()}
                       </p>
                     </div>
-                    <Button
+                    <LoadingButton
                       variant="ghost"
                       size="sm"
                       onClick={() => unenrollFactor(f.id)}
-                      disabled={unenrolling === f.id}
+                      loading={unenrolling === f.id}
+                      aria-label={`Remove ${f.friendly_name ?? 'authenticator'}`}
                       className="text-destructive hover:text-destructive"
                     >
-                      {unenrolling === f.id ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <X className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
+                      <X className="h-3.5 w-3.5" />
+                    </LoadingButton>
                   </div>
                 ))}
               </div>
@@ -214,17 +215,22 @@ export function SecuritySettings() {
                 Add an extra layer of security by requiring a code from your authenticator app when
                 signing in.
               </p>
-              <Button size="sm" onClick={startEnroll}>
+              <LoadingButton
+                size="sm"
+                onClick={startEnroll}
+                loading={enrollState === 'loading'}
+                aria-label="Enable multi-factor authentication"
+              >
                 <Key className="h-3.5 w-3.5 mr-1.5" />
                 Enable MFA
-              </Button>
+              </LoadingButton>
             </>
           ) : null}
 
           {/* Enrollment flow */}
           {enrollState === 'loading' && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Spinner size="sm" />
               Setting up…
             </div>
           )}
@@ -246,14 +252,9 @@ export function SecuritySettings() {
                 <code className="text-xs font-mono break-all select-all">{totpSecret}</code>
               </div>
               <div className="space-y-2">
-                <label
-                  htmlFor="totp-verify"
-                  className="text-base font-medium leading-tight sm:text-[1.125rem]"
-                >
-                  Enter the 6-digit code from your app:
-                </label>
+                <Label htmlFor="totp-verify">Enter the 6-digit code from your app:</Label>
                 <div className="flex flex-col gap-2 sm:flex-row">
-                  <input
+                  <Input
                     id="totp-verify"
                     type="text"
                     inputMode="numeric"
@@ -261,17 +262,20 @@ export function SecuritySettings() {
                     value={verifyCode}
                     onChange={(e) => setVerifyCode(e.target.value.replace(/\D/g, ''))}
                     placeholder="000000"
-                    className="flex h-10 w-full rounded-md border border-border/70 bg-background px-3 py-2 text-center text-sm font-mono tracking-widest ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:w-32"
+                    aria-label="TOTP verification code"
+                    className="text-center font-mono tracking-widest sm:w-32"
                   />
                   <div className="flex gap-2">
-                    <Button
+                    <LoadingButton
                       size="sm"
                       onClick={verifyEnrollment}
-                      disabled={verifyCode.length !== 6 || verifying}
+                      disabled={verifyCode.length !== 6}
+                      loading={verifying}
+                      aria-label="Verify TOTP code"
                       className="flex-1 sm:flex-initial"
                     >
-                      {verifying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Verify'}
-                    </Button>
+                      Verify
+                    </LoadingButton>
                     <Button
                       variant="ghost"
                       size="sm"

--- a/apps/web/tests/pages/dashboard.test.tsx
+++ b/apps/web/tests/pages/dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import DashboardPage from '@/app/(dashboard)/page';
 import { renderWithProviders } from '../test-utils';
 
@@ -18,6 +18,17 @@ describe('DashboardPage', () => {
     expect(container).toBeTruthy();
   });
 
+  it('renders the page-enter animation class', () => {
+    const { container } = renderWithProviders(<DashboardPage />);
+    const root = container.querySelector('.page-enter');
+    expect(root).toBeInTheDocument();
+  });
+
+  it('renders the Dashboard heading', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeInTheDocument();
+  });
+
   it('renders the Total Equity metric card label', () => {
     renderWithProviders(<DashboardPage />);
     expect(screen.getByText('Total Equity')).toBeInTheDocument();
@@ -26,5 +37,85 @@ describe('DashboardPage', () => {
   it('renders the Daily P&L metric card label', () => {
     renderWithProviders(<DashboardPage />);
     expect(screen.getByText('Daily P&L')).toBeInTheDocument();
+  });
+
+  it('renders the Cash Available metric card label', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText('Cash Available')).toBeInTheDocument();
+  });
+
+  it('renders the Positions Value metric card label', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText('Positions Value')).toBeInTheDocument();
+  });
+
+  it('renders Active Signals card', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText('Active Signals')).toBeInTheDocument();
+  });
+
+  it('renders the No Recent Signals empty state', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText('No Recent Signals')).toBeInTheDocument();
+  });
+
+  // --- Semantic HTML ---
+
+  it('wraps system health in a section with aria-label', () => {
+    renderWithProviders(<DashboardPage />);
+    const section = screen.getByLabelText('System health status');
+    expect(section.tagName).toBe('SECTION');
+  });
+
+  it('wraps portfolio metrics in a section with aria-label', () => {
+    renderWithProviders(<DashboardPage />);
+    const section = screen.getByLabelText('Portfolio metrics');
+    expect(section.tagName).toBe('SECTION');
+  });
+
+  it('wraps market prices in a section with aria-label', () => {
+    renderWithProviders(<DashboardPage />);
+    const section = screen.getByLabelText('Market prices');
+    expect(section.tagName).toBe('SECTION');
+  });
+
+  it('wraps signals and alerts in a section with aria-label', () => {
+    renderWithProviders(<DashboardPage />);
+    const section = screen.getByLabelText('Signals and alerts');
+    expect(section.tagName).toBe('SECTION');
+  });
+
+  // --- System Health Strip ---
+
+  it('displays default system health values when offline', () => {
+    renderWithProviders(<DashboardPage />);
+    const healthSection = screen.getByLabelText('System health status');
+    expect(within(healthSection).getByText('Active')).toBeInTheDocument();
+    expect(within(healthSection).getByText('paper')).toBeInTheDocument();
+    expect(within(healthSection).getByText('0')).toBeInTheDocument();
+    expect(within(healthSection).getByText('Idle')).toBeInTheDocument();
+  });
+
+  // --- ErrorBoundary ---
+
+  it('is wrapped in ErrorBoundary (renders children on success)', () => {
+    renderWithProviders(<DashboardPage />);
+    // ErrorBoundary is transparent when no error - children render normally
+    expect(screen.getByLabelText('Trading dashboard')).toBeInTheDocument();
+  });
+
+  // --- Accessibility ---
+
+  it('marks decorative icons as aria-hidden', () => {
+    renderWithProviders(<DashboardPage />);
+    const healthSection = screen.getByLabelText('System health status');
+    const hiddenIcons = healthSection.querySelectorAll('[aria-hidden="true"]');
+    // Icons + separator pipes
+    expect(hiddenIcons.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('has a root container with aria-label', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByLabelText('Trading dashboard')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/pages/markets.test.tsx
+++ b/apps/web/tests/pages/markets.test.tsx
@@ -334,4 +334,97 @@ describe('MarketsPage', () => {
       expect(screen.getByText(/Chart: 3 bars/)).toBeInTheDocument();
     });
   });
+
+  // ─── Table structure ──────────────────────────────────────────────────
+
+  it('renders watchlist as a table with header columns', () => {
+    renderWithProviders(<MarketsPage />);
+    expect(screen.getByRole('table', { name: 'Watchlist stocks' })).toBeInTheDocument();
+    expect(screen.getByText('Symbol')).toBeInTheDocument();
+    expect(screen.getByText('Price')).toBeInTheDocument();
+    expect(screen.getByText('Change')).toBeInTheDocument();
+  });
+
+  // ─── Aria / accessibility ─────────────────────────────────────────────
+
+  it('adds aria-label to watchlist rows', () => {
+    renderWithProviders(<MarketsPage />);
+    const row = screen.getByLabelText('View chart for MSFT');
+    expect(row).toBeInTheDocument();
+    expect(row.tagName).toBe('TR');
+  });
+
+  it('marks the selected row with aria-current', () => {
+    renderWithProviders(<MarketsPage />);
+    // AAPL is selected by default
+    const aaplRow = screen.getByLabelText('View chart for AAPL');
+    expect(aaplRow).toHaveAttribute('aria-current', 'true');
+    // Other rows should not have aria-current
+    const msftRow = screen.getByLabelText('View chart for MSFT');
+    expect(msftRow).not.toHaveAttribute('aria-current');
+  });
+
+  it('labels the watchlist and chart panels as regions', () => {
+    renderWithProviders(<MarketsPage />);
+    expect(screen.getByRole('region', { name: 'Watchlist panel' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Price chart panel' })).toBeInTheDocument();
+  });
+
+  // ─── Keyboard navigation ──────────────────────────────────────────────
+
+  it('switches ticker on Enter key in watchlist row', async () => {
+    renderWithProviders(<MarketsPage />);
+    const nvdaRow = screen.getByLabelText('View chart for NVDA');
+    fireEvent.keyDown(nvdaRow, { key: 'Enter' });
+    const nvdaElements = screen.getAllByText('NVDA');
+    expect(nvdaElements.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('switches ticker on Space key in watchlist row', async () => {
+    renderWithProviders(<MarketsPage />);
+    const googRow = screen.getByLabelText('View chart for GOOGL');
+    fireEvent.keyDown(googRow, { key: ' ' });
+    const googElements = screen.getAllByText('GOOGL');
+    expect(googElements.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ─── Spinner / loading ────────────────────────────────────────────────
+
+  it('shows spinner in watchlist header when loading', () => {
+    useAppStore.setState({ engineOnline: null });
+    renderWithProviders(<MarketsPage />);
+    // Spinner renders with role="status" and aria-label="Loading"
+    const statusEls = screen.getAllByRole('status');
+    const spinnerEl = statusEls.find((el) => el.getAttribute('aria-label') === 'Loading');
+    expect(spinnerEl).toBeTruthy();
+  });
+
+  // ─── ErrorState ───────────────────────────────────────────────────────
+
+  it('shows error state when engine online but quotes fetch fails', async () => {
+    useAppStore.setState({ engineOnline: true });
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+    renderWithProviders(<MarketsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load market data')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  // ─── stagger-grid class ───────────────────────────────────────────────
+
+  it('applies stagger-grid class to the card container', () => {
+    const { container } = renderWithProviders(<MarketsPage />);
+    const staggerEl = container.querySelector('.stagger-grid');
+    expect(staggerEl).toBeInTheDocument();
+  });
+
+  // ─── ErrorBoundary wrapping ───────────────────────────────────────────
+
+  it('renders successfully with ErrorBoundary wrapper', () => {
+    const { container } = renderWithProviders(<MarketsPage />);
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Watchlist')).toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/pages/orders.test.tsx
+++ b/apps/web/tests/pages/orders.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import OrdersPage from '@/app/(dashboard)/orders/page';
 import { renderWithProviders } from '../test-utils';
 
@@ -17,27 +17,96 @@ vi.mock('@/hooks/queries', async (importOriginal) => {
       isLoading: false,
       isError: false,
       error: null,
+      refetch: vi.fn(),
     }),
     useRiskEvaluationsQuery: vi.fn().mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
       error: null,
+      refetch: vi.fn(),
     }),
     useOrderHistoryQuery: vi.fn().mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
       error: null,
+      refetch: vi.fn(),
     }),
   };
 });
+
+async function mockAllEmpty() {
+  const queries = await import('@/hooks/queries');
+  vi.mocked(queries.useFillsQuery).mockReturnValue({
+    data: { data: [], total: 0 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as ReturnType<typeof queries.useFillsQuery>);
+  vi.mocked(queries.useRiskEvaluationsQuery).mockReturnValue({
+    data: { data: [], total: 0 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as ReturnType<typeof queries.useRiskEvaluationsQuery>);
+  vi.mocked(queries.useOrderHistoryQuery).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as ReturnType<typeof queries.useOrderHistoryQuery>);
+}
+
+async function mockWithOrders(orders: Parameters<typeof vi.fn>[0] = undefined) {
+  const queries = await import('@/hooks/queries');
+  vi.mocked(queries.useFillsQuery).mockReturnValue({
+    data: { data: [], total: 0 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as ReturnType<typeof queries.useFillsQuery>);
+  vi.mocked(queries.useRiskEvaluationsQuery).mockReturnValue({
+    data: { data: [], total: 0 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as ReturnType<typeof queries.useRiskEvaluationsQuery>);
+  vi.mocked(queries.useOrderHistoryQuery).mockReturnValue({
+    data: orders ?? [
+      {
+        order_id: 'ord-001',
+        symbol: 'AAPL',
+        side: 'buy',
+        order_type: 'market',
+        qty: 10,
+        filled_qty: 10,
+        status: 'filled',
+        fill_price: 180.0,
+        submitted_at: '2026-03-19T12:00:00Z',
+        filled_at: '2026-03-19T12:00:01Z',
+        risk_note: null,
+      },
+    ],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as ReturnType<typeof queries.useOrderHistoryQuery>);
+}
 
 beforeEach(() => {
   vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
 });
 
 describe('OrdersPage', () => {
+  // ─── Basic rendering ──────────────────────────────────────────────────
+
   it('renders without crashing', () => {
     const { container } = renderWithProviders(<OrdersPage />);
     expect(container).toBeTruthy();
@@ -48,62 +117,391 @@ describe('OrdersPage', () => {
     expect(screen.getByText('Orders & Fills')).toBeInTheDocument();
   });
 
+  it('has page-enter class on root container', () => {
+    const { container } = renderWithProviders(<OrdersPage />);
+    const root = container.querySelector('.page-enter');
+    expect(root).toBeTruthy();
+  });
+
+  // ─── ErrorBoundary ────────────────────────────────────────────────────
+
+  it('wraps content in ErrorBoundary', () => {
+    const { container } = renderWithProviders(<OrdersPage />);
+    // ErrorBoundary renders children directly, verify page renders
+    expect(container.querySelector('.page-enter')).toBeTruthy();
+  });
+
+  // ─── Stats Row ────────────────────────────────────────────────────────
+
   it('renders stats row labels when no data', () => {
     renderWithProviders(<OrdersPage />);
     expect(screen.getByText('Total Events')).toBeInTheDocument();
     expect(screen.getByText('Fill Rate')).toBeInTheDocument();
+    expect(screen.getByText('Total Commission')).toBeInTheDocument();
+    expect(screen.getByText('Avg Slippage')).toBeInTheDocument();
   });
 
-  it('renders order entries when order data is present', async () => {
+  it('renders stagger-grid on stats cards', () => {
+    renderWithProviders(<OrdersPage />);
+    const statsGrid = screen.getByText('Total Events').closest('.stagger-grid');
+    expect(statsGrid).toBeTruthy();
+  });
+
+  it('shows Spinner in stats when loading', async () => {
     const { useOrderHistoryQuery } = await import('@/hooks/queries');
     vi.mocked(useOrderHistoryQuery).mockReturnValue({
-      data: [
-        {
-          order_id: 'ord-001',
-          symbol: 'AAPL',
-          side: 'buy',
-          order_type: 'market',
-          qty: 10,
-          filled_qty: 10,
-          status: 'filled',
-          fill_price: 180.0,
-          submitted_at: new Date().toISOString(),
-          filled_at: new Date().toISOString(),
-          risk_note: null,
-        },
-      ],
-      isLoading: false,
+      data: undefined,
+      isLoading: true,
       isError: false,
       error: null,
-    } as ReturnType<typeof useOrderHistoryQuery>);
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useOrderHistoryQuery>);
 
     renderWithProviders(<OrdersPage />);
+    const spinners = screen.getAllByRole('status');
+    expect(spinners.length).toBeGreaterThan(0);
+  });
+
+  // ─── Filter controls ─────────────────────────────────────────────────
+
+  it('renders Select component for type filter with aria-label', () => {
+    renderWithProviders(<OrdersPage />);
+    const select = screen.getByLabelText('Filter by event type');
+    expect(select).toBeInTheDocument();
+    expect(select.tagName).toBe('SELECT');
+  });
+
+  it('renders Input component for search with aria-label', () => {
+    renderWithProviders(<OrdersPage />);
+    const input = screen.getByLabelText('Search orders by ID, symbol, or reason');
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('renders date range buttons with aria-labels', () => {
+    renderWithProviders(<OrdersPage />);
+    expect(screen.getByLabelText('Filter by Today')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by Week')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by Month')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by All')).toBeInTheDocument();
+  });
+
+  it('shows clear button when filters are active', () => {
+    renderWithProviders(<OrdersPage />);
+    // Change date range to activate a filter
+    fireEvent.click(screen.getByLabelText('Filter by Today'));
+    expect(screen.getByLabelText('Clear all filters')).toBeInTheDocument();
+  });
+
+  it('type filter changes filtered results', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    const select = screen.getByLabelText('Filter by event type');
+    fireEvent.change(select, { target: { value: 'fills' } });
+    // Orders should be hidden, only fills (none) remain
+    expect(screen.getByText('No execution activity yet')).toBeInTheDocument();
+  });
+
+  it('search input filters entries', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    const input = screen.getByLabelText('Search orders by ID, symbol, or reason');
+    fireEvent.change(input, { target: { value: 'NONEXISTENT' } });
+    expect(screen.getByText('No execution activity yet')).toBeInTheDocument();
+  });
+
+  // ─── Table rendering ─────────────────────────────────────────────────
+
+  it('renders Table component with sortable headers when data is present', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    const table = screen.getByRole('table', { name: 'Orders and execution timeline' });
+    expect(table).toBeInTheDocument();
+  });
+
+  it('renders order entries in table when order data is present', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    expect(screen.getByText('AAPL')).toBeInTheDocument();
     expect(screen.getByText(/BUY AAPL/)).toBeInTheDocument();
   });
 
-  it('shows empty timeline when all data is empty arrays', async () => {
+  it('displays side badge with sideColors for buy orders', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    const buyBadge = screen.getByText('BUY');
+    expect(buyBadge).toBeInTheDocument();
+  });
+
+  it('displays side badge with sideColors for sell orders', async () => {
+    await mockWithOrders([
+      {
+        order_id: 'ord-002',
+        symbol: 'MSFT',
+        side: 'sell',
+        order_type: 'limit',
+        qty: 5,
+        filled_qty: 5,
+        status: 'filled',
+        fill_price: 375.0,
+        submitted_at: '2026-03-19T13:00:00Z',
+        filled_at: '2026-03-19T13:00:01Z',
+        risk_note: null,
+      },
+    ]);
+    renderWithProviders(<OrdersPage />);
+    const sellBadge = screen.getByText('SELL');
+    expect(sellBadge).toBeInTheDocument();
+  });
+
+  it('displays order status badge using orderStatusColors', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    expect(screen.getByText('Filled')).toBeInTheDocument();
+  });
+
+  it('renders sortable column headers', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    // SortableTableHead uses aria-sort attribute
+    const typeHeader = screen.getByText('Type').closest('th');
+    expect(typeHeader).toHaveAttribute('aria-sort');
+    const timeHeader = screen.getByText('Time').closest('th');
+    expect(timeHeader).toHaveAttribute('aria-sort');
+  });
+
+  it('expand button has correct aria attributes', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    const expandBtn = screen.getByLabelText('Expand details');
+    expect(expandBtn).toBeInTheDocument();
+    expect(expandBtn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('clicking expand button shows detail panel', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    const expandBtn = screen.getByLabelText('Expand details');
+    fireEvent.click(expandBtn);
+    // Should now show order detail section with "Order Lifecycle"
+    expect(screen.getByText('Order Lifecycle')).toBeInTheDocument();
+  });
+
+  // ─── Empty state ──────────────────────────────────────────────────────
+
+  it('shows empty state when all data is empty arrays', async () => {
+    await mockAllEmpty();
+    renderWithProviders(<OrdersPage />);
+    expect(screen.getByText('No execution activity yet')).toBeInTheDocument();
+  });
+
+  // ─── Error state ──────────────────────────────────────────────────────
+
+  it('shows ErrorState component when queries fail', async () => {
     const { useFillsQuery, useRiskEvaluationsQuery, useOrderHistoryQuery } =
       await import('@/hooks/queries');
     vi.mocked(useFillsQuery).mockReturnValue({
-      data: { data: [], total: 0 },
+      data: undefined,
       isLoading: false,
-      isError: false,
-      error: null,
-    } as ReturnType<typeof useFillsQuery>);
+      isError: true,
+      error: new Error('fetch failed'),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useFillsQuery>);
     vi.mocked(useRiskEvaluationsQuery).mockReturnValue({
-      data: { data: [], total: 0 },
+      data: undefined,
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useRiskEvaluationsQuery>);
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useRiskEvaluationsQuery>);
     vi.mocked(useOrderHistoryQuery).mockReturnValue({
-      data: [],
+      data: undefined,
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useOrderHistoryQuery>);
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useOrderHistoryQuery>);
 
     renderWithProviders(<OrdersPage />);
-    expect(screen.getByText('Orders & Fills')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load data')).toBeInTheDocument();
+    expect(screen.getByText('Try Again')).toBeInTheDocument();
+  });
+
+  it('ErrorState retry button triggers refetch', async () => {
+    const refetchFills = vi.fn();
+    const refetchRisk = vi.fn();
+    const refetchOrders = vi.fn();
+
+    const { useFillsQuery, useRiskEvaluationsQuery, useOrderHistoryQuery } =
+      await import('@/hooks/queries');
+    vi.mocked(useFillsQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('fail'),
+      refetch: refetchFills,
+    } as unknown as ReturnType<typeof useFillsQuery>);
+    vi.mocked(useRiskEvaluationsQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: refetchRisk,
+    } as unknown as ReturnType<typeof useRiskEvaluationsQuery>);
+    vi.mocked(useOrderHistoryQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: refetchOrders,
+    } as unknown as ReturnType<typeof useOrderHistoryQuery>);
+
+    renderWithProviders(<OrdersPage />);
+    fireEvent.click(screen.getByText('Try Again'));
+    expect(refetchFills).toHaveBeenCalled();
+    expect(refetchRisk).toHaveBeenCalled();
+    expect(refetchOrders).toHaveBeenCalled();
+  });
+
+  // ─── Loading state ────────────────────────────────────────────────────
+
+  it('shows Spinner when loading', async () => {
+    const { useFillsQuery, useRiskEvaluationsQuery, useOrderHistoryQuery } =
+      await import('@/hooks/queries');
+    vi.mocked(useFillsQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useFillsQuery>);
+    vi.mocked(useRiskEvaluationsQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useRiskEvaluationsQuery>);
+    vi.mocked(useOrderHistoryQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useOrderHistoryQuery>);
+
+    renderWithProviders(<OrdersPage />);
+    const spinners = screen.getAllByRole('status');
+    expect(spinners.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ─── Pagination ───────────────────────────────────────────────────────
+
+  it('renders pagination nav with aria-label when many entries', async () => {
+    // Create 35 orders to exceed PAGE_SIZE_ORDERS (30)
+    const orders = Array.from({ length: 35 }, (_, i) => ({
+      order_id: `ord-${String(i).padStart(3, '0')}`,
+      symbol: 'AAPL',
+      side: 'buy' as const,
+      order_type: 'market',
+      qty: 10,
+      filled_qty: 10,
+      status: 'filled',
+      fill_price: 180.0,
+      submitted_at: new Date(Date.now() - i * 60000).toISOString(),
+      filled_at: new Date(Date.now() - i * 60000 + 1000).toISOString(),
+      risk_note: null,
+    }));
+    await mockWithOrders(orders);
+    renderWithProviders(<OrdersPage />);
+
+    const nav = screen.getByRole('navigation', { name: 'Pagination' });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByLabelText('Go to previous page')).toBeInTheDocument();
+    expect(screen.getByLabelText('Go to next page')).toBeInTheDocument();
+  });
+
+  it('previous button is disabled on first page', async () => {
+    const orders = Array.from({ length: 35 }, (_, i) => ({
+      order_id: `ord-${String(i).padStart(3, '0')}`,
+      symbol: 'AAPL',
+      side: 'buy' as const,
+      order_type: 'market',
+      qty: 10,
+      filled_qty: 10,
+      status: 'filled',
+      fill_price: 180.0,
+      submitted_at: new Date(Date.now() - i * 60000).toISOString(),
+      filled_at: new Date(Date.now() - i * 60000 + 1000).toISOString(),
+      risk_note: null,
+    }));
+    await mockWithOrders(orders);
+    renderWithProviders(<OrdersPage />);
+
+    expect(screen.getByLabelText('Go to previous page')).toBeDisabled();
+    expect(screen.getByLabelText('Go to next page')).not.toBeDisabled();
+  });
+
+  it('clicking next page navigates forward', async () => {
+    const orders = Array.from({ length: 35 }, (_, i) => ({
+      order_id: `ord-${String(i).padStart(3, '0')}`,
+      symbol: 'AAPL',
+      side: 'buy' as const,
+      order_type: 'market',
+      qty: 10,
+      filled_qty: 10,
+      status: 'filled',
+      fill_price: 180.0,
+      submitted_at: new Date(Date.now() - i * 60000).toISOString(),
+      filled_at: new Date(Date.now() - i * 60000 + 1000).toISOString(),
+      risk_note: null,
+    }));
+    await mockWithOrders(orders);
+    renderWithProviders(<OrdersPage />);
+
+    fireEvent.click(screen.getByLabelText('Go to next page'));
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+  });
+
+  // ─── Event count ──────────────────────────────────────────────────────
+
+  it('shows event count', async () => {
+    await mockWithOrders();
+    renderWithProviders(<OrdersPage />);
+    expect(screen.getByText(/1 event/)).toBeInTheDocument();
+  });
+
+  it('shows plural events count', async () => {
+    await mockWithOrders([
+      {
+        order_id: 'ord-001',
+        symbol: 'AAPL',
+        side: 'buy',
+        order_type: 'market',
+        qty: 10,
+        filled_qty: 10,
+        status: 'filled',
+        fill_price: 180.0,
+        submitted_at: '2026-03-19T12:00:00Z',
+        filled_at: '2026-03-19T12:00:01Z',
+        risk_note: null,
+      },
+      {
+        order_id: 'ord-002',
+        symbol: 'MSFT',
+        side: 'sell',
+        order_type: 'limit',
+        qty: 5,
+        filled_qty: 5,
+        status: 'filled',
+        fill_price: 375.0,
+        submitted_at: '2026-03-19T13:00:00Z',
+        filled_at: '2026-03-19T13:00:01Z',
+        risk_note: null,
+      },
+    ]);
+    renderWithProviders(<OrdersPage />);
+    expect(screen.getByText(/2 events/)).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/pages/portfolio.test.tsx
+++ b/apps/web/tests/pages/portfolio.test.tsx
@@ -547,4 +547,116 @@ describe('PortfolioPage', () => {
       expect(screen.getByText(/No open positions/)).toBeInTheDocument();
     });
   });
+
+  // ─── Design System Polish Tests ────────────────────────────────────
+
+  it('uses Table compound component with aria-label for positions', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('table', { name: 'Open positions' })).toBeInTheDocument();
+    });
+  });
+
+  it('uses Table compound component with aria-label for recent orders', async () => {
+    const filledOrder = {
+      order_id: 'ord-tbl',
+      symbol: 'AAPL',
+      side: 'buy',
+      order_type: 'market',
+      qty: 1,
+      filled_qty: 1,
+      status: 'filled',
+      fill_price: 250.0,
+      submitted_at: '2026-03-15T10:00:00Z',
+      filled_at: '2026-03-15T10:00:01Z',
+      risk_note: null,
+    };
+
+    global.fetch = vi.fn((url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('/portfolio/account'))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockAccount) } as Response);
+      if (urlStr.includes('/portfolio/positions'))
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockPositions),
+        } as Response);
+      if (urlStr.includes('/data/quotes'))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockQuotes) } as Response);
+      if (urlStr.includes('/portfolio/orders/history'))
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([filledOrder]),
+        } as Response);
+      return Promise.resolve({ ok: false } as Response);
+    }) as typeof fetch;
+
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('table', { name: 'Recent orders' })).toBeInTheDocument();
+    });
+  });
+
+  it('has aria-label on Refresh button', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh portfolio data' })).toBeInTheDocument();
+    });
+  });
+
+  it('has aria-pressed attributes on Buy/Sell toggle buttons', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      const buyBtn = screen.getByRole('button', { name: 'Buy' });
+      expect(buyBtn).toHaveAttribute('aria-pressed', 'true');
+      const sellBtn = screen.getByRole('button', { name: 'Sell' });
+      expect(sellBtn).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  it('renders stagger-grid class on snapshot metrics grid', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Portfolio Value')).toBeInTheDocument();
+    });
+    const portfolioValueCard = screen.getByText('Portfolio Value').closest('.stagger-grid');
+    expect(portfolioValueCard).toBeTruthy();
+  });
+
+  it('renders page-enter class on root container', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Portfolio')).toBeInTheDocument();
+    });
+    const heading = screen.getByText('Portfolio');
+    const rootContainer = heading.closest('.page-enter');
+    expect(rootContainer).toBeTruthy();
+  });
+
+  it('uses LoadingButton for order submission', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      const submitBtn = screen.getByRole('button', { name: 'Submit' });
+      expect(submitBtn).toBeInTheDocument();
+      expect(submitBtn).toHaveAttribute('data-slot', 'button');
+    });
+  });
+
+  it('uses Input components with data-slot in Quick Order form', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      const symbolInput = screen.getByPlaceholderText('Symbol');
+      expect(symbolInput).toHaveAttribute('data-slot', 'input');
+      const qtyInput = screen.getByPlaceholderText('Qty');
+      expect(qtyInput).toHaveAttribute('data-slot', 'input');
+    });
+  });
+
+  it('uses Select component with data-slot for Time in Force', async () => {
+    renderWithProviders(<PortfolioPage />);
+    await waitFor(() => {
+      const tifSelect = screen.getByLabelText('Time in Force');
+      expect(tifSelect.closest('[data-slot="select"]')).toBeTruthy();
+    });
+  });
 });

--- a/apps/web/tests/pages/settings.test.tsx
+++ b/apps/web/tests/pages/settings.test.tsx
@@ -9,6 +9,10 @@ vi.mock('next/navigation', () => ({
 }));
 
 // Mock the trading policy hook so tests don't depend on Supabase
+const mockUpdatePolicy = vi.fn().mockResolvedValue(true);
+let mockPolicyLoading = false;
+let mockPolicyError: string | null = null;
+
 vi.mock('@/hooks/use-trading-policy', () => ({
   useTradingPolicy: () => ({
     policy: {
@@ -26,10 +30,10 @@ vi.mock('@/hooks/use-trading-policy', () => ({
       created_at: '2025-01-01T00:00:00Z',
       updated_at: '2025-01-01T00:00:00Z',
     },
-    loading: false,
+    loading: mockPolicyLoading,
     saving: false,
-    error: null,
-    updatePolicy: vi.fn().mockResolvedValue(true),
+    error: mockPolicyError,
+    updatePolicy: mockUpdatePolicy,
   }),
   policyValue: (policy: Record<string, unknown> | null, key: string) => {
     if (policy && key in policy) return policy[key];
@@ -123,6 +127,9 @@ Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
 
 beforeEach(() => {
   localStorageMock.clear();
+  mockPolicyLoading = false;
+  mockPolicyError = null;
+  mockUpdatePolicy.mockResolvedValue(true);
   vi.stubGlobal(
     'fetch',
     vi.fn().mockResolvedValue({
@@ -149,9 +156,10 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(screen.getByText('Settings')).toBeInTheDocument());
   });
 
-  it('shows Save Changes button', async () => {
+  it('shows Save Changes button with aria-label', async () => {
     renderWithProviders(<SettingsPage />);
     await waitFor(() => expect(screen.getByText('Save Changes')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /save settings/i })).toBeInTheDocument();
   });
 
   it('displays connection status section', async () => {
@@ -166,7 +174,7 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('shows tab navigation', async () => {
+  it('shows tab navigation with aria roles', async () => {
     renderWithProviders(<SettingsPage />);
     await waitFor(() => {
       expect(screen.getAllByRole('tab', { name: /Risk/i })[0]).toBeInTheDocument();
@@ -182,6 +190,7 @@ describe('SettingsPage', () => {
       fireEvent.click(screen.getByText('Save Changes'));
     });
     expect(localStorageMock.getItem('sentinel:notification-prefs')).not.toBeNull();
+    expect(mockUpdatePolicy).toHaveBeenCalled();
   });
 
   it('Save Changes shows "Saved" feedback momentarily', async () => {
@@ -193,7 +202,7 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument());
   });
 
-  it('can switch to Risk tab', async () => {
+  it('can switch to Risk tab and shows form fields with labels', async () => {
     renderWithProviders(<SettingsPage />);
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Risk/i })[0]).toBeInTheDocument(),
@@ -205,7 +214,7 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('can switch to Alerts tab', async () => {
+  it('can switch to Alerts tab and shows toggle switches', async () => {
     renderWithProviders(<SettingsPage />);
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Alerts/i })[0]).toBeInTheDocument(),
@@ -214,10 +223,13 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Critical Alerts')).toBeInTheDocument();
       expect(screen.getByText('Warning Alerts')).toBeInTheDocument();
+      // Toggle switches should have proper aria roles
+      const switches = screen.getAllByRole('switch');
+      expect(switches.length).toBeGreaterThan(0);
     });
   });
 
-  it('can switch to Trading tab', async () => {
+  it('can switch to Trading tab and shows toggle fields', async () => {
     renderWithProviders(<SettingsPage />);
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Trading/i })[0]).toBeInTheDocument(),
@@ -226,6 +238,9 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Paper Trading Mode')).toBeInTheDocument();
       expect(screen.getByText('Auto Trading')).toBeInTheDocument();
+      // Toggle switches should have aria-checked
+      const switches = screen.getAllByRole('switch');
+      expect(switches.length).toBeGreaterThan(0);
     });
   });
 
@@ -236,5 +251,40 @@ describe('SettingsPage', () => {
     );
     fireEvent.click(screen.getAllByRole('tab', { name: /Trading/i })[0]);
     await waitFor(() => expect(screen.getByText('Sentinel Trading v0.1.0')).toBeInTheDocument());
+  });
+
+  it('renders page-enter class on root container', async () => {
+    const { container } = renderWithProviders(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText('Settings')).toBeInTheDocument());
+    const root = container.querySelector('.page-enter');
+    expect(root).toBeInTheDocument();
+  });
+
+  it('shows loading spinner when policy is loading', async () => {
+    mockPolicyLoading = true;
+    renderWithProviders(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Loading settings…')).toBeInTheDocument();
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  it('connection status refresh has aria-label', async () => {
+    renderWithProviders(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText('Service Status')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /test service connections/i })).toBeInTheDocument();
+  });
+
+  it('risk settings inputs use design system Input component', async () => {
+    renderWithProviders(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getAllByRole('tab', { name: /Risk/i })[0]).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getAllByRole('tab', { name: /Risk/i })[0]);
+    await waitFor(() => {
+      // Design system Input components have data-slot="input"
+      const inputs = document.querySelectorAll('[data-slot="input"]');
+      expect(inputs.length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
## Phase 3 — Core Dashboard Pages Polish

### Summary
Professional polish for the 5 core dashboard pages using the Phase 1 design system components.

### Changes (18 files, +2186/-1139)

**Dashboard Home** (page.tsx + 17 tests)
- ErrorBoundary wrapper, semantic sections, FALLBACK_ACCOUNT constants
- Status-colors for trading/agent/signal badges, aria-labels throughout

**Portfolio** (page.tsx + positions-table + quick-order + recent-orders + snapshot-metrics + 27 tests)
- Table compound component for positions and recent orders with SortableTableHead
- Input/Select/Label for quick-order form, LoadingButton for submission
- orderStatusColors/sideColors, stagger-grid on metrics, TICKER_SYMBOLS datalist

**Markets** (page.tsx + 22 tests)
- Table compound component for watchlist with aria-current on selected row
- ErrorState for fetch failures, Spinner for loading, keyboard nav (Enter/Space)
- getStatusColors for price changes, stagger-grid on cards

**Orders** (page.tsx + 30 tests, up from 5)
- SortableTableHead for sortable columns, Select/Input for filters
- orderStatusColors/sideColors for status/side badges
- ErrorState with retry, Spinner loading, aria-labels on pagination

**Settings** (page.tsx + risk/security/broker/connection components + 14 tests)
- Input/Label/LoadingButton across all form sections
- Spinner replaces Loader2, ErrorState for errors, stagger-grid on card grids

### Testing
- **1159 tests passing** (104 files) — up from 1097 after Phase 2
- **62 new/expanded tests** across 5 page test files
- Lint: all 3 packages clean
