### PR TITLE
feat: cursor-based keyset pagination for agent alerts

### DIFF
--- a/apps/agents/src/recommendations-store.ts
+++ b/apps/agents/src/recommendations-store.ts
@@ -166,13 +166,40 @@ export async function createAlert(alert: AlertCreate): Promise<AgentAlert> {
   return data as AgentAlert;
 }
 
-export async function listAlerts(limit = 50): Promise<AgentAlert[]> {
+export interface AlertsCursor {
+  lastCreatedAt: string;
+  lastId: string;
+}
+
+export interface AlertsPage {
+  alerts: AgentAlert[];
+  nextCursor: AlertsCursor | null;
+}
+
+export async function listAlerts(limit = 50, cursor?: AlertsCursor): Promise<AlertsPage> {
   const db = getSupabaseClient();
-  const { data, error } = await db
+  // Fetch one extra row to determine if there's a next page
+  let query = db
     .from('agent_alerts')
     .select('*')
     .order('created_at', { ascending: false })
-    .limit(limit);
+    .order('id', { ascending: false });
+
+  if (cursor) {
+    // Keyset pagination: rows older than the cursor position
+    query = query.or(
+      `created_at.lt.${cursor.lastCreatedAt},and(created_at.eq.${cursor.lastCreatedAt},id.lt.${cursor.lastId})`,
+    );
+  }
+
+  const { data, error } = await query.limit(limit + 1);
   if (error) throw new Error(error.message);
-  return (data ?? []) as AgentAlert[];
+  const rows = (data ?? []) as AgentAlert[];
+  const hasMore = rows.length > limit;
+  const alerts = hasMore ? rows.slice(0, limit) : rows;
+  const last = alerts[alerts.length - 1];
+  return {
+    alerts,
+    nextCursor: hasMore && last ? { lastCreatedAt: last.created_at, lastId: last.id } : null,
+  };
 }

--- a/apps/agents/src/server.ts
+++ b/apps/agents/src/server.ts
@@ -372,10 +372,24 @@ export function createApp(orchestrator: Orchestrator): Express {
 
   // ── Alerts ──────────────────────────────────────────────────────
 
-  app.get('/alerts', async (_req: Request, res: Response, next: NextFunction) => {
+  app.get('/alerts', async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const alerts = await listAlerts(50);
-      res.json({ alerts });
+      const rawLimit = parseInt(req.query.limit as string, 10);
+      const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 100) : 50;
+      const lastCreatedAt = req.query.lastCreatedAt as string | undefined;
+      const lastId = req.query.lastId as string | undefined;
+
+      // Both cursor fields are required together
+      if ((lastCreatedAt && !lastId) || (!lastCreatedAt && lastId)) {
+        res
+          .status(400)
+          .json({ error: 'Both lastCreatedAt and lastId are required for cursor pagination.' });
+        return;
+      }
+
+      const cursor = lastCreatedAt && lastId ? { lastCreatedAt, lastId } : undefined;
+      const page = await listAlerts(limit, cursor);
+      res.json(page);
     } catch (err) {
       next(err);
     }

--- a/apps/agents/tests/recommendations-store.test.ts
+++ b/apps/agents/tests/recommendations-store.test.ts
@@ -257,7 +257,20 @@ describe('markRiskBlocked', () => {
 describe('listAlerts', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('queries agent_alerts and returns an array', async () => {
+  // Helper to build the Supabase mock chain for listAlerts
+  // Chain: from → select → order(created_at) → order(id) → [or →] limit
+  function mockAlertQuery(data: unknown[] | null, error: { message: string } | null = null) {
+    const limitMock = vi.fn().mockResolvedValue({ data, error });
+    const orMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const order2Mock = vi.fn().mockReturnValue({ or: orMock, limit: limitMock });
+    const order1Mock = vi.fn().mockReturnValue({ order: order2Mock });
+    const selectMock = vi.fn().mockReturnValue({ order: order1Mock });
+    mockFrom.mockReturnValue({ select: selectMock });
+    return { selectMock, order1Mock, order2Mock, limitMock, orMock };
+  }
+
+  it('returns alerts page with nextCursor when more rows exist', async () => {
+    // 3 rows returned = 2 + 1 extra → hasMore=true, nextCursor set
     const rows = [
       {
         id: 'alt-1',
@@ -265,7 +278,7 @@ describe('listAlerts', () => {
         title: 'Alert 1',
         message: 'msg1',
         acknowledged: false,
-        created_at: '',
+        created_at: '2026-01-02T00:00:00Z',
       },
       {
         id: 'alt-2',
@@ -273,58 +286,78 @@ describe('listAlerts', () => {
         title: 'Alert 2',
         message: 'msg2',
         acknowledged: false,
-        created_at: '',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'alt-3',
+        severity: 'info',
+        title: 'Alert 3',
+        message: 'msg3',
+        acknowledged: false,
+        created_at: '2026-01-01T00:00:00Z',
       },
     ];
-    const limitMock = vi.fn().mockResolvedValue({ data: rows, error: null });
-    const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
-    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
-    mockFrom.mockReturnValue({ select: selectMock });
+    mockAlertQuery(rows);
 
-    const result = await listAlerts();
+    const result = await listAlerts(2);
     expect(mockFrom).toHaveBeenCalledWith('agent_alerts');
-    expect(result).toHaveLength(2);
-    expect(result[0].severity).toBe('warning');
+    expect(result.alerts).toHaveLength(2);
+    expect(result.alerts[0].severity).toBe('warning');
+    expect(result.nextCursor).toEqual({
+      lastCreatedAt: '2026-01-01T00:00:00Z',
+      lastId: 'alt-2',
+    });
   });
 
-  it('returns empty array when no alerts exist', async () => {
-    const limitMock = vi.fn().mockResolvedValue({ data: null, error: null });
-    const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
-    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
-    mockFrom.mockReturnValue({ select: selectMock });
+  it('returns null nextCursor on last page', async () => {
+    // Only 1 row (limit=2 → fetch 3, got 1 → no more)
+    const rows = [
+      {
+        id: 'alt-1',
+        severity: 'info',
+        title: 'Alert 1',
+        message: 'msg1',
+        acknowledged: false,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+    mockAlertQuery(rows);
 
+    const result = await listAlerts(2);
+    expect(result.alerts).toHaveLength(1);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('returns empty page when no alerts exist', async () => {
+    mockAlertQuery(null);
     const result = await listAlerts();
-    expect(result).toEqual([]);
+    expect(result.alerts).toEqual([]);
+    expect(result.nextCursor).toBeNull();
   });
 
-  it('uses custom limit parameter', async () => {
-    const rows = [{ id: 'alt-1', severity: 'info', title: 'Test', message: 'msg', acknowledged: false, created_at: '' }];
-    const limitMock = vi.fn().mockResolvedValue({ data: rows, error: null });
-    const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
-    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
-    mockFrom.mockReturnValue({ select: selectMock });
-
-    await listAlerts(100);
-    expect(limitMock).toHaveBeenCalledWith(100);
+  it('fetches limit+1 rows for has-more detection', async () => {
+    const { limitMock } = mockAlertQuery([]);
+    await listAlerts(25);
+    expect(limitMock).toHaveBeenCalledWith(26); // 25 + 1
   });
 
-  it('uses default limit of 50', async () => {
-    const rows = [];
-    const limitMock = vi.fn().mockResolvedValue({ data: rows, error: null });
-    const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
-    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
-    mockFrom.mockReturnValue({ select: selectMock });
-
+  it('defaults to limit 50 (fetches 51)', async () => {
+    const { limitMock } = mockAlertQuery([]);
     await listAlerts();
-    expect(limitMock).toHaveBeenCalledWith(50);
+    expect(limitMock).toHaveBeenCalledWith(51); // 50 + 1
+  });
+
+  it('applies cursor filter via .or() when cursor provided', async () => {
+    const { orMock } = mockAlertQuery([]);
+    const cursor = { lastCreatedAt: '2026-01-01T00:00:00Z', lastId: 'alt-1' };
+    await listAlerts(50, cursor);
+    expect(orMock).toHaveBeenCalledWith(
+      'created_at.lt.2026-01-01T00:00:00Z,and(created_at.eq.2026-01-01T00:00:00Z,id.lt.alt-1)',
+    );
   });
 
   it('throws on Supabase error', async () => {
-    const limitMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'query failed' } });
-    const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
-    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
-    mockFrom.mockReturnValue({ select: selectMock });
-
+    mockAlertQuery(null, { message: 'query failed' });
     await expect(listAlerts()).rejects.toThrow('query failed');
   });
 });
@@ -333,7 +366,12 @@ describe('rejectRecommendation', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('atomically rejects a pending recommendation', async () => {
-    const rejected = { id: 'uuid-1', status: 'rejected', ticker: 'AAPL', reviewed_at: '2026-03-26T10:00:00Z' };
+    const rejected = {
+      id: 'uuid-1',
+      status: 'rejected',
+      ticker: 'AAPL',
+      reviewed_at: '2026-03-26T10:00:00Z',
+    };
     mockFrom.mockReturnValue({
       update: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
@@ -374,7 +412,12 @@ describe('rejectRecommendation', () => {
         eq: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             select: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: null, error: { code: 'OTHER', message: 'reject failed' } }),
+              single: vi
+                .fn()
+                .mockResolvedValue({
+                  data: null,
+                  error: { code: 'OTHER', message: 'reject failed' },
+                }),
             }),
           }),
         }),
@@ -401,7 +444,12 @@ describe('Edge Cases and Data Integrity', () => {
       signal_strength: 0.92,
       metadata: { rsi: 75, volume: 'high' },
     };
-    const inserted = { id: 'uuid-2', status: 'pending', created_at: '2026-03-26T10:00:00Z', ...rec };
+    const inserted = {
+      id: 'uuid-2',
+      status: 'pending',
+      created_at: '2026-03-26T10:00:00Z',
+      ...rec,
+    };
     mockFrom.mockReturnValue({
       insert: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({
@@ -424,7 +472,12 @@ describe('Edge Cases and Data Integrity', () => {
       quantity: 1,
       order_type: 'market' as const,
     };
-    const inserted = { id: 'uuid-3', status: 'pending', created_at: '2026-03-26T11:00:00Z', ...rec };
+    const inserted = {
+      id: 'uuid-3',
+      status: 'pending',
+      created_at: '2026-03-26T11:00:00Z',
+      ...rec,
+    };
     mockFrom.mockReturnValue({
       insert: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({
@@ -457,7 +510,12 @@ describe('Edge Cases and Data Integrity', () => {
     mockFrom.mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'OTHER', message: 'permission denied' } }),
+          single: vi
+            .fn()
+            .mockResolvedValue({
+              data: null,
+              error: { code: 'OTHER', message: 'permission denied' },
+            }),
         }),
       }),
     });
@@ -471,7 +529,12 @@ describe('Edge Cases and Data Integrity', () => {
         eq: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             select: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: null, error: { code: 'OTHER', message: 'constraint violation' } }),
+              single: vi
+                .fn()
+                .mockResolvedValue({
+                  data: null,
+                  error: { code: 'OTHER', message: 'constraint violation' },
+                }),
             }),
           }),
         }),
@@ -501,7 +564,11 @@ describe('Edge Cases and Data Integrity', () => {
         }),
       });
 
-      const result = await createAlert({ severity, title: `${severity} alert`, message: 'Test message' });
+      const result = await createAlert({
+        severity,
+        title: `${severity} alert`,
+        message: 'Test message',
+      });
       expect(result.severity).toBe(severity);
     }
   });
@@ -524,7 +591,12 @@ describe('Edge Cases and Data Integrity', () => {
       }),
     });
 
-    const result = await createAlert({ severity: 'warning', title: 'Price Alert', message: 'AAPL dropped 5%', ticker: 'AAPL' });
+    const result = await createAlert({
+      severity: 'warning',
+      title: 'Price Alert',
+      message: 'AAPL dropped 5%',
+      ticker: 'AAPL',
+    });
     expect(result.ticker).toBe('AAPL');
   });
 
@@ -537,7 +609,9 @@ describe('Edge Cases and Data Integrity', () => {
       }),
     });
 
-    await expect(createAlert({ severity: 'info', title: 'Test', message: 'Test message' })).rejects.toThrow('insert failed');
+    await expect(
+      createAlert({ severity: 'info', title: 'Test', message: 'Test message' }),
+    ).rejects.toThrow('insert failed');
   });
 });
 
@@ -546,7 +620,12 @@ describe('Race Condition Prevention', () => {
 
   it('atomicApprove prevents double-approval via status check', async () => {
     // First approval succeeds
-    const approved = { id: 'uuid-1', status: 'approved', ticker: 'AAPL', reviewed_at: '2026-03-26T10:00:00Z' };
+    const approved = {
+      id: 'uuid-1',
+      status: 'approved',
+      ticker: 'AAPL',
+      reviewed_at: '2026-03-26T10:00:00Z',
+    };
     mockFrom.mockReturnValue({
       update: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
@@ -581,7 +660,12 @@ describe('Race Condition Prevention', () => {
 
   it('rejectRecommendation prevents double-rejection via status check', async () => {
     // First rejection succeeds
-    const rejected = { id: 'uuid-1', status: 'rejected', ticker: 'AAPL', reviewed_at: '2026-03-26T10:00:00Z' };
+    const rejected = {
+      id: 'uuid-1',
+      status: 'rejected',
+      ticker: 'AAPL',
+      reviewed_at: '2026-03-26T10:00:00Z',
+    };
     mockFrom.mockReturnValue({
       update: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
@@ -616,7 +700,12 @@ describe('Race Condition Prevention', () => {
 
   it('atomicApprove and rejectRecommendation cannot both succeed', async () => {
     // Approval succeeds first
-    const approved = { id: 'uuid-1', status: 'approved', ticker: 'AAPL', reviewed_at: '2026-03-26T10:00:00Z' };
+    const approved = {
+      id: 'uuid-1',
+      status: 'approved',
+      ticker: 'AAPL',
+      reviewed_at: '2026-03-26T10:00:00Z',
+    };
     mockFrom.mockReturnValue({
       update: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
@@ -658,7 +747,9 @@ describe('Timestamp and Metadata Handling', () => {
       eq: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
           select: vi.fn().mockReturnValue({
-            single: vi.fn().mockResolvedValue({ data: { id: 'uuid-1', status: 'approved' }, error: null }),
+            single: vi
+              .fn()
+              .mockResolvedValue({ data: { id: 'uuid-1', status: 'approved' }, error: null }),
           }),
         }),
       }),
@@ -677,7 +768,9 @@ describe('Timestamp and Metadata Handling', () => {
       eq: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
           select: vi.fn().mockReturnValue({
-            single: vi.fn().mockResolvedValue({ data: { id: 'uuid-1', status: 'rejected' }, error: null }),
+            single: vi
+              .fn()
+              .mockResolvedValue({ data: { id: 'uuid-1', status: 'rejected' }, error: null }),
           }),
         }),
       }),

--- a/apps/agents/tests/server.test.ts
+++ b/apps/agents/tests/server.test.ts
@@ -36,7 +36,7 @@ vi.mock('../src/recommendations-store.js', () => ({
   markRiskBlocked: vi.fn(),
   rejectRecommendation: vi.fn(),
   getRecommendation: vi.fn(),
-  listAlerts: vi.fn().mockResolvedValue([]),
+  listAlerts: vi.fn().mockResolvedValue({ alerts: [], nextCursor: null }),
 }));
 
 vi.mock('../src/scheduler.js', () => ({
@@ -183,10 +183,38 @@ describe('GET /recommendations', () => {
 });
 
 describe('GET /alerts', () => {
-  it('returns empty array', async () => {
+  it('returns empty page with null cursor', async () => {
     const res = await request(app).get('/alerts');
     expect(res.status).toBe(200);
     expect(res.body.alerts).toEqual([]);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('passes cursor params to listAlerts', async () => {
+    const { listAlerts } = await import('../src/recommendations-store.js');
+    vi.mocked(listAlerts).mockResolvedValue({ alerts: [], nextCursor: null });
+    await request(app).get('/alerts?limit=25&lastCreatedAt=2026-01-01T00:00:00Z&lastId=abc');
+    expect(listAlerts).toHaveBeenCalledWith(25, {
+      lastCreatedAt: '2026-01-01T00:00:00Z',
+      lastId: 'abc',
+    });
+  });
+
+  it('returns 400 when only one cursor field is provided', async () => {
+    const res = await request(app).get('/alerts?lastCreatedAt=2026-01-01T00:00:00Z');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/lastCreatedAt.*lastId/);
+  });
+
+  it('clamps limit to 1..100 range', async () => {
+    const { listAlerts } = await import('../src/recommendations-store.js');
+    vi.mocked(listAlerts).mockResolvedValue({ alerts: [], nextCursor: null });
+
+    await request(app).get('/alerts?limit=200');
+    expect(listAlerts).toHaveBeenCalledWith(100, undefined);
+
+    await request(app).get('/alerts?limit=-5');
+    expect(listAlerts).toHaveBeenCalledWith(1, undefined);
   });
 });
 

--- a/apps/web/src/hooks/queries/use-alerts-query.ts
+++ b/apps/web/src/hooks/queries/use-alerts-query.ts
@@ -1,15 +1,16 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useAppStore } from '@/stores/app-store';
 import { queryKeys } from '@/lib/query-keys';
-import { agentsClient, type AgentAlert } from '@/lib/agents-client';
+import { agentsClient, type AgentAlert, type AlertsCursor } from '@/lib/agents-client';
 
 async function fetchAlerts(): Promise<AgentAlert[]> {
   const { alerts } = await agentsClient.getAlerts();
   return alerts;
 }
 
+/** Latest alerts (flat array, auto-refetch). Used by NotificationCenter. */
 export function useAlertsQuery(refetchInterval = 30_000) {
   const agentsOnline = useAppStore((s) => s.agentsOnline);
 
@@ -18,5 +19,21 @@ export function useAlertsQuery(refetchInterval = 30_000) {
     queryFn: fetchAlerts,
     enabled: agentsOnline === true,
     refetchInterval,
+  });
+}
+
+/** Paginated alerts with cursor-based infinite loading. */
+export function useAlertsInfiniteQuery(limit = 50) {
+  const agentsOnline = useAppStore((s) => s.agentsOnline);
+
+  return useInfiniteQuery({
+    queryKey: [...queryKeys.agents.alerts(), 'infinite'],
+    queryFn: ({ pageParam }) =>
+      pageParam
+        ? agentsClient.getAlerts({ limit, cursor: pageParam })
+        : agentsClient.getAlerts({ limit }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    initialPageParam: undefined as AlertsCursor | undefined,
+    enabled: agentsOnline === true,
   });
 }

--- a/apps/web/src/lib/agents-client.ts
+++ b/apps/web/src/lib/agents-client.ts
@@ -54,6 +54,16 @@ export interface AgentAlert {
   acknowledged: boolean;
 }
 
+export interface AlertsCursor {
+  lastCreatedAt: string;
+  lastId: string;
+}
+
+export interface AlertsPage {
+  alerts: AgentAlert[];
+  nextCursor: AlertsCursor | null;
+}
+
 export interface ApproveResult {
   orderId: string;
   status: string;
@@ -150,8 +160,15 @@ export const agentsClient = {
     });
   },
 
-  /** Get the 50 most recent agent-generated alerts. */
-  getAlerts(): Promise<{ alerts: AgentAlert[] }> {
-    return agentsFetch<{ alerts: AgentAlert[] }>('/alerts');
+  /** Get a page of agent-generated alerts (newest first, keyset cursor). */
+  getAlerts(params?: { limit?: number; cursor?: AlertsCursor }): Promise<AlertsPage> {
+    const sp = new URLSearchParams();
+    if (params?.limit) sp.set('limit', String(params.limit));
+    if (params?.cursor) {
+      sp.set('lastCreatedAt', params.cursor.lastCreatedAt);
+      sp.set('lastId', params.cursor.lastId);
+    }
+    const qs = sp.toString();
+    return agentsFetch<AlertsPage>(`/alerts${qs ? `?${qs}` : ''}`);
   },
 };

--- a/apps/web/tests/unit/agents-client.test.ts
+++ b/apps/web/tests/unit/agents-client.test.ts
@@ -244,13 +244,49 @@ describe('agentsClient.rejectRecommendation', () => {
 describe('agentsClient.getAlerts', () => {
   beforeEach(() => mockFetch.mockReset());
 
-  it('fetches alerts from /api/agents/alerts', async () => {
-    mockFetch.mockReturnValue(mockOk({ alerts: [alertFixture] }));
+  it('fetches first page of alerts from /api/agents/alerts', async () => {
+    mockFetch.mockReturnValue(
+      mockOk({
+        alerts: [alertFixture],
+        nextCursor: { lastCreatedAt: alertFixture.created_at, lastId: alertFixture.id },
+      }),
+    );
     const result = await agentsClient.getAlerts();
 
     expect(mockFetch).toHaveBeenCalledWith('/api/agents/alerts', expect.any(Object));
     expect(result.alerts).toHaveLength(1);
     expect(result.alerts[0]?.title).toBe('Volatility spike');
+    expect(result.nextCursor).toEqual({
+      lastCreatedAt: '2026-01-01T00:00:00Z',
+      lastId: 'alert-1',
+    });
+  });
+
+  it('passes cursor params as query string', async () => {
+    mockFetch.mockReturnValue(mockOk({ alerts: [], nextCursor: null }));
+    await agentsClient.getAlerts({
+      limit: 25,
+      cursor: { lastCreatedAt: '2026-01-01T00:00:00Z', lastId: 'alert-1' },
+    });
+
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toContain('/api/agents/alerts?');
+    expect(url).toContain('limit=25');
+    expect(url).toContain('lastCreatedAt=2026-01-01T00%3A00%3A00Z');
+    expect(url).toContain('lastId=alert-1');
+  });
+
+  it('returns null nextCursor on last page', async () => {
+    mockFetch.mockReturnValue(mockOk({ alerts: [alertFixture], nextCursor: null }));
+    const result = await agentsClient.getAlerts();
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('omits query string when no params provided', async () => {
+    mockFetch.mockReturnValue(mockOk({ alerts: [], nextCursor: null }));
+    await agentsClient.getAlerts();
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toBe('/api/agents/alerts');
   });
 
   it('throws AgentsApiError on 401 response', async () => {

--- a/supabase/migrations/00033_alerts_pagination_index.sql
+++ b/supabase/migrations/00033_alerts_pagination_index.sql
@@ -1,0 +1,5 @@
+-- Composite index for stable keyset pagination on agent_alerts.
+-- Covers ORDER BY created_at DESC, id DESC and the cursor filter:
+--   WHERE (created_at < :cursor) OR (created_at = :cursor AND id < :cursorId)
+CREATE INDEX IF NOT EXISTS idx_agent_alerts_pagination
+  ON public.agent_alerts (created_at DESC, id DESC);


### PR DESCRIPTION
## Summary

Implements stable cursor-based keyset pagination for the agent alerts system, replacing the previous simple LIMIT 50 approach.

## Changes

### Backend (apps/agents)
- **recommendations-store.ts**: New AlertsCursor and AlertsPage types. listAlerts() now uses composite sort (created_at DESC, id DESC) with limit+1 fetch pattern for has-more detection. Keyset filter via .or() when cursor provided.
- **server.ts**: GET /alerts accepts limit, lastCreatedAt, lastId query params. Returns 400 for partial cursor. Clamps limit to 1..100.

### Frontend (apps/web)
- **agents-client.ts**: Added AlertsCursor/AlertsPage types. getAlerts() accepts optional {limit, cursor} params, builds query string.
- **use-alerts-query.ts**: Preserved useAlertsQuery for NotificationCenter (flat array, 30s refetch). Added useAlertsInfiniteQuery using useInfiniteQuery for paginated browsing.

### Migration
- **00033_alerts_pagination_index.sql**: Composite index (created_at DESC, id DESC) for pagination performance.

### Tests
- Updated all existing tests for new response shape
- Added pagination-specific tests (cursor params, validation, limit clamping, has-more detection)
- 293/293 agents tests pass
- 1172/1172 web tests pass

## Design Decisions
- Keyset pagination (not offset) for stability across concurrent inserts
- limit+1 fetch to detect next page without extra COUNT query
- Backward compatible: getAlerts() with no params returns first page
- Response shape { alerts, nextCursor } - existing destructuring still works