### PR TITLE
fix: resolve 60 TypeScript typecheck errors in web test files

### DIFF
--- a/apps/web/tests/components/layout/breadcrumbs.test.tsx
+++ b/apps/web/tests/components/layout/breadcrumbs.test.tsx
@@ -113,7 +113,7 @@ describe('ROUTE_LABELS', () => {
 
   it.each(expectedRoutes)('has a label for %s', (route) => {
     expect(ROUTE_LABELS[route]).toBeDefined();
-    expect(ROUTE_LABELS[route].length).toBeGreaterThan(0);
+    expect(ROUTE_LABELS[route]!.length).toBeGreaterThan(0);
   });
 
   it('contains at least 25 entries', () => {

--- a/apps/web/tests/hooks/use-positions-query.test.ts
+++ b/apps/web/tests/hooks/use-positions-query.test.ts
@@ -47,7 +47,7 @@ describe('usePositionsQuery', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toHaveLength(2);
-    expect(result.current.data![0].instrument_id).toBe('AAPL');
+    expect(result.current.data![0]!.instrument_id).toBe('AAPL');
   });
 
   it('calls the correct engine URL', async () => {

--- a/apps/web/tests/hooks/use-recommendations-query.test.ts
+++ b/apps/web/tests/hooks/use-recommendations-query.test.ts
@@ -33,8 +33,26 @@ describe('useRecommendationsQuery', () => {
 
   it('fetches pending recommendations by default', async () => {
     const mockRecs = [
-      { id: 'rec-1', ticker: 'AAPL', side: 'buy', status: 'pending' },
-      { id: 'rec-2', ticker: 'MSFT', side: 'sell', status: 'pending' },
+      {
+        id: 'rec-1',
+        created_at: '2024-01-01T00:00:00Z',
+        agent_role: 'analyst',
+        ticker: 'AAPL',
+        side: 'buy' as const,
+        quantity: 10,
+        order_type: 'market' as const,
+        status: 'pending' as const,
+      },
+      {
+        id: 'rec-2',
+        created_at: '2024-01-01T00:00:00Z',
+        agent_role: 'analyst',
+        ticker: 'MSFT',
+        side: 'sell' as const,
+        quantity: 5,
+        order_type: 'market' as const,
+        status: 'pending' as const,
+      },
     ];
     vi.mocked(agentsClient.getRecommendations).mockResolvedValue({
       recommendations: mockRecs,
@@ -47,13 +65,24 @@ describe('useRecommendationsQuery', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toHaveLength(2);
-    expect(result.current.data![0].ticker).toBe('AAPL');
+    expect(result.current.data![0]!.ticker).toBe('AAPL');
     expect(agentsClient.getRecommendations).toHaveBeenCalledWith('pending');
   });
 
   it('fetches with custom status filter', async () => {
     vi.mocked(agentsClient.getRecommendations).mockResolvedValue({
-      recommendations: [{ id: 'rec-3', ticker: 'GOOG', side: 'buy', status: 'approved' }],
+      recommendations: [
+        {
+          id: 'rec-3',
+          created_at: '2024-01-01T00:00:00Z',
+          agent_role: 'analyst',
+          ticker: 'GOOG',
+          side: 'buy' as const,
+          quantity: 10,
+          order_type: 'market' as const,
+          status: 'approved' as const,
+        },
+      ],
     });
 
     const { result } = renderHook(() => useRecommendationsQuery('approved'), {

--- a/apps/web/tests/hooks/use-strategies-query.test.ts
+++ b/apps/web/tests/hooks/use-strategies-query.test.ts
@@ -50,8 +50,8 @@ describe('useStrategiesQuery', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toHaveLength(2);
-    expect(result.current.data![0].name).toBe('rsi_momentum');
-    expect(result.current.data![1].family).toBe('reversion');
+    expect(result.current.data![0]!.name).toBe('rsi_momentum');
+    expect(result.current.data![1]!.family).toBe('reversion');
   });
 
   it('extracts strategies array from response', async () => {

--- a/apps/web/tests/hooks/use-system-controls-query.test.ts
+++ b/apps/web/tests/hooks/use-system-controls-query.test.ts
@@ -143,7 +143,7 @@ describe('useHaltSystemMutation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1]!.body);
     expect(body.trading_halted).toBe(true);
   });
 });
@@ -171,7 +171,7 @@ describe('useResumeSystemMutation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1]!.body);
     expect(body.trading_halted).toBe(false);
   });
 });

--- a/apps/web/tests/pages/approvals.test.tsx
+++ b/apps/web/tests/pages/approvals.test.tsx
@@ -115,7 +115,7 @@ describe('ApprovalsPage', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useRecommendationsQuery>);
+    } as unknown as ReturnType<typeof useRecommendationsQuery>);
 
     renderWithProviders(<ApprovalsPage />);
     expect(screen.getByText(/all caught up/i)).toBeInTheDocument();

--- a/apps/web/tests/pages/audit-log.test.tsx
+++ b/apps/web/tests/pages/audit-log.test.tsx
@@ -57,7 +57,7 @@ describe('AuditLogPage', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useOperatorActionsQuery>);
+    } as unknown as ReturnType<typeof useOperatorActionsQuery>);
 
     renderWithProviders(<AuditLogPage />);
     expect(screen.getByText('Total Actions')).toBeInTheDocument();

--- a/apps/web/tests/pages/journal.test.tsx
+++ b/apps/web/tests/pages/journal.test.tsx
@@ -9,8 +9,15 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+interface JournalResponse {
+  entries: JournalEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 const mockUseJournalQuery = vi.fn(() => ({
-  data: undefined,
+  data: undefined as JournalResponse | undefined,
   isLoading: false,
   isError: false,
 }));
@@ -19,7 +26,7 @@ vi.mock('@/hooks/queries', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/hooks/queries')>();
   return {
     ...actual,
-    useJournalQuery: (...args: unknown[]) => mockUseJournalQuery(...args),
+    useJournalQuery: () => mockUseJournalQuery(),
     useJournalStatsQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
     useGradeJournalMutation: vi.fn(() => ({
       mutate: vi.fn(),

--- a/apps/web/tests/pages/orders.test.tsx
+++ b/apps/web/tests/pages/orders.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import OrdersPage from '@/app/(dashboard)/orders/page';
 import { renderWithProviders } from '../test-utils';
+import type { OrderHistoryEntry } from '@/hooks/queries/use-order-history-query';
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/orders',
@@ -44,24 +45,24 @@ async function mockAllEmpty() {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as ReturnType<typeof queries.useFillsQuery>);
+  } as unknown as ReturnType<typeof queries.useFillsQuery>);
   vi.mocked(queries.useRiskEvaluationsQuery).mockReturnValue({
     data: { data: [], total: 0 },
     isLoading: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as ReturnType<typeof queries.useRiskEvaluationsQuery>);
+  } as unknown as ReturnType<typeof queries.useRiskEvaluationsQuery>);
   vi.mocked(queries.useOrderHistoryQuery).mockReturnValue({
     data: [],
     isLoading: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as ReturnType<typeof queries.useOrderHistoryQuery>);
+  } as unknown as ReturnType<typeof queries.useOrderHistoryQuery>);
 }
 
-async function mockWithOrders(orders: Parameters<typeof vi.fn>[0] = undefined) {
+async function mockWithOrders(orders?: OrderHistoryEntry[]) {
   const queries = await import('@/hooks/queries');
   vi.mocked(queries.useFillsQuery).mockReturnValue({
     data: { data: [], total: 0 },
@@ -69,14 +70,14 @@ async function mockWithOrders(orders: Parameters<typeof vi.fn>[0] = undefined) {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as ReturnType<typeof queries.useFillsQuery>);
+  } as unknown as ReturnType<typeof queries.useFillsQuery>);
   vi.mocked(queries.useRiskEvaluationsQuery).mockReturnValue({
     data: { data: [], total: 0 },
     isLoading: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as ReturnType<typeof queries.useRiskEvaluationsQuery>);
+  } as unknown as ReturnType<typeof queries.useRiskEvaluationsQuery>);
   vi.mocked(queries.useOrderHistoryQuery).mockReturnValue({
     data: orders ?? [
       {
@@ -97,7 +98,7 @@ async function mockWithOrders(orders: Parameters<typeof vi.fn>[0] = undefined) {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as ReturnType<typeof queries.useOrderHistoryQuery>);
+  } as unknown as ReturnType<typeof queries.useOrderHistoryQuery>);
 }
 
 beforeEach(() => {

--- a/apps/web/tests/pages/roles.test.tsx
+++ b/apps/web/tests/pages/roles.test.tsx
@@ -82,7 +82,7 @@ describe('OperatorRolesPage', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useRolesQuery>);
+    } as unknown as ReturnType<typeof useRolesQuery>);
 
     renderWithProviders(<RolesPage />);
     expect(screen.getByText(/no team members found/i)).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('OperatorRolesPage', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useRolesQuery>);
+    } as unknown as ReturnType<typeof useRolesQuery>);
 
     renderWithProviders(<RolesPage />);
     expect(screen.getByText('Alice Operator')).toBeInTheDocument();

--- a/apps/web/tests/pages/settings.test.tsx
+++ b/apps/web/tests/pages/settings.test.tsx
@@ -230,7 +230,7 @@ describe('SettingsPage', () => {
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Risk/i })[0]).toBeInTheDocument(),
     );
-    fireEvent.click(screen.getAllByRole('tab', { name: /Risk/i })[0]);
+    fireEvent.click(screen.getAllByRole('tab', { name: /Risk/i })[0]!);
     await waitFor(() => {
       expect(screen.getByText('Position Limits')).toBeInTheDocument();
       expect(screen.getByText('Circuit Breakers')).toBeInTheDocument();
@@ -242,7 +242,7 @@ describe('SettingsPage', () => {
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Alerts/i })[0]).toBeInTheDocument(),
     );
-    fireEvent.click(screen.getAllByRole('tab', { name: /Alerts/i })[0]);
+    fireEvent.click(screen.getAllByRole('tab', { name: /Alerts/i })[0]!);
     await waitFor(() => {
       expect(screen.getByText('Critical Alerts')).toBeInTheDocument();
       expect(screen.getByText('Warning Alerts')).toBeInTheDocument();
@@ -257,7 +257,7 @@ describe('SettingsPage', () => {
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Trading/i })[0]).toBeInTheDocument(),
     );
-    fireEvent.click(screen.getAllByRole('tab', { name: /Trading/i })[0]);
+    fireEvent.click(screen.getAllByRole('tab', { name: /Trading/i })[0]!);
     await waitFor(() => {
       expect(screen.getByText('Paper Trading Mode')).toBeInTheDocument();
       expect(screen.getByText('Auto Trading')).toBeInTheDocument();
@@ -272,7 +272,7 @@ describe('SettingsPage', () => {
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Trading/i })[0]).toBeInTheDocument(),
     );
-    fireEvent.click(screen.getAllByRole('tab', { name: /Trading/i })[0]);
+    fireEvent.click(screen.getAllByRole('tab', { name: /Trading/i })[0]!);
     await waitFor(() => expect(screen.getByText('9.9.9-test')).toBeInTheDocument());
   });
 
@@ -303,7 +303,7 @@ describe('SettingsPage', () => {
     await waitFor(() =>
       expect(screen.getAllByRole('tab', { name: /Risk/i })[0]).toBeInTheDocument(),
     );
-    fireEvent.click(screen.getAllByRole('tab', { name: /Risk/i })[0]);
+    fireEvent.click(screen.getAllByRole('tab', { name: /Risk/i })[0]!);
     await waitFor(() => {
       // Design system Input components have data-slot="input"
       const inputs = document.querySelectorAll('[data-slot="input"]');

--- a/apps/web/tests/pages/system-controls.test.tsx
+++ b/apps/web/tests/pages/system-controls.test.tsx
@@ -98,7 +98,7 @@ describe('SystemControlsPage', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useSystemControlsQuery>);
+    } as unknown as ReturnType<typeof useSystemControlsQuery>);
 
     renderWithProviders(<SystemControlsPage />);
     expect(screen.getByText('Halted')).toBeInTheDocument();

--- a/apps/web/tests/pages/workflows.test.tsx
+++ b/apps/web/tests/pages/workflows.test.tsx
@@ -74,7 +74,7 @@ describe('WorkflowsPage', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as ReturnType<typeof useWorkflowJobsQuery>);
+    } as unknown as ReturnType<typeof useWorkflowJobsQuery>);
 
     renderWithProviders(<WorkflowsPage />);
     expect(screen.getByText('No workflows found')).toBeInTheDocument();

--- a/apps/web/tests/unit/advisor-api-routes.test.ts
+++ b/apps/web/tests/unit/advisor-api-routes.test.ts
@@ -64,7 +64,7 @@ describe('Advisor API routes', () => {
       mockSupabase.auth.getUser.mockResolvedValueOnce({
         data: { user: null },
         error: { message: 'Not authenticated' },
-      });
+      } as never);
 
       const { GET } = await import('@/app/api/advisor/profile/route');
       const res = await GET();
@@ -92,7 +92,7 @@ describe('Advisor API routes', () => {
       mockSupabase.auth.getUser.mockResolvedValueOnce({
         data: { user: null },
         error: { message: 'Not authenticated' },
-      });
+      } as never);
 
       const { GET } = await import('@/app/api/advisor/memory-events/route');
       const req = new Request('http://localhost/api/advisor/memory-events');

--- a/apps/web/tests/unit/advisor-context.test.ts
+++ b/apps/web/tests/unit/advisor-context.test.ts
@@ -28,7 +28,7 @@ describe('buildAdvisorContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset the from mock to default empty responses
-    mockSupabase.from.mockImplementation((table: string) => {
+    mockSupabase.from.mockImplementation(((table: string) => {
       if (table === 'advisor_profiles') {
         return chainable({ profile: { risk_tolerance: 'moderate' } });
       }
@@ -51,7 +51,7 @@ describe('buildAdvisorContext', () => {
         return chainable([]);
       }
       return chainable();
-    });
+    }) as never);
   });
 
   it('assembles context with profile and preferences', async () => {
@@ -68,7 +68,7 @@ describe('buildAdvisorContext', () => {
   });
 
   it('handles missing profile gracefully', async () => {
-    mockSupabase.from.mockImplementation((table: string) => {
+    mockSupabase.from.mockImplementation(((table: string) => {
       if (table === 'advisor_profiles') {
         return chainable(null, { code: 'PGRST116' });
       }
@@ -76,7 +76,7 @@ describe('buildAdvisorContext', () => {
         return chainable([]);
       }
       return chainable(null, { code: 'PGRST116' });
-    });
+    }) as never);
 
     const { buildAdvisorContext } = await import('@/lib/advisor-context');
     const ctx = await buildAdvisorContext('user-1');

--- a/apps/web/tests/unit/api-proxy-routes.test.ts
+++ b/apps/web/tests/unit/api-proxy-routes.test.ts
@@ -248,7 +248,7 @@ describe('/api/engine/[...path] route handler', () => {
     await GET(request, ctx);
 
     // The original request (with its query string) is passed to the proxy
-    const [, forwardedReq] = mockProxyServiceRequest.mock.calls[0];
+    const [, forwardedReq] = mockProxyServiceRequest.mock.calls[0]!;
     const url = new URL(forwardedReq.url);
     expect(url.searchParams.get('symbols')).toBe('AAPL,MSFT');
     expect(url.searchParams.get('interval')).toBe('1d');
@@ -282,10 +282,10 @@ describe('/api/engine/[...path] route handler', () => {
 
     await GET(request, ctx);
 
-    const extraHeaders = mockProxyServiceRequest.mock.calls[0][3] as Record<string, string>;
+    const extraHeaders = mockProxyServiceRequest.mock.calls[0]![3] as Record<string, string>;
     expect(extraHeaders['x-correlation-id']).toBeDefined();
     expect(typeof extraHeaders['x-correlation-id']).toBe('string');
-    expect(extraHeaders['x-correlation-id'].length).toBeGreaterThan(0);
+    expect(extraHeaders['x-correlation-id']!.length).toBeGreaterThan(0);
   });
 
   // ─── Error boundary tests ─────────────────────────────────────────────

--- a/apps/web/tests/unit/auth-hardened-routes.test.ts
+++ b/apps/web/tests/unit/auth-hardened-routes.test.ts
@@ -59,13 +59,13 @@ describe('Auth enforcement on hardened routes', { timeout: 15_000 }, () => {
 
   it('GET /api/fills returns 401', async () => {
     const { GET } = await import('@/app/api/fills/route');
-    const res = await GET(req('/api/fills'));
+    const res = await GET(req('/api/fills') as never);
     expect(res.status).toBe(401);
   });
 
   it('POST /api/fills returns 401', async () => {
     const { POST } = await import('@/app/api/fills/route');
-    const res = await POST(req('/api/fills', 'POST'));
+    const res = await POST(req('/api/fills', 'POST') as never);
     expect(res.status).toBe(401);
   });
 
@@ -95,7 +95,7 @@ describe('Auth enforcement on hardened routes', { timeout: 15_000 }, () => {
 
   it('GET /api/experiments returns 401', async () => {
     const { GET } = await import('@/app/api/experiments/route');
-    const res = await GET(req('/api/experiments') as never);
+    const res = await GET();
     expect(res.status).toBe(401);
   });
 
@@ -107,7 +107,7 @@ describe('Auth enforcement on hardened routes', { timeout: 15_000 }, () => {
 
   it('GET /api/system-controls returns 401', async () => {
     const { GET } = await import('@/app/api/system-controls/route');
-    const res = await GET(req('/api/system-controls'));
+    const res = await GET();
     expect(res.status).toBe(401);
   });
 

--- a/apps/web/tests/unit/broker-route.test.ts
+++ b/apps/web/tests/unit/broker-route.test.ts
@@ -87,8 +87,7 @@ describe('/api/onboarding/broker', () => {
   describe('POST', () => {
     it('returns 401 when not authenticated', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: null } });
-      const req = makeRequest('POST');
-      const res = await POST(req);
+      const res = await POST();
       expect(res.status).toBe(401);
     });
 
@@ -104,8 +103,7 @@ describe('/api/onboarding/broker', () => {
         }),
       });
 
-      const req = makeRequest('POST');
-      const res = await POST(req);
+      const res = await POST();
       expect(res.status).toBe(409);
       const body = await res.json();
       expect(body.error).toContain('already exists');
@@ -142,8 +140,7 @@ describe('/api/onboarding/broker', () => {
         return { insert: vi.fn().mockResolvedValue({ error: null }) };
       });
 
-      const req = makeRequest('POST');
-      const res = await POST(req);
+      const res = await POST();
       expect(res.status).toBe(201);
 
       expect(insertedData).toBeDefined();

--- a/apps/web/tests/unit/journal-api.test.ts
+++ b/apps/web/tests/unit/journal-api.test.ts
@@ -138,7 +138,7 @@ describe('Journal API routes', { timeout: 15_000 }, () => {
 
     it('GET /api/journal/stats returns 401 when unauthenticated', async () => {
       const { GET } = await import('@/app/api/journal/stats/route');
-      const res = await GET(req('/api/journal/stats'));
+      const res = await GET();
       expect(res.status).toBe(401);
     });
   });

--- a/apps/web/tests/unit/paper-account-route.test.ts
+++ b/apps/web/tests/unit/paper-account-route.test.ts
@@ -19,13 +19,6 @@ vi.mock('@/lib/api-error', () => ({
 
 import { POST } from '@/app/api/onboarding/paper-account/route';
 
-function makeRequest(): Request {
-  return new Request('http://localhost/api/onboarding/paper-account', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-  });
-}
-
 describe('/api/onboarding/paper-account', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,7 +31,7 @@ describe('/api/onboarding/paper-account', () => {
 
   it('returns 401 when not authenticated', async () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: null } });
-    const res = await POST(makeRequest());
+    const res = await POST();
     expect(res.status).toBe(401);
   });
 
@@ -55,7 +48,7 @@ describe('/api/onboarding/paper-account', () => {
       }),
     });
 
-    const res = await POST(makeRequest());
+    const res = await POST();
     const body = await res.json();
     expect(body.id).toBe('acc-existing');
     expect(body.already_existed).toBe(true);
@@ -88,7 +81,7 @@ describe('/api/onboarding/paper-account', () => {
       return { insert: vi.fn().mockResolvedValue({ error: null }) };
     });
 
-    const res = await POST(makeRequest());
+    const res = await POST();
     expect(res.status).toBe(201);
 
     expect(insertedData).toBeDefined();

--- a/apps/web/tests/unit/service-proxy.test.ts
+++ b/apps/web/tests/unit/service-proxy.test.ts
@@ -815,7 +815,7 @@ describe('proxyServiceRequest', () => {
       );
 
       expect(consoleError).toHaveBeenCalled();
-      const logCall = consoleError.mock.calls[0][0] as string;
+      const logCall = consoleError.mock.calls[0]![0] as string;
       const logData = JSON.parse(logCall);
       expect(logData.correlationId).toBe('log-corr-789');
       expect(logData.scope).toBe('service-proxy');
@@ -840,7 +840,7 @@ describe('proxyServiceRequest', () => {
       );
 
       expect(consoleLog).toHaveBeenCalled();
-      const logCall = consoleLog.mock.calls[0][0] as string;
+      const logCall = consoleLog.mock.calls[0]![0] as string;
       const logData = JSON.parse(logCall);
       expect(logData.correlationId).toBe('success-corr-abc');
       expect(logData.action).toBe('success');

--- a/apps/web/tests/unit/status-colors.test.ts
+++ b/apps/web/tests/unit/status-colors.test.ts
@@ -84,8 +84,8 @@ describe('orderStatusColors', () => {
   it.each(expectedStatuses)('order status "%s" has bg and text properties', (status) => {
     const style = orderStatusColors[status];
     expect(style).toBeDefined();
-    expect(style.bg).toEqual(expect.any(String));
-    expect(style.text).toEqual(expect.any(String));
+    expect(style!.bg).toEqual(expect.any(String));
+    expect(style!.text).toEqual(expect.any(String));
   });
 
   it('DEFAULT_ORDER_STYLE has bg and text', () => {


### PR DESCRIPTION
## Summary

Fixes all 60 TypeScript typecheck errors across 22 test files in \pps/web/tests/\.

### Error categories fixed:
| Error | Count | Fix |
|-------|-------|-----|
| TS2352 (unsafe cast) | ~12 | Added \s unknown as\ intermediate cast for UseQueryResult mocks |
| TS2345/TS2554 (wrong args) | ~14 | Updated call sites for refactored 0-arg route handlers |
| TS2322/TS2739 (mock shape) | ~10 | Added missing required fields to mock objects |
| TS2532/TS18048 (possibly undefined) | ~18 | Added non-null assertions for test DOM/mock access |
| TS2556 (spread arg) | 1 | Fixed spread argument type |
| TS2488 (iterator) | 1 | Fixed destructuring on iterator type |

### Verification:
- \	sc --noEmit\: **0 errors** (was 60)
- \pnpm test\: **1169 tests pass** (107 test files, 0 failures)

No production code changed — all fixes are in test files only.