### PR TITLE
feat(web): upgrade desktop dashboard into pane-based workstation

### DIFF
--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -3,7 +3,6 @@
 import { useMemo } from 'react';
 import {
   DollarSign,
-  TrendingUp,
   BarChart3,
   AlertTriangle,
   Zap,
@@ -11,8 +10,11 @@ import {
   Activity,
   Clock,
   Bot,
+  Waves,
+  ListChecks,
+  ArrowRight,
 } from 'lucide-react';
-import { MetricCard } from '@/components/dashboard/metric-card';
+import Link from 'next/link';
 import { AlertFeed } from '@/components/dashboard/alert-feed';
 import { PriceTicker } from '@/components/dashboard/price-ticker';
 import { IncidentControls } from '@/components/dashboard/incident-controls';
@@ -25,6 +27,7 @@ import { ErrorBoundary } from '@/components/error-boundary';
 import { OfflineBanner } from '@/components/ui/offline-banner';
 import { SimulatedBadge } from '@/components/ui/simulated-badge';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
+import { Button } from '@/components/ui/button';
 import { useAppStore } from '@/stores/app-store';
 import type { Alert } from '@sentinel/shared';
 import { cn } from '@/lib/utils';
@@ -96,6 +99,7 @@ function DashboardContent() {
   const recentSignals = useMemo(() => {
     if (!filledRecs) return [];
     return filledRecs.slice(0, MAX_LIVE_SCAN_TICKERS).map((r) => ({
+      id: r.id,
       ticker: r.ticker,
       side: r.side,
       reason: r.reason ?? '',
@@ -103,6 +107,15 @@ function DashboardContent() {
       ts: r.created_at,
     }));
   }, [filledRecs]);
+
+  const watchlist = useMemo(
+    () =>
+      tickerData.slice(0, 8).map((item) => ({
+        ...item,
+        signalCount: recentSignals.filter((sig) => sig.ticker === item.ticker).length,
+      })),
+    [tickerData, recentSignals],
+  );
 
   const equity = account?.equity ?? FALLBACK_ACCOUNT.equity;
   const pnl = equity - (account?.initial_capital ?? FALLBACK_ACCOUNT.initial_capital);
@@ -114,127 +127,54 @@ function DashboardContent() {
     agentStatus?.halted ? 'error' : agentStatus?.isRunning ? 'success' : 'neutral',
   );
 
+  const heroTicker = tickerData[0];
+
   return (
-    <div className="space-y-4 p-3 sm:p-4 xl:p-6 page-enter" aria-label="Trading dashboard">
+    <div className="space-y-4 p-3 sm:p-4 xl:p-5 page-enter" aria-label="Trading dashboard">
       <h1 className="text-heading-page">Dashboard</h1>
 
       {engineOnline === false && <OfflineBanner service="engine" />}
       {agentsOnline === false && <OfflineBanner service="agents" />}
 
-      {/* System Health Strip */}
-      <section
-        aria-label="System health status"
-        className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm sm:px-4"
-      >
-        <div className="flex items-center gap-1.5">
-          <Shield className="h-3.5 w-3.5" aria-hidden="true" />
-          <span className={cn('font-medium', tradingColors.text)}>
+      <section aria-label="System state" className="workstation-strip">
+        <div className="workspace-keyline">
+          <p className="workspace-label">Trading</p>
+          <div className={cn('workspace-value', tradingColors.text)}>
+            <Shield className="h-3.5 w-3.5" aria-hidden="true" />
             {systemControls?.trading_halted ? 'Halted' : 'Active'}
-          </span>
+          </div>
         </div>
-        <span className="hidden sm:inline text-border" aria-hidden="true">
-          |
-        </span>
-        <div className="flex items-center gap-1.5">
-          <Activity className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-          <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase">
-            {systemControls?.global_mode ?? 'paper'}
-          </span>
+        <div className="workspace-keyline">
+          <p className="workspace-label">Market Mode</p>
+          <div className="workspace-value text-foreground/90">
+            <Activity className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+            <span className="uppercase">{systemControls?.global_mode ?? 'paper'}</span>
+          </div>
         </div>
-        <span className="hidden sm:inline text-border" aria-hidden="true">
-          |
-        </span>
-        <div className="flex items-center gap-1.5">
-          <Clock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-          <span className="text-muted-foreground">Pending:</span>
-          <span
+        <div className="workspace-keyline">
+          <p className="workspace-label">Approvals</p>
+          <div
             className={cn(
-              'font-medium',
+              'workspace-value',
               (pendingRecs?.length ?? 0) > 0 ? pendingColors.text : 'text-muted-foreground',
             )}
           >
+            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
             {pendingRecs?.length ?? 0}
-          </span>
+          </div>
         </div>
-        <span className="hidden sm:inline text-border" aria-hidden="true">
-          |
-        </span>
-        <div className="flex items-center gap-1.5">
-          <Bot className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-          <span className={cn('font-medium', agentColors.text)}>
+        <div className="workspace-keyline">
+          <p className="workspace-label">Agents</p>
+          <div className={cn('workspace-value', agentColors.text)}>
+            <Bot className="h-3.5 w-3.5" aria-hidden="true" />
             {agentStatus?.halted ? 'Halted' : agentStatus?.isRunning ? 'Running' : 'Idle'}
-          </span>
-          {agentStatus?.cycleCount != null && (
-            <span className="text-xs text-muted-foreground">#{agentStatus.cycleCount}</span>
-          )}
-        </div>
-      </section>
-
-      {/* Incident Controls */}
-      <IncidentControls />
-
-      {/* Portfolio Metrics */}
-      <section aria-label="Portfolio metrics">
-        <div className="@container">
-          <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 stagger-grid">
-            <MetricCard
-              label={
-                <>
-                  Total Equity{' '}
-                  <InfoTooltip content="Total value of all assets including cash and open positions." />
-                </>
-              }
-              value={<AnimatedNumber value={equity} prefix="$" decimals={2} />}
-              icon={<DollarSign className="h-4 w-4 text-muted-foreground" />}
-            />
-            <MetricCard
-              label={
-                <>
-                  Daily P&L{' '}
-                  <InfoTooltip content="Today's profit or loss across all positions, updated in real-time during market hours." />
-                </>
-              }
-              value={
-                <AnimatedNumber
-                  value={Math.abs(pnl)}
-                  prefix={pnl >= 0 ? '+$' : '-$'}
-                  decimals={2}
-                />
-              }
-              change={pnlPct}
-              icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
-            />
-            <MetricCard
-              label={
-                <>
-                  Cash Available <InfoTooltip content="Uninvested cash available for new trades." />
-                </>
-              }
-              value={
-                <AnimatedNumber
-                  value={account?.cash ?? FALLBACK_ACCOUNT.cash}
-                  prefix="$"
-                  decimals={2}
-                />
-              }
-              icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />}
-            />
-            <MetricCard
-              label="Positions Value"
-              value={
-                <AnimatedNumber
-                  value={account?.positions_value ?? FALLBACK_ACCOUNT.positions_value}
-                  prefix="$"
-                  decimals={2}
-                />
-              }
-              icon={<AlertTriangle className="h-4 w-4 text-muted-foreground" />}
-            />
+            {agentStatus?.cycleCount != null && (
+              <span className="text-[11px] text-muted-foreground">#{agentStatus.cycleCount}</span>
+            )}
           </div>
         </div>
       </section>
 
-      {/* Price Ticker */}
       <section aria-label="Market prices" className="relative">
         <PriceTicker items={tickerData} />
         <span className="absolute -top-1.5 right-2">
@@ -252,68 +192,185 @@ function DashboardContent() {
         </span>
       </section>
 
-      {/* Signals & Alerts */}
-      <section aria-label="Signals and alerts">
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {/* Active Signals */}
-          <Card className="bg-card border-border">
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-heading-card">Active Signals</CardTitle>
-              <Zap className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-            </CardHeader>
-            <CardContent>
-              {recentSignals.length === 0 ? (
-                <EmptyState
-                  icon={Zap}
-                  title="No Recent Signals"
-                  description="Strategies generate signals during market hours."
-                  className="border-0 bg-transparent py-6"
-                />
-              ) : (
-                <div className="space-y-2" role="list" aria-label="Recent trading signals">
-                  {recentSignals.map((s, i) => (
-                    <article
-                      key={i}
-                      className="flex items-center justify-between py-1.5 border-b border-border/50 last:border-0"
-                      role="listitem"
-                    >
-                      <div className="flex items-center gap-2">
-                        <span
-                          className={cn(
-                            'text-[10px] font-bold px-1.5 py-0.5 rounded',
-                            sideColors[s.side] ?? sideColors.buy,
-                          )}
-                        >
-                          {s.side.toUpperCase()}
-                        </span>
-                        <span className="text-sm font-semibold text-foreground">{s.ticker}</span>
-                      </div>
-                      {s.strength != null && (
-                        <span
-                          className={cn(
-                            'text-xs font-mono px-1.5 py-0.5 rounded border',
-                            getSignalStrengthColor(s.strength),
-                          )}
-                        >
-                          {(s.strength * 100).toFixed(0)}%
-                        </span>
-                      )}
-                    </article>
-                  ))}
+      <section aria-label="Trading workstation" className="workstation-grid">
+        <Card className="workstation-panel workstation-watchlist @container/watchlist">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-heading-card">Watchlist</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1.5 pt-0">
+            {watchlist.map((item) => (
+              <article
+                key={item.ticker}
+                className="grid grid-cols-[4rem_1fr_auto] items-center gap-2 rounded-md px-1 py-1 text-xs hover:bg-accent/40"
+              >
+                <span className="font-mono text-foreground/90">{item.ticker}</span>
+                <span className="font-mono text-muted-foreground">${item.price.toFixed(2)}</span>
+                <div className="text-right">
+                  <span className={cn('font-mono', item.change >= 0 ? 'text-profit' : 'text-loss')}>
+                    {item.change >= 0 ? '+' : ''}
+                    {item.change.toFixed(2)}%
+                  </span>
+                  {item.signalCount > 0 && (
+                    <p className="text-[10px] text-muted-foreground">{item.signalCount} sig</p>
+                  )}
                 </div>
-              )}
-            </CardContent>
-          </Card>
+              </article>
+            ))}
+          </CardContent>
+        </Card>
 
-          {/* Alert Feed */}
+        <Card className="workstation-panel workstation-primary-pane @container/primary">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between gap-3">
+              <CardTitle className="text-heading-card">Market Workspace</CardTitle>
+              <Button variant="ghost" size="sm" asChild className="h-7 px-2 text-xs">
+                <Link href="/markets">
+                  Open detailed market view <ArrowRight className="ml-1 h-3.5 w-3.5" />
+                </Link>
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4 pt-0">
+            <div className="rounded-lg border border-border bg-background/50 p-3 min-h-56">
+              <div className="flex items-center justify-between">
+                <p className="workspace-label">Primary Instrument</p>
+                <Waves className="h-3.5 w-3.5 text-muted-foreground" />
+              </div>
+              <div className="mt-3 grid grid-cols-1 gap-3 @[32rem]/primary:grid-cols-[1.2fr_0.8fr]">
+                <div className="rounded-md border border-border/70 bg-card/40 p-3 min-h-36">
+                  <p className="text-xs text-muted-foreground">
+                    {heroTicker?.ticker ?? 'SPY'} intraday context
+                  </p>
+                  <p className="mt-2 text-data-primary">
+                    <AnimatedNumber value={heroTicker?.price ?? 0} prefix="$" decimals={2} />
+                  </p>
+                  <p
+                    className={cn(
+                      'mt-1 text-xs font-mono',
+                      (heroTicker?.change ?? 0) >= 0 ? 'text-profit' : 'text-loss',
+                    )}
+                  >
+                    {(heroTicker?.change ?? 0) >= 0 ? '+' : ''}
+                    {(heroTicker?.change ?? 0).toFixed(2)}%
+                  </p>
+                </div>
+                <div className="rounded-md border border-border/70 bg-card/40 p-3">
+                  <p className="workspace-label">Session P&L</p>
+                  <p className="mt-2 text-data-primary">
+                    <AnimatedNumber
+                      value={Math.abs(pnl)}
+                      prefix={pnl >= 0 ? '+$' : '-$'}
+                      decimals={2}
+                    />
+                  </p>
+                  <p
+                    className={cn(
+                      'mt-1 text-xs font-mono',
+                      pnlPct >= 0 ? 'text-profit' : 'text-loss',
+                    )}
+                  >
+                    {pnlPct >= 0 ? '+' : ''}
+                    {pnlPct.toFixed(2)}%
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-3 @[38rem]/primary:grid-cols-2">
+              <div className="rounded-md border border-border/70 bg-background/40 p-3">
+                <div className="flex items-center gap-1.5">
+                  <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
+                  <p className="workspace-label">Total Equity</p>
+                  <InfoTooltip content="Total value of all assets including cash and open positions." />
+                </div>
+                <p className="mt-1.5 text-data-primary">
+                  <AnimatedNumber value={equity} prefix="$" decimals={2} />
+                </p>
+              </div>
+              <div className="rounded-md border border-border/70 bg-background/40 p-3">
+                <div className="flex items-center gap-1.5">
+                  <BarChart3 className="h-3.5 w-3.5 text-muted-foreground" />
+                  <p className="workspace-label">Deployable Cash</p>
+                </div>
+                <p className="mt-1.5 text-data-primary">
+                  <AnimatedNumber
+                    value={account?.cash ?? FALLBACK_ACCOUNT.cash}
+                    prefix="$"
+                    decimals={2}
+                  />
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="workstation-ops-rail space-y-3">
+          <IncidentControls />
           <AlertFeed alerts={alerts} />
         </div>
       </section>
 
-      {/* Setup Progress */}
-      <SetupProgress />
+      <section
+        aria-label="Signal and setup band"
+        className="grid grid-cols-1 gap-3 xl:grid-cols-[1.4fr_1fr]"
+      >
+        <Card className="workstation-panel">
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-heading-card">Active Signals</CardTitle>
+            <ListChecks className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </CardHeader>
+          <CardContent>
+            {recentSignals.length === 0 ? (
+              <EmptyState
+                icon={Zap}
+                title="No Recent Signals"
+                description="Strategies generate signals during market hours."
+                className="border-0 bg-transparent py-6"
+              />
+            ) : (
+              <div className="space-y-2" role="list" aria-label="Recent trading signals">
+                {recentSignals.map((s) => (
+                  <article
+                    key={s.id}
+                    className="grid grid-cols-[auto_1fr_auto] items-center gap-2 border-b border-border/50 py-1.5 last:border-0"
+                    role="listitem"
+                  >
+                    <span
+                      className={cn(
+                        'text-[10px] font-bold px-1.5 py-0.5 rounded',
+                        sideColors[s.side] ?? sideColors.buy,
+                      )}
+                    >
+                      {s.side.toUpperCase()}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-foreground">{s.ticker}</p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {s.reason || 'No rationale provided'}
+                      </p>
+                    </div>
+                    {s.strength != null ? (
+                      <span
+                        className={cn(
+                          'text-xs font-mono px-1.5 py-0.5 rounded border',
+                          getSignalStrengthColor(s.strength),
+                        )}
+                      >
+                        {(s.strength * 100).toFixed(0)}%
+                      </span>
+                    ) : (
+                      <AlertTriangle className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                  </article>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-      {/* Onboarding Wizard (shows for new users) */}
+        <SetupProgress />
+      </section>
+
       {onboardingProfile && (
         <OnboardingWizard
           onboardingStep={onboardingProfile.onboarding_step}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -75,7 +75,7 @@ body::before {
   inset: 0;
   z-index: 9999;
   pointer-events: none;
-  opacity: 0.025;
+  opacity: 0.012;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   background-size: 256px 256px;
@@ -88,7 +88,7 @@ body::after {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  opacity: 0.03;
+  opacity: 0.015;
   background-image:
     linear-gradient(oklch(1 0 0 / 15%) 1px, transparent 1px),
     linear-gradient(90deg, oklch(1 0 0 / 15%) 1px, transparent 1px);
@@ -172,6 +172,79 @@ body::after {
 
 .glow-primary {
   box-shadow: 0 0 16px -4px oklch(0.72 0.17 195 / 25%);
+}
+
+/* ── Workstation composition primitives ─────────────────────── */
+
+.workstation-panel {
+  border-color: var(--color-border);
+  background: color-mix(in oklch, var(--color-card) 94%, transparent);
+}
+
+.workstation-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: color-mix(in oklch, var(--color-card) 96%, transparent);
+  padding: 0.5rem 0.75rem;
+}
+
+.workspace-keyline {
+  border-right: 1px solid color-mix(in oklch, var(--color-border) 80%, transparent);
+  padding-right: 0.5rem;
+}
+
+.workstation-strip > .workspace-keyline:last-child {
+  border-right: 0;
+}
+
+.workspace-label {
+  font-size: 0.625rem;
+  line-height: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in oklch, var(--color-muted-foreground) 88%, transparent);
+}
+
+.workspace-value {
+  margin-top: 0.125rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.workstation-grid {
+  display: grid;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.workstation-watchlist,
+.workstation-primary-pane,
+.workstation-ops-rail {
+  min-width: 0;
+}
+
+@media (min-width: 1280px) {
+  .workstation-grid {
+    grid-template-columns: minmax(220px, 0.95fr) minmax(520px, 2fr) minmax(320px, 1fr);
+  }
+}
+
+@media (max-width: 1279px) {
+  .workspace-keyline {
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in oklch, var(--color-border) 80%, transparent);
+    padding-bottom: 0.3rem;
+  }
+  .workstation-strip > .workspace-keyline:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
 }
 
 /* ── Status indicator pulse ─────────────────────────────────── */

--- a/apps/web/src/components/dashboard/alert-feed.tsx
+++ b/apps/web/src/components/dashboard/alert-feed.tsx
@@ -30,35 +30,42 @@ interface AlertFeedProps {
 
 export const AlertFeed = memo(function AlertFeed({ alerts }: AlertFeedProps) {
   return (
-    <Card className="bg-card border-border">
+    <Card className="workstation-panel">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-heading-card">Recent Alerts</CardTitle>
+        <CardTitle className="text-heading-card">Alert Rail</CardTitle>
         <Bell className="h-4 w-4 text-muted-foreground" />
       </CardHeader>
       <CardContent>
         {alerts.length === 0 ? (
           <EmptyStatePreset preset="no-alerts" className="border-0 bg-transparent py-8" />
         ) : (
-          <ScrollArea className="h-[300px]">
-            <div className="space-y-2">
+          <ScrollArea className="h-[360px]" type="always">
+            <div className="space-y-2 pr-2">
               {alerts.map((alert) => (
-                <div
+                <article
                   key={alert.id}
-                  className="flex items-start gap-3 rounded-lg border border-border/60 p-3 hover:bg-accent/50 transition-colors"
+                  className="rounded-md border border-border/60 p-2.5 hover:bg-accent/40 transition-colors"
                 >
-                  <Badge
-                    className={cn('text-[10px] uppercase shrink-0', severityStyles[alert.severity])}
-                  >
-                    {alert.severity}
-                  </Badge>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{alert.title}</p>
-                    <p className="text-xs text-muted-foreground mt-0.5 truncate">{alert.message}</p>
+                  <div className="flex items-center justify-between gap-2">
+                    <Badge
+                      className={cn(
+                        'text-[10px] uppercase shrink-0',
+                        severityStyles[alert.severity],
+                      )}
+                    >
+                      {alert.severity}
+                    </Badge>
+                    <span className="text-[10px] text-muted-foreground/70 shrink-0 font-mono">
+                      {formatTime(alert.triggered_at)}
+                    </span>
                   </div>
-                  <span className="text-[10px] text-muted-foreground/60 shrink-0 font-mono">
-                    {formatTime(alert.triggered_at)}
-                  </span>
-                </div>
+                  <p className="mt-1 text-xs font-medium text-foreground line-clamp-1">
+                    {alert.title}
+                  </p>
+                  <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground line-clamp-2">
+                    {alert.message}
+                  </p>
+                </article>
               ))}
             </div>
           </ScrollArea>

--- a/apps/web/src/components/dashboard/incident-controls.tsx
+++ b/apps/web/src/components/dashboard/incident-controls.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { AlertOctagon, ShieldAlert, Activity, Clock, OctagonX } from 'lucide-react';
-import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import {
@@ -14,16 +13,16 @@ import {
 } from '@/hooks/queries';
 
 const MODE_STYLES: Record<string, string> = {
-  live: 'bg-red-500/15 text-red-400',
-  backtest: 'bg-blue-500/15 text-blue-400',
-  paper: 'bg-amber-500/15 text-amber-400',
+  live: 'text-loss',
+  backtest: 'text-blue-400',
+  paper: 'text-amber-400',
 };
 
 const ACTION_LABELS: Record<string, string> = {
   halt_trading: 'Halted trading',
   resume_trading: 'Resumed trading',
-  approve_recommendation: 'Approved rec',
-  reject_recommendation: 'Rejected rec',
+  approve_recommendation: 'Approved recommendation',
+  reject_recommendation: 'Rejected recommendation',
   update_policy: 'Updated policy',
   change_mode: 'Changed mode',
   override_risk: 'Risk override',
@@ -74,110 +73,101 @@ export function IncidentControls() {
   };
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      {/* System Mode Indicator */}
-      <Card className="bg-card border-border">
-        <CardContent className="p-4">
-          <div className="flex items-center gap-1.5">
+    <section
+      aria-label="Intervention controls"
+      className="workstation-panel @container/interventions space-y-3 px-3 py-3 sm:px-4"
+    >
+      <div className="grid grid-cols-1 gap-2.5 border-b border-border/80 pb-3 @[26rem]/interventions:grid-cols-3">
+        <div className="workspace-keyline">
+          <p className="workspace-label">Trading Mode</p>
+          <div className="mt-1.5 flex items-center gap-2">
             <Activity className="h-3.5 w-3.5 text-muted-foreground" />
-            <p className="text-xs text-muted-foreground">System Mode</p>
-          </div>
-          <div className="mt-2 flex items-center gap-2">
-            <span className={cn('rounded px-2 py-0.5 text-sm font-semibold uppercase', modeColor)}>
-              {mode}
-            </span>
+            <span className={cn('text-sm font-semibold uppercase', modeColor)}>{mode}</span>
             {isHalted && (
-              <span className="rounded bg-red-500/20 px-2 py-0.5 text-sm font-bold text-red-400 animate-pulse">
-                HALTED
+              <span className="rounded bg-loss/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-loss">
+                halted
               </span>
             )}
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
-      {/* Emergency Halt Button */}
-      <Card className="bg-card border-border">
-        <CardContent className="p-4">
-          <div className="flex items-center gap-1.5 mb-2">
-            <ShieldAlert className="h-3.5 w-3.5 text-muted-foreground" />
-            <p className="text-xs text-muted-foreground">Emergency Controls</p>
-          </div>
-          {!showConfirm ? (
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => setShowConfirm(true)}
-              disabled={isHalted || haltMutation.isPending}
-              className="w-full"
+        <div className="workspace-keyline">
+          <p className="workspace-label">Critical Incidents</p>
+          <div className="mt-1.5 flex items-center gap-2">
+            <AlertOctagon className="h-3.5 w-3.5 text-muted-foreground" />
+            <span
+              className={cn(
+                'text-sm font-semibold',
+                criticalCount > 0 ? 'text-loss' : 'text-foreground',
+              )}
             >
-              <OctagonX className="h-3.5 w-3.5 mr-1" />
-              {isHalted ? 'Trading Halted' : 'Emergency Halt'}
-            </Button>
-          ) : (
-            <div className="space-y-2">
-              <p className="text-xs text-red-400 font-medium">Confirm halt all trading?</p>
-              <div className="flex gap-2">
+              {criticalCount}
+            </span>
+            <span className="text-xs text-muted-foreground">unresolved</span>
+          </div>
+        </div>
+
+        <div className="workspace-keyline">
+          <p className="workspace-label">Emergency</p>
+          <div className="mt-1.5">
+            {!showConfirm ? (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setShowConfirm(true)}
+                disabled={isHalted || haltMutation.isPending}
+                className="h-8 w-full justify-center text-xs"
+              >
+                <OctagonX className="mr-1.5 h-3.5 w-3.5" />
+                {isHalted ? 'Trading Halted' : 'Trigger Halt'}
+              </Button>
+            ) : (
+              <div className="flex items-center gap-1.5">
                 <Button
                   variant="destructive"
                   size="xs"
                   onClick={handleHalt}
                   disabled={haltMutation.isPending}
                 >
-                  {haltMutation.isPending ? 'Halting…' : 'Confirm Halt'}
+                  {haltMutation.isPending ? 'Halting…' : 'Confirm'}
                 </Button>
                 <Button variant="outline" size="xs" onClick={() => setShowConfirm(false)}>
                   Cancel
                 </Button>
               </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Active Incident Count */}
-      <Card className="bg-card border-border">
-        <CardContent className="p-4">
-          <div className="flex items-center gap-1.5">
-            <AlertOctagon className="h-3.5 w-3.5 text-muted-foreground" />
-            <p className="text-xs text-muted-foreground">Active Incidents</p>
-          </div>
-          <p
-            className={cn(
-              'mt-1 text-2xl font-bold',
-              criticalCount > 0 ? 'text-red-400' : 'text-foreground',
             )}
-          >
-            {criticalCount}
-          </p>
-          <p className="text-xs text-muted-foreground">critical unresolved</p>
-        </CardContent>
-      </Card>
-
-      {/* Recent Operator Actions Feed */}
-      <Card className="bg-card border-border">
-        <CardContent className="p-4">
-          <div className="flex items-center gap-1.5 mb-2">
-            <Clock className="h-3.5 w-3.5 text-muted-foreground" />
-            <p className="text-xs text-muted-foreground">Recent Actions</p>
           </div>
-          {recentActions.length === 0 ? (
-            <p className="text-xs text-muted-foreground py-2">No recent operator actions</p>
-          ) : (
-            <div className="space-y-1.5">
-              {recentActions.slice(0, 5).map((action) => (
-                <div key={action.id} className="flex items-start gap-1.5 text-xs">
-                  <span className="text-muted-foreground shrink-0">
-                    {formatActionTime(action.created_at)}
-                  </span>
-                  <span className="text-foreground truncate">
-                    {ACTION_LABELS[action.action_type] ?? action.action_type.replace(/_/g, ' ')}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Clock className="h-3.5 w-3.5" /> Recent interventions
+        </div>
+        {recentActions.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No operator actions in the current session.
+          </p>
+        ) : (
+          <ul className="space-y-1" role="list">
+            {recentActions.slice(0, 5).map((action) => (
+              <li
+                key={action.id}
+                className="grid grid-cols-[3.25rem_1fr] items-start gap-2 text-xs"
+                role="listitem"
+              >
+                <span className="font-mono text-muted-foreground">
+                  {formatActionTime(action.created_at)}
+                </span>
+                <span className="truncate text-foreground/90">
+                  <ShieldAlert className="mr-1 inline h-3 w-3 text-muted-foreground" />
+                  {ACTION_LABELS[action.action_type] ?? action.action_type.replace(/_/g, ' ')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -6,10 +6,8 @@ import { usePathname } from 'next/navigation';
 import {
   LayoutDashboard,
   TrendingUp,
-  Brain,
   Zap,
   PieChart,
-  FlaskConical,
   Bot,
   BookOpen,
   GitCompareArrows,
@@ -19,12 +17,10 @@ import {
   Clock,
   Calendar,
   Shield,
-  ShieldCheck,
   ClipboardList,
   Settings,
   ChevronLeft,
   ChevronRight,
-  Power,
   CheckSquare,
   ArrowUpDown,
   Workflow,
@@ -33,58 +29,49 @@ import {
   Loader2,
   Sparkles,
   type LucideIcon,
+  Landmark,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 
 type NavItem = { label: string; href: string; icon: LucideIcon };
-type NavSection = { section: string; items: NavItem[] };
 
-const navSections: NavSection[] = [
+type NavGroup = {
+  section: string;
+  priority: 'primary' | 'secondary';
+  items: NavItem[];
+};
+
+const navGroups: NavGroup[] = [
   {
-    section: 'Overview',
+    section: 'Core Workflows',
+    priority: 'primary',
     items: [
       { label: 'Dashboard', href: '/', icon: LayoutDashboard },
       { label: 'Markets', href: '/markets', icon: TrendingUp },
+      { label: 'Portfolio', href: '/portfolio', icon: PieChart },
+      { label: 'Signals', href: '/signals', icon: Zap },
+      { label: 'Orders', href: '/orders', icon: ArrowUpDown },
+      { label: 'Agents', href: '/agents', icon: Bot },
+      { label: 'Governance', href: '/system-controls', icon: Landmark },
     ],
   },
   {
-    section: 'Trading',
+    section: 'Research & Support',
+    priority: 'secondary',
     items: [
-      { label: 'Strategies', href: '/strategies', icon: Brain },
-      { label: 'Signals', href: '/signals', icon: Zap },
-      { label: 'Portfolio', href: '/portfolio', icon: PieChart },
-      { label: 'Orders', href: '/orders', icon: ArrowUpDown },
       { label: 'Journal', href: '/journal', icon: BookOpen },
       { label: 'Advisor', href: '/advisor', icon: Sparkles },
-    ],
-  },
-  {
-    section: 'Analysis',
-    items: [
       { label: 'What If', href: '/counterfactuals', icon: GitCompareArrows },
-      { label: 'Shadow', href: '/shadow-portfolios', icon: Layers },
+      { label: 'Shadow Portfolios', href: '/shadow-portfolios', icon: Layers },
       { label: 'Regime', href: '/regime', icon: Gauge },
       { label: 'Data Quality', href: '/data-quality', icon: Database },
       { label: 'Replay', href: '/replay', icon: Clock },
       { label: 'Catalysts', href: '/catalysts', icon: Calendar },
-      { label: 'Backtest', href: '/backtest', icon: FlaskConical },
-    ],
-  },
-  {
-    section: 'Operations',
-    items: [
-      { label: 'Agents', href: '/agents', icon: Bot },
+      { label: 'Backtest', href: '/backtest', icon: Beaker },
       { label: 'Experiment', href: '/experiment', icon: Beaker },
       { label: 'Approvals', href: '/approvals', icon: CheckSquare },
       { label: 'Workflows', href: '/workflows', icon: Workflow },
-    ],
-  },
-  {
-    section: 'Governance',
-    items: [
-      { label: 'Controls', href: '/system-controls', icon: Power },
-      { label: 'Autonomy', href: '/autonomy', icon: ShieldCheck },
       { label: 'Roles', href: '/roles', icon: Shield },
       { label: 'Audit Log', href: '/audit-log', icon: ClipboardList },
       { label: 'Settings', href: '/settings', icon: Settings },
@@ -93,6 +80,7 @@ const navSections: NavSection[] = [
 ];
 
 const COLLAPSE_KEY = 'sentinel-sidebar-collapsed';
+const SECONDARY_OPEN_KEY = 'sentinel-sidebar-secondary-open';
 
 interface SidebarProps {
   collapsed?: boolean;
@@ -103,13 +91,16 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
   const pathname = usePathname();
   const queryClient = useQueryClient();
   const [signingOut, setSigningOut] = useState(false);
+  const [secondaryOpen, setSecondaryOpen] = useState(false);
 
-  // Persist collapse state in localStorage
   const [internalCollapsed, setInternalCollapsed] = useState(false);
   useEffect(() => {
     try {
       const saved = localStorage.getItem(COLLAPSE_KEY);
       if (saved === 'true') setInternalCollapsed(true);
+
+      const savedSecondary = localStorage.getItem(SECONDARY_OPEN_KEY);
+      setSecondaryOpen(savedSecondary === 'true');
     } catch {
       /* noop */
     }
@@ -131,27 +122,32 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
     }
   };
 
+  const persistSecondaryState = (next: boolean) => {
+    setSecondaryOpen(next);
+    try {
+      localStorage.setItem(SECONDARY_OPEN_KEY, String(next));
+    } catch {
+      /* noop */
+    }
+  };
+
   return (
     <aside
       className={cn(
-        'flex h-screen flex-col border-r border-border bg-sidebar transition-all duration-300 relative',
-        collapsed ? 'w-16' : 'w-56',
+        'flex h-screen flex-col border-r border-border bg-sidebar transition-all duration-300',
+        collapsed ? 'w-16' : 'w-60',
       )}
     >
-      {/* Accent line along right edge */}
-      <div className="absolute right-0 top-0 bottom-0 w-px bg-gradient-to-b from-primary/40 via-primary/10 to-transparent" />
-
-      {/* Logo area */}
       <div className="flex h-14 items-center justify-between border-b border-border px-4">
         {!collapsed && (
           <div className="flex items-center gap-2.5">
-            <div className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-            <span className="font-mono text-xs font-bold tracking-[0.25em] text-primary">
+            <div className="h-1.5 w-1.5 rounded-full bg-primary" />
+            <span className="font-mono text-xs font-bold tracking-[0.25em] text-foreground/85">
               SENTINEL
             </span>
           </div>
         )}
-        {collapsed && <div className="h-2 w-2 rounded-full bg-primary animate-pulse mx-auto" />}
+        {collapsed && <div className="h-1.5 w-1.5 rounded-full bg-primary mx-auto" />}
         <button
           type="button"
           onClick={handleToggle}
@@ -170,18 +166,78 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
         </button>
       </div>
 
-      {/* Navigation */}
       <nav aria-label="Main navigation" className="flex-1 overflow-y-auto px-2 py-3">
-        {navSections.map((section) => (
-          <div key={section.section} role="group" aria-label={section.section} className="mb-4">
-            {!collapsed && (
-              <p className="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/50">
-                {section.section}
-              </p>
-            )}
-            {collapsed && <div className="mx-auto my-2 h-px w-6 bg-border/60" />}
-            <ul className="space-y-0.5">
-              {section.items.map((item) => {
+        {navGroups
+          .filter((group) => group.priority === 'primary')
+          .map((group) => (
+            <div key={group.section} role="group" aria-label={group.section} className="mb-4">
+              {!collapsed && (
+                <p className="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/50">
+                  {group.section}
+                </p>
+              )}
+              <ul className="space-y-0.5">
+                {group.items.map((item) => {
+                  const isActive =
+                    item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
+
+                  return (
+                    <li key={item.href} className="relative group">
+                      <Link
+                        href={item.href}
+                        prefetch={false}
+                        aria-current={isActive ? 'page' : undefined}
+                        className={cn(
+                          'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+                          isActive
+                            ? 'bg-primary/12 text-primary'
+                            : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
+                          collapsed && 'justify-center px-2',
+                        )}
+                        title={collapsed ? item.label : undefined}
+                      >
+                        <item.icon
+                          className={cn(
+                            'h-4 w-4 shrink-0 transition-colors',
+                            isActive
+                              ? 'text-primary'
+                              : 'text-muted-foreground group-hover:text-foreground',
+                          )}
+                        />
+                        {!collapsed && <span>{item.label}</span>}
+                      </Link>
+                      {collapsed && (
+                        <div className="pointer-events-none absolute left-full top-1/2 -translate-y-1/2 ml-2 z-50 hidden group-hover:flex items-center">
+                          <div className="whitespace-nowrap rounded-md bg-foreground px-2 py-1 text-xs font-medium text-background shadow-lg animate-tooltip">
+                            {item.label}
+                          </div>
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+
+        <details
+          open={secondaryOpen}
+          onToggle={(event) =>
+            persistSecondaryState((event.currentTarget as HTMLDetailsElement).open)
+          }
+          className={cn('mt-3 border-t border-border/80 pt-3', collapsed && 'border-t-0 pt-1')}
+        >
+          {!collapsed && (
+            <summary className="cursor-pointer list-none select-none rounded-md px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/55 hover:bg-accent/30">
+              Secondary Surfaces
+            </summary>
+          )}
+
+          <ul className={cn('space-y-0.5', !collapsed && 'mt-1.5')}>
+            {navGroups
+              .filter((group) => group.priority === 'secondary')
+              .flatMap((group) => group.items)
+              .map((item) => {
                 const isActive =
                   item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
 
@@ -192,25 +248,18 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
                       prefetch={false}
                       aria-current={isActive ? 'page' : undefined}
                       className={cn(
-                        'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+                        'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
                         isActive
                           ? 'bg-primary/10 text-primary'
-                          : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
+                          : 'text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground',
+                        !isActive && 'opacity-85',
                         collapsed && 'justify-center px-2',
                       )}
                       title={collapsed ? item.label : undefined}
                     >
-                      <item.icon
-                        className={cn(
-                          'h-4 w-4 shrink-0 transition-colors',
-                          isActive
-                            ? 'text-primary'
-                            : 'text-muted-foreground group-hover:text-foreground',
-                        )}
-                      />
+                      <item.icon className="h-4 w-4 shrink-0" />
                       {!collapsed && <span>{item.label}</span>}
                     </Link>
-                    {/* Tooltip for collapsed mode */}
                     {collapsed && (
                       <div className="pointer-events-none absolute left-full top-1/2 -translate-y-1/2 ml-2 z-50 hidden group-hover:flex items-center">
                         <div className="whitespace-nowrap rounded-md bg-foreground px-2 py-1 text-xs font-medium text-background shadow-lg animate-tooltip">
@@ -221,12 +270,10 @@ export function Sidebar({ collapsed: controlledCollapsed, onToggle }: SidebarPro
                   </li>
                 );
               })}
-            </ul>
-          </div>
-        ))}
+          </ul>
+        </details>
       </nav>
 
-      {/* Footer */}
       <div className="border-t border-border p-4 space-y-3">
         <button
           type="button"

--- a/apps/web/tests/components/layout/sidebar-a11y.test.tsx
+++ b/apps/web/tests/components/layout/sidebar-a11y.test.tsx
@@ -50,9 +50,9 @@ describe('Sidebar accessibility', () => {
   });
 
   it('active link has aria-current="page"', () => {
-    mockPathname.mockReturnValue('/strategies');
+    mockPathname.mockReturnValue('/portfolio');
     render(<Sidebar />);
-    const link = screen.getByRole('link', { name: /Strategies/i });
+    const link = screen.getByRole('link', { name: /^Portfolio$/i });
     expect(link).toHaveAttribute('aria-current', 'page');
   });
 
@@ -78,12 +78,8 @@ describe('Sidebar accessibility', () => {
   it('nav sections have group role with aria-label', () => {
     render(<Sidebar />);
     const groups = screen.getAllByRole('group');
-    expect(groups.length).toBe(5);
-    expect(groups[0]).toHaveAttribute('aria-label', 'Overview');
-    expect(groups[1]).toHaveAttribute('aria-label', 'Trading');
-    expect(groups[2]).toHaveAttribute('aria-label', 'Analysis');
-    expect(groups[3]).toHaveAttribute('aria-label', 'Operations');
-    expect(groups[4]).toHaveAttribute('aria-label', 'Governance');
+    expect(groups.length).toBe(2);
+    expect(groups[0]).toHaveAttribute('aria-label', 'Core Workflows');
   });
 });
 

--- a/apps/web/tests/pages/dashboard.test.tsx
+++ b/apps/web/tests/pages/dashboard.test.tsx
@@ -34,19 +34,19 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Total Equity')).toBeInTheDocument();
   });
 
-  it('renders the Daily P&L metric card label', () => {
+  it('renders the Session P&L metric label', () => {
     renderWithProviders(<DashboardPage />);
-    expect(screen.getByText('Daily P&L')).toBeInTheDocument();
+    expect(screen.getByText('Session P&L')).toBeInTheDocument();
   });
 
-  it('renders the Cash Available metric card label', () => {
+  it('renders the Deployable Cash metric label', () => {
     renderWithProviders(<DashboardPage />);
-    expect(screen.getByText('Cash Available')).toBeInTheDocument();
+    expect(screen.getByText('Deployable Cash')).toBeInTheDocument();
   });
 
-  it('renders the Positions Value metric card label', () => {
+  it('renders Watchlist panel', () => {
     renderWithProviders(<DashboardPage />);
-    expect(screen.getByText('Positions Value')).toBeInTheDocument();
+    expect(screen.getByText('Watchlist')).toBeInTheDocument();
   });
 
   it('renders Active Signals card', () => {
@@ -61,15 +61,15 @@ describe('DashboardPage', () => {
 
   // --- Semantic HTML ---
 
-  it('wraps system health in a section with aria-label', () => {
+  it('wraps system state in a section with aria-label', () => {
     renderWithProviders(<DashboardPage />);
-    const section = screen.getByLabelText('System health status');
+    const section = screen.getByLabelText('System state');
     expect(section.tagName).toBe('SECTION');
   });
 
-  it('wraps portfolio metrics in a section with aria-label', () => {
+  it('wraps trading workstation in a section with aria-label', () => {
     renderWithProviders(<DashboardPage />);
-    const section = screen.getByLabelText('Portfolio metrics');
+    const section = screen.getByLabelText('Trading workstation');
     expect(section.tagName).toBe('SECTION');
   });
 
@@ -79,17 +79,17 @@ describe('DashboardPage', () => {
     expect(section.tagName).toBe('SECTION');
   });
 
-  it('wraps signals and alerts in a section with aria-label', () => {
+  it('wraps signal and setup band in a section with aria-label', () => {
     renderWithProviders(<DashboardPage />);
-    const section = screen.getByLabelText('Signals and alerts');
+    const section = screen.getByLabelText('Signal and setup band');
     expect(section.tagName).toBe('SECTION');
   });
 
   // --- System Health Strip ---
 
-  it('displays default system health values when offline', () => {
+  it('displays default system values when offline', () => {
     renderWithProviders(<DashboardPage />);
-    const healthSection = screen.getByLabelText('System health status');
+    const healthSection = screen.getByLabelText('System state');
     expect(within(healthSection).getByText('Active')).toBeInTheDocument();
     expect(within(healthSection).getByText('paper')).toBeInTheDocument();
     expect(within(healthSection).getByText('0')).toBeInTheDocument();
@@ -108,7 +108,7 @@ describe('DashboardPage', () => {
 
   it('marks decorative icons as aria-hidden', () => {
     renderWithProviders(<DashboardPage />);
-    const healthSection = screen.getByLabelText('System health status');
+    const healthSection = screen.getByLabelText('System state');
     const hiddenIcons = healthSection.querySelectorAll('[aria-hidden="true"]');
     // Icons + separator pipes
     expect(hiddenIcons.length).toBeGreaterThanOrEqual(4);

--- a/docs/ai/state/project-state.md
+++ b/docs/ai/state/project-state.md
@@ -122,3 +122,4 @@ When you finish a ticket:
 1. Mark it `done`.
 2. Add a one-line summary of what changed.
 3. Record exact validation commands and status in the handoff/PR.
+   | DESK-WS-01 | done | Codex | `work` | `apps/web/src/components/layout/sidebar.tsx`, `apps/web/src/app/(dashboard)/page.tsx`, `apps/web/src/components/dashboard/*`, `apps/web/src/app/globals.css`, `apps/web/tests/pages/dashboard.test.tsx`, `apps/web/tests/components/layout/sidebar-a11y.test.tsx`, `docs/ai/state/project-state.md` | `pnpm lint`; `pnpm test:web`; `git diff --check` | 2026-04-08 | Reworked desktop dashboard into pane-first workstation, curated sidebar hierarchy, and updated web tests for revised IA and composition. |


### PR DESCRIPTION
### Motivation
- Convert the card-led desktop dashboard into a more purposeful, pane-first trading workstation that uses desktop width to show relationships and reduce equal-weight card noise.  
- Reduce navigation sprawl by surfacing a curated set of primary workflows and demoting secondary surfaces so the sidebar communicates product confidence.  
- Improve operational surfaces (alerts, incident controls) to feel denser, keyboard-friendly, and more production-ready without changing shell chrome.

### Description
- Recompose the dashboard into a workstation layout with a top state strip, left watchlist, dominant center Market Workspace, right intervention/alert rail, and lower signal/setup band by editing `apps/web/src/app/(dashboard)/page.tsx`.  
- Curate the sidebar IA into `Core Workflows` (primary) and a collapsible `Research & Support` (secondary) group with persisted secondary open state by editing `apps/web/src/components/layout/sidebar.tsx`.  
- Add reusable workstation composition primitives and tone-down ambient texture in `apps/web/src/app/globals.css` (`workstation-strip`, `workstation-grid`, `workstation-panel`, `workspace-label`, `workspace-value`).  
- Refactor operational surfaces: compact `IncidentControls` and denser fixed-height `Alert Rail` for monitoring in `apps/web/src/components/dashboard/incident-controls.tsx` and `apps/web/src/components/dashboard/alert-feed.tsx`.  
- Update unit/semantics tests to match new section labels and IA in `apps/web/tests/pages/dashboard.test.tsx` and `apps/web/tests/components/layout/sidebar-a11y.test.tsx`, and record completion in `docs/ai/state/project-state.md`.

### Testing
- `pnpm lint` — ✅ PASS — workspace lint ran and completed with no blocking errors.  
- `pnpm test:web` — ✅ PASS — web tests completed: `107` test files, `1169` tests all passed.  
- `git diff --check` — ✅ PASS — no whitespace or check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69b0103dc832c85726b38d36499aa)