### PR TITLE
fix(markets): gracefully degrade chart when bars endpoint errors

### DIFF
--- a/apps/web/src/app/(dashboard)/backtest/page.tsx
+++ b/apps/web/src/app/(dashboard)/backtest/page.tsx
@@ -19,6 +19,7 @@ import { TradeLog } from '@/components/backtest/trade-log';
 import { runSyntheticBacktest, type BacktestResult } from '@/components/backtest/synthetic-runner';
 import { type EngineBacktestResponse, parsePct } from '@/components/backtest/engine-types';
 import { engineUrl, engineHeaders } from '@/lib/engine-fetch';
+import { humanizeFetchError } from '@/lib/humanize-fetch-error';
 
 /** Execution source of the most recent backtest run. */
 type ExecutionSource = 'engine' | 'synthetic';
@@ -89,8 +90,7 @@ export default function BacktestPage() {
       ran = true;
       setExecutionSource('engine');
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Engine unavailable — unknown error';
-      setEngineError(message);
+      setEngineError(humanizeFetchError(error, { subject: 'backtest engine' }));
     }
 
     if (!ran) {

--- a/apps/web/src/app/(dashboard)/journal/page.tsx
+++ b/apps/web/src/app/(dashboard)/journal/page.tsx
@@ -16,11 +16,14 @@ import {
   ShoppingCart,
   Link as LinkIcon,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useJournalQuery, useJournalStatsQuery, useGradeJournalMutation } from '@/hooks/queries';
 import type { JournalEntry, TradeGrade } from '@sentinel/shared';
 import Link from 'next/link';
 import { PAGE_SIZE_JOURNAL } from '@/lib/constants';
+import { humanizeFetchError } from '@/lib/humanize-fetch-error';
+import { RotateCcw } from 'lucide-react';
 
 // ─── Constants ────────────────────────────────────────────────────────
 
@@ -353,10 +356,11 @@ export default function JournalPage() {
     [eventFilter, tickerFilter, page],
   );
 
-  const { data, isLoading, isError } = useJournalQuery(filters);
+  const { data, isLoading, isError, error, refetch } = useJournalQuery(filters);
   const entries = data?.entries ?? [];
   const totalEntries = data?.total ?? 0;
   const totalPages = Math.ceil(totalEntries / PAGE_SIZE_JOURNAL);
+  const hasStaleData = entries.length > 0;
 
   return (
     <div className="space-y-6 page-enter">
@@ -429,15 +433,44 @@ export default function JournalPage() {
         </div>
       )}
 
-      {isError && (
+      {isError && hasStaleData && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200"
+        >
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span className="flex-1">
+            {humanizeFetchError(error, { subject: 'journal entries' })} Showing previously loaded
+            entries.
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void refetch()}
+            className="h-7 gap-1 px-2 text-xs text-amber-100 hover:bg-amber-500/20 hover:text-amber-50"
+          >
+            <RotateCcw className="h-3 w-3" />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {isError && !hasStaleData && (
         <Card className="border-red-900/50 bg-red-950/20">
-          <CardContent className="p-6 text-center text-red-400">
-            Failed to load journal entries. Please try again.
+          <CardContent className="flex flex-col items-center gap-3 p-6 text-center">
+            <p className="text-sm text-red-400">
+              {humanizeFetchError(error, { subject: 'journal entries' })}
+            </p>
+            <Button variant="outline" size="sm" onClick={() => void refetch()} className="gap-1.5">
+              <RotateCcw className="h-4 w-4" />
+              Try Again
+            </Button>
           </CardContent>
         </Card>
       )}
 
-      {!isLoading && !isError && entries.length === 0 && (
+      {!isLoading && (!isError || hasStaleData) && entries.length === 0 && (
         <Card className="border-zinc-800 bg-zinc-900/50">
           <CardContent className="p-12 text-center">
             <BookOpen className="mx-auto h-10 w-10 text-zinc-700" />
@@ -449,7 +482,7 @@ export default function JournalPage() {
         </Card>
       )}
 
-      {!isLoading && !isError && entries.length > 0 && (
+      {!isLoading && entries.length > 0 && (
         <div className="space-y-3">
           {entries.map((entry) => (
             <JournalCard key={entry.id} entry={entry} />

--- a/apps/web/src/app/(dashboard)/markets/page.tsx
+++ b/apps/web/src/app/(dashboard)/markets/page.tsx
@@ -7,6 +7,8 @@ const PriceChart = dynamic(
   () => import('@/components/charts/price-chart').then((m) => ({ default: m.PriceChart })),
   { ssr: false },
 );
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { OfflineBanner } from '@/components/ui/offline-banner';
@@ -111,6 +113,18 @@ function MarketsContent() {
   const quotesMode = isLive ? 'live' : engineOnline === false ? 'offline' : 'cached';
   const chartMode = bars && bars.length > 0 ? 'live' : 'simulated';
 
+  const barsErrorMessage = useMemo(() => {
+    if (!barsError) return null;
+    const raw = barsErrorObj?.message ?? '';
+    const match = raw.match(/Bars fetch failed:\s*(\d+)/);
+    const status = match ? Number(match[1]) : null;
+    if (status === 503) return 'Live market data is temporarily unavailable upstream.';
+    if (status === 429) return 'Live market data rate limit reached. Please retry shortly.';
+    if (status === 404) return 'No historical bars found for this ticker.';
+    if (status && status >= 500) return 'The market data service is having trouble right now.';
+    return 'Could not load live price history.';
+  }, [barsError, barsErrorObj]);
+
   const watchlist: WatchlistItem[] = useMemo(() => {
     if (!quotes)
       return engineOnline === false
@@ -190,20 +204,30 @@ function MarketsContent() {
                 </div>
               </CardHeader>
               <CardContent className="min-h-[18rem] p-0 px-2 pb-2 sm:px-4 sm:pb-4 lg:min-h-[30rem]">
-                {barsError && engineOnline === true ? (
-                  <ErrorState
-                    title="Chart data unavailable"
-                    message={barsErrorObj?.message ?? 'Could not load price history.'}
-                    onRetry={() => refetchBars()}
-                    className="flex h-full items-center justify-center"
-                  />
-                ) : (
-                  <PriceChart
-                    data={chartData}
-                    loading={chartLoading || loading}
-                    className="rounded-md"
-                  />
+                {barsError && engineOnline === true && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="mx-2 mt-2 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200 sm:mx-0"
+                  >
+                    <AlertTriangle className="h-4 w-4 shrink-0" />
+                    <span className="flex-1">{barsErrorMessage} Showing simulated data.</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => refetchBars()}
+                      className="h-7 gap-1 px-2 text-xs text-amber-100 hover:bg-amber-500/20 hover:text-amber-50"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      Retry
+                    </Button>
+                  </div>
                 )}
+                <PriceChart
+                  data={chartData}
+                  loading={chartLoading || loading}
+                  className="rounded-md"
+                />
               </CardContent>
             </Card>
           }

--- a/apps/web/src/app/(dashboard)/markets/page.tsx
+++ b/apps/web/src/app/(dashboard)/markets/page.tsx
@@ -33,6 +33,7 @@ import {
 import { useAppStore } from '@/stores/app-store';
 import { cn } from '@/lib/utils';
 import { getStatusColors } from '@/lib/status-colors';
+import { humanizeFetchError } from '@/lib/humanize-fetch-error';
 import type { OHLCV } from '@sentinel/shared';
 import { useQuotesQuery, useBarsQuery } from '@/hooks/queries';
 import {
@@ -115,14 +116,7 @@ function MarketsContent() {
 
   const barsErrorMessage = useMemo(() => {
     if (!barsError) return null;
-    const raw = barsErrorObj?.message ?? '';
-    const match = raw.match(/Bars fetch failed:\s*(\d+)/);
-    const status = match ? Number(match[1]) : null;
-    if (status === 503) return 'Live market data is temporarily unavailable upstream.';
-    if (status === 429) return 'Live market data rate limit reached. Please retry shortly.';
-    if (status === 404) return 'No historical bars found for this ticker.';
-    if (status && status >= 500) return 'The market data service is having trouble right now.';
-    return 'Could not load live price history.';
+    return humanizeFetchError(barsErrorObj, { subject: 'live price history' });
   }, [barsError, barsErrorObj]);
 
   const watchlist: WatchlistItem[] = useMemo(() => {
@@ -149,7 +143,7 @@ function MarketsContent() {
       <PageContainer className="page-enter" density="compact">
         <ErrorState
           title="Failed to load market data"
-          message={quotesErrorObj?.message ?? 'Could not fetch quotes from the engine.'}
+          message={humanizeFetchError(quotesErrorObj, { subject: 'market quotes' })}
           onRetry={() => refetchQuotes()}
         />
       </PageContainer>

--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useMemo, useCallback } from 'react';
-import { ArrowUpDown, Activity } from 'lucide-react';
+import { ArrowUpDown, Activity, AlertTriangle, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { ErrorState } from '@/components/ui/error-state';
 import { ErrorBoundary } from '@/components/error-boundary';
@@ -11,6 +12,7 @@ import type { Fill, RiskEvaluation } from '@sentinel/shared';
 import type { OrderHistoryEntry } from '@/hooks/queries/use-order-history-query';
 import type { SortState } from '@/components/ui/table';
 import { PAGE_SIZE_ORDERS } from '@/lib/constants';
+import { humanizeFetchError } from '@/lib/humanize-fetch-error';
 import {
   StatsRow,
   OrderFilters,
@@ -46,11 +48,46 @@ export default function OrdersPage() {
   const ordersQuery = useOrderHistoryQuery(200);
 
   const isLoading = fillsQuery.isLoading || riskQuery.isLoading || ordersQuery.isLoading;
-  const isError = fillsQuery.isError || riskQuery.isError || ordersQuery.isError;
 
   const fills = useMemo(() => fillsQuery.data?.data ?? [], [fillsQuery.data]);
   const riskEvals = useMemo(() => riskQuery.data?.data ?? [], [riskQuery.data]);
   const orders = useMemo(() => ordersQuery.data ?? [], [ordersQuery.data]);
+
+  const failedSources = useMemo(() => {
+    const sources: { label: string; message: string }[] = [];
+    if (fillsQuery.isError)
+      sources.push({
+        label: 'Fills',
+        message: humanizeFetchError(fillsQuery.error, { subject: 'fills' }),
+      });
+    if (riskQuery.isError)
+      sources.push({
+        label: 'Risk evaluations',
+        message: humanizeFetchError(riskQuery.error, { subject: 'risk evaluations' }),
+      });
+    if (ordersQuery.isError)
+      sources.push({
+        label: 'Orders',
+        message: humanizeFetchError(ordersQuery.error, { subject: 'order history' }),
+      });
+    return sources;
+  }, [
+    fillsQuery.isError,
+    fillsQuery.error,
+    riskQuery.isError,
+    riskQuery.error,
+    ordersQuery.isError,
+    ordersQuery.error,
+  ]);
+
+  const allFailed = failedSources.length === 3;
+  const hasPartialFailure = failedSources.length > 0 && !allFailed;
+
+  const retryAll = useCallback(() => {
+    void fillsQuery.refetch();
+    void riskQuery.refetch();
+    void ordersQuery.refetch();
+  }, [fillsQuery, riskQuery, ordersQuery]);
 
   // Build unified timeline
   const timeline = useMemo(() => {
@@ -234,19 +271,39 @@ export default function OrdersPage() {
           </div>
         )}
 
-        {isError && (
+        {hasPartialFailure && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200"
+          >
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span className="flex-1">
+              Some data sources failed to load:{' '}
+              {failedSources.map((s) => `${s.label} — ${s.message}`).join(' · ')} Showing available
+              entries.
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={retryAll}
+              className="h-7 gap-1 px-2 text-xs text-amber-100 hover:bg-amber-500/20 hover:text-amber-50"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {allFailed && (
           <ErrorState
             title="Failed to load data"
-            message="Failed to load execution data. Please try again."
-            onRetry={() => {
-              void fillsQuery.refetch();
-              void riskQuery.refetch();
-              void ordersQuery.refetch();
-            }}
+            message={failedSources[0]?.message ?? 'Could not load execution data.'}
+            onRetry={retryAll}
           />
         )}
 
-        {!isLoading && !isError && pagedEntries.length === 0 && (
+        {!isLoading && !allFailed && pagedEntries.length === 0 && (
           <Card className="border-zinc-800 bg-zinc-900/50">
             <CardContent className="p-12 text-center">
               <Activity className="mx-auto h-10 w-10 text-zinc-700" />
@@ -258,7 +315,7 @@ export default function OrdersPage() {
           </Card>
         )}
 
-        {!isLoading && !isError && pagedEntries.length > 0 && (
+        {!isLoading && !allFailed && pagedEntries.length > 0 && (
           <OrderTimelineTable
             pagedEntries={pagedEntries}
             sortState={sortState}

--- a/apps/web/src/app/(dashboard)/signals/page.tsx
+++ b/apps/web/src/app/(dashboard)/signals/page.tsx
@@ -22,6 +22,7 @@ import { DEFAULT_SIGNAL_TICKERS, MAX_LIVE_SCAN_TICKERS } from '@/lib/constants';
 import { SignalTimeline, type SortField, type SortDir } from '@/components/signals/signal-timeline';
 import type { SignalRow } from '@/components/signals/signal-card';
 import { markPageVisited } from '@/components/dashboard/setup-progress';
+import { humanizeFetchError } from '@/lib/humanize-fetch-error';
 import {
   MetricGroup,
   PageContainer,
@@ -95,11 +96,11 @@ export default function SignalsPage() {
       setLastScanTime(new Date().toLocaleTimeString());
       toast.success(`Scan complete — ${rows.length} signal${rows.length !== 1 ? 's' : ''} found`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Scan failed';
+      const raw = err instanceof Error ? err.message : 'Scan failed';
       setError(
-        message.includes('timed out')
+        raw.includes('timed out')
           ? `Signal scan exceeded the live data time budget. Limit scans to ${MAX_LIVE_SCAN_TICKERS} tickers or wait for cached data to refresh.`
-          : message,
+          : humanizeFetchError(err, { subject: 'signal scan' }),
       );
       setSignals([]);
       setScanMeta(null);

--- a/apps/web/src/lib/humanize-fetch-error.ts
+++ b/apps/web/src/lib/humanize-fetch-error.ts
@@ -1,0 +1,50 @@
+/**
+ * Translate a thrown query/fetch error into a short, user-friendly message.
+ *
+ * The query hooks in this app raise errors like `new Error("Bars fetch
+ * failed: 503")` or `new Error("Engine error: 429")`. Those strings leak
+ * HTTP status codes into user-visible alerts. Route them through this
+ * helper before rendering so the UI stays readable.
+ */
+
+export interface HumanizeFetchErrorOptions {
+  /**
+   * Short noun describing what was being loaded, e.g. `"market data"`,
+   * `"signal scan"`, `"journal entries"`. Used to tailor the default
+   * copy. Should be lowercase and not end in punctuation.
+   */
+  subject?: string;
+}
+
+export function humanizeFetchError(err: unknown, options: HumanizeFetchErrorOptions = {}): string {
+  const subject = options.subject ?? 'data';
+  if (err == null) return `Could not load ${subject}.`;
+
+  const raw = err instanceof Error ? err.message : String(err);
+
+  if (/timed out|timeout|AbortError/i.test(raw)) {
+    return `Request timed out while loading ${subject}.`;
+  }
+
+  if (/failed to fetch|network|NetworkError/i.test(raw)) {
+    return `Network error while loading ${subject}.`;
+  }
+
+  const statusMatch = raw.match(/\b([45]\d{2})\b/);
+  const status = statusMatch ? Number(statusMatch[1]) : null;
+
+  if (status === 503) return `${capitalize(subject)} service is temporarily unavailable.`;
+  if (status === 504) return `${capitalize(subject)} request timed out upstream.`;
+  if (status === 429) return 'Rate limit reached. Please retry shortly.';
+  if (status === 404) return `No ${subject} found.`;
+  if (status === 401 || status === 403) return `Not authorized to load ${subject}.`;
+  if (status && status >= 500) return `${capitalize(subject)} service is having trouble right now.`;
+  if (status && status >= 400) return `Could not load ${subject} (error ${status}).`;
+
+  return `Could not load ${subject}.`;
+}
+
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/apps/web/tests/pages/orders.test.tsx
+++ b/apps/web/tests/pages/orders.test.tsx
@@ -297,38 +297,37 @@ describe('OrdersPage', () => {
 
   // ─── Error state ──────────────────────────────────────────────────────
 
-  it('shows ErrorState component when queries fail', async () => {
+  it('shows ErrorState component when all queries fail', async () => {
     const { useFillsQuery, useRiskEvaluationsQuery, useOrderHistoryQuery } =
       await import('@/hooks/queries');
     vi.mocked(useFillsQuery).mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: true,
-      error: new Error('fetch failed'),
+      error: new Error('Fills fetch failed: 503'),
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useFillsQuery>);
     vi.mocked(useRiskEvaluationsQuery).mockReturnValue({
       data: undefined,
       isLoading: false,
-      isError: false,
-      error: null,
+      isError: true,
+      error: new Error('Risk fetch failed: 503'),
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useRiskEvaluationsQuery>);
     vi.mocked(useOrderHistoryQuery).mockReturnValue({
       data: undefined,
       isLoading: false,
-      isError: false,
-      error: null,
+      isError: true,
+      error: new Error('Order history fetch failed: 503'),
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useOrderHistoryQuery>);
 
     renderWithProviders(<OrdersPage />);
-    expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('Failed to load data')).toBeInTheDocument();
     expect(screen.getByText('Try Again')).toBeInTheDocument();
   });
 
-  it('ErrorState retry button triggers refetch', async () => {
+  it('ErrorState retry button triggers refetch on all queries when all fail', async () => {
     const refetchFills = vi.fn();
     const refetchRisk = vi.fn();
     const refetchOrders = vi.fn();
@@ -339,18 +338,54 @@ describe('OrdersPage', () => {
       data: undefined,
       isLoading: false,
       isError: true,
-      error: new Error('fail'),
+      error: new Error('Fills fetch failed: 503'),
       refetch: refetchFills,
     } as unknown as ReturnType<typeof useFillsQuery>);
     vi.mocked(useRiskEvaluationsQuery).mockReturnValue({
       data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Risk fetch failed: 503'),
+      refetch: refetchRisk,
+    } as unknown as ReturnType<typeof useRiskEvaluationsQuery>);
+    vi.mocked(useOrderHistoryQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Order history fetch failed: 503'),
+      refetch: refetchOrders,
+    } as unknown as ReturnType<typeof useOrderHistoryQuery>);
+
+    renderWithProviders(<OrdersPage />);
+    fireEvent.click(screen.getByText('Try Again'));
+    expect(refetchFills).toHaveBeenCalled();
+    expect(refetchRisk).toHaveBeenCalled();
+    expect(refetchOrders).toHaveBeenCalled();
+  });
+
+  it('shows inline warning with partial data when only some queries fail', async () => {
+    const refetchFills = vi.fn();
+    const refetchRisk = vi.fn();
+    const refetchOrders = vi.fn();
+
+    const { useFillsQuery, useRiskEvaluationsQuery, useOrderHistoryQuery } =
+      await import('@/hooks/queries');
+    vi.mocked(useFillsQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Fills fetch failed: 503'),
+      refetch: refetchFills,
+    } as unknown as ReturnType<typeof useFillsQuery>);
+    vi.mocked(useRiskEvaluationsQuery).mockReturnValue({
+      data: { data: [], total: 0 },
       isLoading: false,
       isError: false,
       error: null,
       refetch: refetchRisk,
     } as unknown as ReturnType<typeof useRiskEvaluationsQuery>);
     vi.mocked(useOrderHistoryQuery).mockReturnValue({
-      data: undefined,
+      data: [],
       isLoading: false,
       isError: false,
       error: null,
@@ -358,7 +393,12 @@ describe('OrdersPage', () => {
     } as unknown as ReturnType<typeof useOrderHistoryQuery>);
 
     renderWithProviders(<OrdersPage />);
-    fireEvent.click(screen.getByText('Try Again'));
+    expect(screen.queryByText('Failed to load data')).not.toBeInTheDocument();
+    expect(screen.getByText(/Some data sources failed to load/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Fills — Fills service is temporarily unavailable/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(refetchFills).toHaveBeenCalled();
     expect(refetchRisk).toHaveBeenCalled();
     expect(refetchOrders).toHaveBeenCalled();

--- a/apps/web/tests/unit/humanize-fetch-error.test.ts
+++ b/apps/web/tests/unit/humanize-fetch-error.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { humanizeFetchError } from '@/lib/humanize-fetch-error';
+
+describe('humanizeFetchError', () => {
+  it('returns default copy for nullish errors', () => {
+    expect(humanizeFetchError(null)).toBe('Could not load data.');
+    expect(humanizeFetchError(undefined)).toBe('Could not load data.');
+  });
+
+  it('uses provided subject in default copy', () => {
+    expect(humanizeFetchError(null, { subject: 'market data' })).toBe(
+      'Could not load market data.',
+    );
+  });
+
+  it('maps 503 to a friendly unavailability message', () => {
+    expect(
+      humanizeFetchError(new Error('Bars fetch failed: 503'), { subject: 'live price history' }),
+    ).toBe('Live price history service is temporarily unavailable.');
+  });
+
+  it('maps 504 to a friendly upstream timeout message', () => {
+    expect(humanizeFetchError(new Error('Engine error: 504'), { subject: 'quotes' })).toBe(
+      'Quotes request timed out upstream.',
+    );
+  });
+
+  it('maps 429 to rate limit messaging regardless of subject', () => {
+    expect(humanizeFetchError(new Error('Quotes fetch failed: 429'))).toBe(
+      'Rate limit reached. Please retry shortly.',
+    );
+  });
+
+  it('maps 404 to "no X found"', () => {
+    expect(
+      humanizeFetchError(new Error('Bars fetch failed: 404'), { subject: 'journal entries' }),
+    ).toBe('No journal entries found.');
+  });
+
+  it('maps 401/403 to not-authorized', () => {
+    expect(humanizeFetchError(new Error('Engine error: 401'))).toBe('Not authorized to load data.');
+    expect(humanizeFetchError(new Error('Engine error: 403'))).toBe('Not authorized to load data.');
+  });
+
+  it('maps other 5xx to a generic service-trouble message', () => {
+    expect(humanizeFetchError(new Error('Bars fetch failed: 500'), { subject: 'quotes' })).toBe(
+      'Quotes service is having trouble right now.',
+    );
+  });
+
+  it('maps other 4xx to a generic error with status', () => {
+    expect(humanizeFetchError(new Error('Bars fetch failed: 422'), { subject: 'quotes' })).toBe(
+      'Could not load quotes (error 422).',
+    );
+  });
+
+  it('detects timeouts', () => {
+    expect(humanizeFetchError(new Error('The request timed out'))).toBe(
+      'Request timed out while loading data.',
+    );
+    expect(humanizeFetchError(new DOMException('Aborted', 'AbortError'))).toBe(
+      'Request timed out while loading data.',
+    );
+  });
+
+  it('detects network failures', () => {
+    expect(humanizeFetchError(new TypeError('Failed to fetch'))).toBe(
+      'Network error while loading data.',
+    );
+  });
+
+  it('falls back to default copy for unrecognized errors', () => {
+    expect(humanizeFetchError(new Error('something weird'))).toBe('Could not load data.');
+  });
+
+  it('accepts non-Error throwables', () => {
+    expect(humanizeFetchError('Engine error: 503')).toBe(
+      'Data service is temporarily unavailable.',
+    );
+  });
+});


### PR DESCRIPTION
When the engine /data/bars endpoint returns 503/429/5xx, the Markets
page was replacing the chart with a hard "Chart data unavailable"
error screen even though quotes and the simulated-data fallback were
still working. Render the price chart with the existing simulated
data instead, and surface a small dismissable amber notice with a
Retry button plus a human-friendly message per status code so users
understand the degradation without losing the chart UI.