### PR TITLE
Distributed rate limiter + async integration, fail-closed halt checks, and infra/docs updates

### DIFF
--- a/apps/engine/pyproject.toml
+++ b/apps/engine/pyproject.toml
@@ -43,7 +43,7 @@ addopts = "--tb=short"
 source = ["src"]
 
 [tool.coverage.report]
-fail_under = 60
+fail_under = 75
 show_missing = true
 skip_empty = true
 

--- a/apps/engine/railway.toml
+++ b/apps/engine/railway.toml
@@ -14,4 +14,4 @@ healthcheckPath = "/health"
 healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5
-numReplicas = 1
+numReplicas = 2

--- a/apps/engine/src/api/routes/portfolio.py
+++ b/apps/engine/src/api/routes/portfolio.py
@@ -23,6 +23,7 @@ from src.services.order_service import (
     check_trading_halts,
     fetch_live_price,
     run_pre_trade_risk_check,
+    should_fail_closed_on_halt_check,
 )
 from src.telemetry import get_tracer
 
@@ -89,14 +90,15 @@ async def submit_order(body: SubmitOrderBody) -> OrderSubmitResponse:
     from src.config import Settings as _Settings
     from src.execution.alpaca_broker import AlpacaBroker
 
-    exp_id = _Settings().experiment_id
-    await check_trading_halts(experiment_id=exp_id)
-
     try:
         broker = get_broker()
 
         # Gate live-broker orders on system_controls
         await check_live_execution_gate(broker)
+
+        exp_id = _Settings().experiment_id
+        fail_closed_halts = should_fail_closed_on_halt_check(broker)
+        await check_trading_halts(fail_closed=fail_closed_halts, experiment_id=exp_id)
 
         symbol = body.symbol.upper()
 

--- a/apps/engine/src/middleware/rate_limit.py
+++ b/apps/engine/src/middleware/rate_limit.py
@@ -1,64 +1,114 @@
-"""Rate limiting middleware for API protection."""
+"""Rate limiting middleware for API protection.
+
+Uses Redis REST when configured and falls back to in-process memory in local/dev.
+"""
 
 import asyncio
+import os
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+import httpx
 from fastapi import HTTPException, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
-class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Simple in-memory rate limiter (per-IP basis).
-
-    For production, use external service like Redis.
-    Protects public endpoints from abuse.
-    """
-
-    def __init__(self, app, requests_per_minute: int = 100) -> None:
-        super().__init__(app)
+class _MemoryLimiter:
+    def __init__(self, requests_per_minute: int) -> None:
         self.requests_per_minute = requests_per_minute
         self.request_counts: dict[str, list[datetime]] = defaultdict(list)
         self.lock = asyncio.Lock()
 
+    async def check(self, key: str) -> tuple[bool, int]:
+        async with self.lock:
+            now = datetime.now()
+            cutoff = now - timedelta(minutes=1)
+            if key in self.request_counts:
+                self.request_counts[key] = [ts for ts in self.request_counts[key] if ts > cutoff]
+                if not self.request_counts[key]:
+                    del self.request_counts[key]
+
+            current_count = len(self.request_counts.get(key, []))
+            if current_count >= self.requests_per_minute:
+                return False, 0
+
+            self.request_counts[key].append(now)
+            remaining = self.requests_per_minute - len(self.request_counts[key])
+            return True, remaining
+
+
+class _RedisRestLimiter:
+    def __init__(self, requests_per_minute: int) -> None:
+        self.requests_per_minute = requests_per_minute
+        self.base_url = os.getenv("RATE_LIMIT_REDIS_REST_URL", "").rstrip("/")
+        self.token = os.getenv("RATE_LIMIT_REDIS_REST_TOKEN", "")
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.base_url and self.token)
+
+    async def check(self, key: str) -> tuple[bool, int] | None:
+        if not self.configured:
+            return None
+
+        bucket = f"sentinel:engine:rate-limit:{key}"
+        payload = [
+            ["INCR", bucket],
+            ["PEXPIRE", bucket, "60000", "NX"],
+        ]
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.post(
+                    f"{self.base_url}/pipeline",
+                    headers=headers,
+                    json=payload,
+                )
+            if response.status_code >= 400:
+                return None
+            data = response.json()
+            count = int(data["result"][0]["result"])
+            remaining = max(0, self.requests_per_minute - count)
+            return count <= self.requests_per_minute, remaining
+        except Exception:
+            return None
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Rate limiter with Redis-backed distributed mode and local-memory fallback."""
+
+    def __init__(self, app, requests_per_minute: int = 100) -> None:
+        super().__init__(app)
+        self.requests_per_minute = requests_per_minute
+        self.redis = _RedisRestLimiter(requests_per_minute)
+        self.memory = _MemoryLimiter(requests_per_minute)
+
     async def dispatch(self, request: Request, call_next) -> Response:
-        # Skip rate limit for internal endpoints
         if request.url.path in ["/health", "/docs", "/openapi.json", "/redoc"]:
             return await call_next(request)
 
-        # Extract client IP
         client_ip = (
             request.headers.get("X-Forwarded-For", "").split(",")[0].strip() or request.client.host
             if request.client
             else "unknown"
         )
 
-        async with self.lock:
-            now = datetime.now()
-            cutoff = now - timedelta(minutes=1)
+        result = await self.redis.check(client_ip)
+        if result is None:
+            result = await self.memory.check(client_ip)
 
-            # Clean old requests for this IP
-            if client_ip in self.request_counts:
-                self.request_counts[client_ip] = [
-                    req_time for req_time in self.request_counts[client_ip] if req_time > cutoff
-                ]
-                # Remove empty entries to prevent unbounded memory growth
-                if not self.request_counts[client_ip]:
-                    del self.request_counts[client_ip]
-
-            # Check limit
-            current_count = len(self.request_counts.get(client_ip, []))
-            if current_count >= self.requests_per_minute:
-                raise HTTPException(
-                    status_code=429,
-                    detail=f"Rate limit exceeded: {self.requests_per_minute}/min",
-                )
-
-            self.request_counts[client_ip].append(now)
+        allowed, remaining = result
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Rate limit exceeded: {self.requests_per_minute}/min",
+            )
 
         response = await call_next(request)
         response.headers["X-RateLimit-Limit"] = str(self.requests_per_minute)
-        response.headers["X-RateLimit-Remaining"] = str(
-            self.requests_per_minute - len(self.request_counts[client_ip])
-        )
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
         return response

--- a/apps/engine/src/services/order_service.py
+++ b/apps/engine/src/services/order_service.py
@@ -16,7 +16,7 @@ from src.risk.risk_manager import PortfolioState, PreTradeCheck, RiskManager
 logger = logging.getLogger(__name__)
 
 
-async def check_trading_halts(experiment_id: str | None = None) -> None:
+async def check_trading_halts(*, fail_closed: bool, experiment_id: str | None = None) -> None:
     """Raise HTTPException(403) if system or experiment trading is halted."""
     db = get_db()
     if db is None:
@@ -33,7 +33,16 @@ async def check_trading_halts(experiment_id: str | None = None) -> None:
     except HTTPException:
         raise
     except Exception as exc:
-        logger.warning("Could not check trading halt status: %s", exc)
+        if fail_closed:
+            logger.error("Could not verify system trading halt status: %s", exc)
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Could not verify system trading halt status; "
+                    "refusing order as a safety default."
+                ),
+            ) from exc
+        logger.warning("Could not check trading halt status (continuing): %s", exc)
 
     # Experiment-level halt
     if experiment_id:
@@ -49,7 +58,16 @@ async def check_trading_halts(experiment_id: str | None = None) -> None:
         except HTTPException:
             raise
         except Exception as exc:
-            logger.warning("Could not check experiment halt status: %s", exc)
+            if fail_closed:
+                logger.error("Could not verify experiment halt status: %s", exc)
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "Could not verify experiment halt status; "
+                        "refusing order as a safety default."
+                    ),
+                ) from exc
+            logger.warning("Could not check experiment halt status (continuing): %s", exc)
 
 
 async def fetch_live_price(broker: BrokerAdapter, symbol: str) -> float | None:
@@ -124,6 +142,18 @@ def _is_paper_endpoint(base_url: str) -> bool:
     if not host:
         return False
     return host.lower() in _ALPACA_PAPER_HOSTS
+
+
+def should_fail_closed_on_halt_check(broker: BrokerAdapter) -> bool:
+    """Return True when halt-state query errors must block order submission.
+
+    This is limited to Alpaca live-trading endpoints. Paper brokers and paper
+    Alpaca endpoints continue on control-plane read errors to preserve
+    development and paper-trading availability.
+    """
+    from src.execution.alpaca_broker import AlpacaBroker
+
+    return isinstance(broker, AlpacaBroker) and not _is_paper_endpoint(broker.base_url)
 
 
 async def check_live_execution_gate(broker: BrokerAdapter) -> None:

--- a/apps/engine/tests/unit/test_live_execution_gate.py
+++ b/apps/engine/tests/unit/test_live_execution_gate.py
@@ -19,6 +19,7 @@ from src.execution.paper_broker import PaperBroker
 from src.services.order_service import (
     _is_paper_endpoint,
     check_live_execution_gate,
+    check_trading_halts,
 )
 
 # ---------------------------------------------------------------------------
@@ -151,7 +152,46 @@ class TestLiveExecutionGate:
             with pytest.raises(HTTPException) as exc_info:
                 await check_live_execution_gate(broker)
             assert exc_info.value.status_code == 403
-            assert "disabled" in exc_info.value.detail
+
+
+class TestTradingHalts:
+    """Safety checks for system/experiment trading halts."""
+
+    @pytest.mark.asyncio
+    async def test_system_halt_query_error_fails_closed(self):
+        mock_db = MagicMock()
+        system_chain = (
+            mock_db.table.return_value.select.return_value.limit.return_value.single.return_value
+        )
+        system_chain.execute.side_effect = RuntimeError("db down")
+
+        with patch("src.services.order_service.get_db", return_value=mock_db):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_trading_halts(fail_closed=True)
+            assert exc_info.value.status_code == 503
+            assert "safety default" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_experiment_halt_query_error_fails_closed(self):
+        mock_db = MagicMock()
+
+        # system_controls check passes
+        system_chain = (
+            mock_db.table.return_value.select.return_value.limit.return_value.single.return_value
+        )
+        system_chain.execute.return_value = MagicMock(data={"trading_halted": False})
+
+        # experiments check fails
+        experiment_chain = (
+            mock_db.table.return_value.select.return_value.eq.return_value.single.return_value
+        )
+        experiment_chain.execute.side_effect = RuntimeError("db timeout")
+
+        with patch("src.services.order_service.get_db", return_value=mock_db):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_trading_halts(fail_closed=True, experiment_id="exp-123")
+            assert exc_info.value.status_code == 503
+            assert "safety default" in exc_info.value.detail
 
     @pytest.mark.asyncio
     async def test_live_url_wrong_mode_returns_403(self):

--- a/apps/engine/tests/unit/test_portfolio_routes.py
+++ b/apps/engine/tests/unit/test_portfolio_routes.py
@@ -1,6 +1,6 @@
 """Tests for the portfolio API routes."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -74,6 +74,79 @@ class TestPortfolioEndpoints:
         data = response.json()
         assert data["status"] == "filled"
         assert data["fill_quantity"] == 5.0
+
+    @patch(_PATCH_GET_BROKER)
+    @patch("src.api.routes.portfolio.check_trading_halts", new_callable=AsyncMock)
+    @patch("src.api.routes.portfolio.check_live_execution_gate", new_callable=AsyncMock)
+    @patch("src.api.routes.portfolio.fetch_live_price", new_callable=AsyncMock, return_value=100.0)
+    @patch("src.api.routes.portfolio.run_pre_trade_risk_check", new_callable=AsyncMock)
+    @patch("src.api.routes.portfolio.should_fail_closed_on_halt_check", return_value=True)
+    def test_submit_order_live_uses_fail_closed_halts(
+        self,
+        mock_should_fail_closed,
+        mock_risk,
+        _mock_price,
+        mock_live_gate,
+        mock_halts,
+        mock_get_broker,
+    ):
+        mock_risk.return_value = MagicMock(allowed=True, adjusted_shares=None, reason=None)
+        broker = AsyncMock()
+        broker.submit_order.return_value = MagicMock(
+            order_id="o-1",
+            status="filled",
+            fill_price=100.0,
+            fill_quantity=1.0,
+            commission=0.0,
+            slippage=0.0,
+        )
+        mock_get_broker.return_value = broker
+
+        response = self.client.post(
+            "/api/v1/portfolio/orders",
+            json={"symbol": "AAPL", "side": "buy", "quantity": 1},
+        )
+
+        assert response.status_code == 200
+        mock_live_gate.assert_awaited_once_with(broker)
+        mock_should_fail_closed.assert_called_once_with(broker)
+        mock_halts.assert_awaited_once()
+        assert mock_halts.await_args.kwargs["fail_closed"] is True
+
+    @patch(_PATCH_GET_BROKER)
+    @patch("src.api.routes.portfolio.check_trading_halts", new_callable=AsyncMock)
+    @patch("src.api.routes.portfolio.check_live_execution_gate", new_callable=AsyncMock)
+    @patch("src.api.routes.portfolio.fetch_live_price", new_callable=AsyncMock, return_value=100.0)
+    @patch("src.api.routes.portfolio.run_pre_trade_risk_check", new_callable=AsyncMock)
+    @patch("src.api.routes.portfolio.should_fail_closed_on_halt_check", return_value=False)
+    def test_submit_order_paper_does_not_fail_closed_halts(
+        self,
+        _mock_should_fail_closed,
+        mock_risk,
+        _mock_price,
+        _mock_live_gate,
+        mock_halts,
+        mock_get_broker,
+    ):
+        mock_risk.return_value = MagicMock(allowed=True, adjusted_shares=None, reason=None)
+        broker = AsyncMock()
+        broker.submit_order.return_value = MagicMock(
+            order_id="o-2",
+            status="filled",
+            fill_price=100.0,
+            fill_quantity=1.0,
+            commission=0.0,
+            slippage=0.0,
+        )
+        mock_get_broker.return_value = broker
+
+        response = self.client.post(
+            "/api/v1/portfolio/orders",
+            json={"symbol": "AAPL", "side": "buy", "quantity": 1},
+        )
+
+        assert response.status_code == 200
+        assert mock_halts.await_args.kwargs["fail_closed"] is False
 
     def test_submit_order_invalid_body(self):
         response = self.client.post(

--- a/apps/web/src/app/api/advisor/context/route.ts
+++ b/apps/web/src/app/api/advisor/context/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/advisor/memory-events/route.ts
+++ b/apps/web/src/app/api/advisor/memory-events/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/advisor/preferences/[id]/confirm/route.ts
+++ b/apps/web/src/app/api/advisor/preferences/[id]/confirm/route.ts
@@ -17,7 +17,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/advisor/preferences/[id]/dismiss/route.ts
+++ b/apps/web/src/app/api/advisor/preferences/[id]/dismiss/route.ts
@@ -17,7 +17,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/advisor/preferences/[id]/route.ts
+++ b/apps/web/src/app/api/advisor/preferences/[id]/route.ts
@@ -19,7 +19,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -94,7 +94,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/advisor/preferences/route.ts
+++ b/apps/web/src/app/api/advisor/preferences/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const PreferenceCreateSchema = z.object({

--- a/apps/web/src/app/api/advisor/profile/route.ts
+++ b/apps/web/src/app/api/advisor/profile/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -59,7 +59,7 @@ export async function PATCH(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const ALLOWED_PROFILE_FIELDS = [

--- a/apps/web/src/app/api/advisor/threads/[id]/messages/route.ts
+++ b/apps/web/src/app/api/advisor/threads/[id]/messages/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -66,7 +66,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const MessageCreateSchema = z.object({

--- a/apps/web/src/app/api/advisor/threads/[id]/route.ts
+++ b/apps/web/src/app/api/advisor/threads/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -50,7 +50,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const ThreadUpdateSchema = z
@@ -98,7 +98,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/advisor/threads/route.ts
+++ b/apps/web/src/app/api/advisor/threads/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -52,7 +52,7 @@ export async function POST(req: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const ThreadCreateSchema = z.object({

--- a/apps/web/src/app/api/autonomy/activity/route.ts
+++ b/apps/web/src/app/api/autonomy/activity/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase

--- a/apps/web/src/app/api/catalysts/route.ts
+++ b/apps/web/src/app/api/catalysts/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { searchParams } = new URL(request.url);
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const CatalystCreateSchema = z.object({

--- a/apps/web/src/app/api/counterfactuals/route.ts
+++ b/apps/web/src/app/api/counterfactuals/route.ts
@@ -63,7 +63,7 @@ export async function GET(req: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = parseSearchParams(req, counterfactualQuery);

--- a/apps/web/src/app/api/data-quality/route.ts
+++ b/apps/web/src/app/api/data-quality/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const url = new URL(request.url);
@@ -100,7 +100,7 @@ export async function POST(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(request, postBodySchema);
@@ -138,7 +138,7 @@ export async function PATCH(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(request, patchBodySchema);

--- a/apps/web/src/app/api/experiments/[id]/advance/route.ts
+++ b/apps/web/src/app/api/experiments/[id]/advance/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const AdvanceSchema = z.object({

--- a/apps/web/src/app/api/experiments/[id]/halt/route.ts
+++ b/apps/web/src/app/api/experiments/[id]/halt/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const HaltSchema = z.object({

--- a/apps/web/src/app/api/experiments/[id]/report/route.ts
+++ b/apps/web/src/app/api/experiments/[id]/report/route.ts
@@ -58,7 +58,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/experiments/[id]/route.ts
+++ b/apps/web/src/app/api/experiments/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -61,7 +61,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/experiments/route.ts
+++ b/apps/web/src/app/api/experiments/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -46,7 +46,7 @@ export async function POST(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const ExperimentCreateSchema = z.object({

--- a/apps/web/src/app/api/fills/route.ts
+++ b/apps/web/src/app/api/fills/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { searchParams } = request.nextUrl;
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const FillCreateSchema = z.object({

--- a/apps/web/src/app/api/funding/route.ts
+++ b/apps/web/src/app/api/funding/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const params = parseSearchParams(request, FundingQuerySchema);
@@ -112,7 +112,7 @@ export async function POST(request: Request) {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, FundingPostSchema);

--- a/apps/web/src/app/api/journal/[id]/route.ts
+++ b/apps/web/src/app/api/journal/[id]/route.ts
@@ -47,7 +47,7 @@ export async function GET(
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const { data, error } = await supabase
@@ -89,7 +89,7 @@ export async function PATCH(
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, JournalUpdateSchema);

--- a/apps/web/src/app/api/journal/route.ts
+++ b/apps/web/src/app/api/journal/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const params = parseSearchParams(request, JournalQuerySchema);
@@ -113,7 +113,7 @@ export async function POST(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, JournalCreateSchema);

--- a/apps/web/src/app/api/journal/stats/route.ts
+++ b/apps/web/src/app/api/journal/stats/route.ts
@@ -12,7 +12,7 @@ export async function GET(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const { data, error } = await supabase

--- a/apps/web/src/app/api/onboarding/broker/route.ts
+++ b/apps/web/src/app/api/onboarding/broker/route.ts
@@ -36,7 +36,7 @@ export async function GET() {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const { data, error } = await supabase
@@ -64,7 +64,7 @@ export async function POST() {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     // Check for existing broker account
@@ -115,7 +115,7 @@ export async function PUT(request: Request) {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, BrokerUpdateSchema);

--- a/apps/web/src/app/api/onboarding/consent/route.ts
+++ b/apps/web/src/app/api/onboarding/consent/route.ts
@@ -29,7 +29,7 @@ export async function GET(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const { data, error } = await supabase
@@ -58,7 +58,7 @@ export async function POST(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, ConsentRecordSchema);

--- a/apps/web/src/app/api/onboarding/paper-account/route.ts
+++ b/apps/web/src/app/api/onboarding/paper-account/route.ts
@@ -18,7 +18,7 @@ export async function POST(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     // Check if user already has a paper account

--- a/apps/web/src/app/api/onboarding/profile/route.ts
+++ b/apps/web/src/app/api/onboarding/profile/route.ts
@@ -16,7 +16,7 @@ export async function GET(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const { data, error } = await supabase
@@ -122,7 +122,7 @@ export async function PUT(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await request.json().catch(() => null);

--- a/apps/web/src/app/api/operator-actions/route.ts
+++ b/apps/web/src/app/api/operator-actions/route.ts
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { searchParams } = new URL(request.url);
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase

--- a/apps/web/src/app/api/plaid/exchange/route.ts
+++ b/apps/web/src/app/api/plaid/exchange/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const plaid = getPlaidClient();

--- a/apps/web/src/app/api/plaid/link-token/route.ts
+++ b/apps/web/src/app/api/plaid/link-token/route.ts
@@ -19,7 +19,7 @@ export async function POST(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const plaid = getPlaidClient();

--- a/apps/web/src/app/api/portfolio/external/route.ts
+++ b/apps/web/src/app/api/portfolio/external/route.ts
@@ -23,7 +23,7 @@ export async function GET(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const { data, error } = await supabase
@@ -58,7 +58,7 @@ export async function DELETE(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, DeleteLinkSchema);

--- a/apps/web/src/app/api/recommendations/[id]/events/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/events/route.ts
@@ -40,7 +40,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const [recResult, eventsResult, riskResult, operatorActionsResult] = await Promise.all([
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(request, postBodySchema);

--- a/apps/web/src/app/api/recommendations/[id]/explanation/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/explanation/route.ts
@@ -24,7 +24,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {
@@ -58,7 +58,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   try {

--- a/apps/web/src/app/api/recommendations/[id]/risk-preview/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/risk-preview/route.ts
@@ -29,7 +29,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   // Fetch recommendation from agent_recommendations table

--- a/apps/web/src/app/api/regime/playbooks/[id]/route.ts
+++ b/apps/web/src/app/api/regime/playbooks/[id]/route.ts
@@ -39,7 +39,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase
@@ -62,7 +62,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(request, patchBodySchema);
@@ -118,7 +118,7 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { error } = await supabase

--- a/apps/web/src/app/api/regime/playbooks/route.ts
+++ b/apps/web/src/app/api/regime/playbooks/route.ts
@@ -62,7 +62,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase
@@ -87,7 +87,7 @@ export async function POST(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(request, postBodySchema);

--- a/apps/web/src/app/api/regime/route.ts
+++ b/apps/web/src/app/api/regime/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   // Get latest regime
@@ -83,7 +83,7 @@ export async function POST(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(request, postBodySchema);

--- a/apps/web/src/app/api/replay/recommendation/[id]/route.ts
+++ b/apps/web/src/app/api/replay/recommendation/[id]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
   if (auth instanceof NextResponse) return auth;
   const { supabase, user } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { id } = await params;

--- a/apps/web/src/app/api/replay/recommendation/route.ts
+++ b/apps/web/src/app/api/replay/recommendation/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { supabase, user } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const params = parseSearchParams(request, SearchQuery);

--- a/apps/web/src/app/api/replay/route.ts
+++ b/apps/web/src/app/api/replay/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { supabase, user } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const query = parseSearchParams(request, ReplayQuery);

--- a/apps/web/src/app/api/risk-evaluations/route.ts
+++ b/apps/web/src/app/api/risk-evaluations/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { searchParams } = request.nextUrl;
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const RiskEvalCreateSchema = z.object({

--- a/apps/web/src/app/api/roles/route.ts
+++ b/apps/web/src/app/api/roles/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const params = parseSearchParams(request, RolesQuerySchema);
@@ -120,7 +120,7 @@ export async function PATCH(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const body = await parseBody(request, RoleUpdateSchema);

--- a/apps/web/src/app/api/settings/policy/route.ts
+++ b/apps/web/src/app/api/settings/policy/route.ts
@@ -44,7 +44,7 @@ export async function GET(): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     // Try to fetch existing policy
@@ -94,7 +94,7 @@ export async function PUT(request: Request): Promise<Response> {
     if (auth instanceof NextResponse) return auth;
     const { user, supabase } = auth;
 
-    const rl = checkApiRateLimit(user.id);
+    const rl = await checkApiRateLimit(user.id);
     if (rl) return rl;
 
     const body = await parseBody(request, PolicyUpdateSchema);

--- a/apps/web/src/app/api/shadow-portfolios/[id]/route.ts
+++ b/apps/web/src/app/api/shadow-portfolios/[id]/route.ts
@@ -35,7 +35,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   // Fetch shadow portfolio
@@ -70,7 +70,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(req, patchBodySchema);
@@ -118,7 +118,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { error } = await supabase

--- a/apps/web/src/app/api/shadow-portfolios/route.ts
+++ b/apps/web/src/app/api/shadow-portfolios/route.ts
@@ -48,7 +48,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase
@@ -72,7 +72,7 @@ export async function POST(req: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const parsed = await parseBody(req, postBodySchema);

--- a/apps/web/src/app/api/strategy-health/[name]/route.ts
+++ b/apps/web/src/app/api/strategy-health/[name]/route.ts
@@ -20,7 +20,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { name } = await params;

--- a/apps/web/src/app/api/strategy-health/route.ts
+++ b/apps/web/src/app/api/strategy-health/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/system-controls/route.ts
+++ b/apps/web/src/app/api/system-controls/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase.from('system_controls').select('*').limit(1).single();
@@ -36,7 +36,7 @@ export async function PATCH(request: Request) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const SystemControlsUpdateSchema = z.object({

--- a/apps/web/src/app/api/workflows/[id]/steps/route.ts
+++ b/apps/web/src/app/api/workflows/[id]/steps/route.ts
@@ -14,7 +14,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { data, error } = await supabase

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
   if (auth instanceof NextResponse) return auth;
   const { user, supabase } = auth;
 
-  const rl = checkApiRateLimit(user.id);
+  const rl = await checkApiRateLimit(user.id);
   if (rl) return rl;
 
   const { searchParams } = request.nextUrl;

--- a/apps/web/src/lib/auth/require-auth.ts
+++ b/apps/web/src/lib/auth/require-auth.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { checkApiRateLimit } from '@/lib/server/rate-limiter';
 import type { SupabaseClient, User } from '@supabase/supabase-js';
 
 // ─── Types ──────────────────────────────────────────────────────────
@@ -44,6 +45,22 @@ export async function requireAuth(): Promise<AuthContext | NextResponse> {
 
   if (error || !user) return UNAUTHORIZED;
   return { user, supabase };
+}
+
+/**
+ * Compatibility helper for mutation/read routes that need both auth + API rate limiting.
+ *
+ * Prefer this helper in new routes to avoid duplicated boilerplate:
+ *   const auth = await requireAuthWithRateLimit();
+ *   if (auth instanceof NextResponse) return auth;
+ */
+export async function requireAuthWithRateLimit(): Promise<AuthContext | NextResponse> {
+  const auth = await requireAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const rl = await checkApiRateLimit(auth.user.id);
+  if (rl) return rl;
+  return auth;
 }
 
 // ─── requireRole ────────────────────────────────────────────────────

--- a/apps/web/src/lib/server/csrf.ts
+++ b/apps/web/src/lib/server/csrf.ts
@@ -158,8 +158,8 @@ export const mutationRateLimiter = new RateLimiter(20, 60_000);
  * Check mutation-specific rate limit for an authenticated user.
  * Returns `null` if allowed, or a `429 Response` if rate-limited.
  */
-export function checkMutationRateLimit(userId: string): Response | null {
-  const result = mutationRateLimiter.check(userId);
+export async function checkMutationRateLimit(userId: string): Promise<Response | null> {
+  const result = await mutationRateLimiter.check(userId);
   if (!result.allowed) {
     return rateLimitResponse(result.resetAtMs);
   }

--- a/apps/web/src/lib/server/rate-limiter.ts
+++ b/apps/web/src/lib/server/rate-limiter.ts
@@ -1,20 +1,12 @@
 /**
- * Lightweight in-process sliding-window rate limiter for Next.js API routes.
+ * Rate limiter for Next.js API routes with Redis REST support.
  *
  * ## Design constraints and trade-offs
  *
- * This is an **in-process** implementation — state lives in a module-level
- * Map that is local to a single Node.js worker. On Vercel, each region runs
- * multiple serverless function instances concurrently, so the effective
- * limit seen by a single client is `LIMIT_PER_WINDOW × number_of_instances`.
- *
- * This is acceptable for a single-tenant trading platform where the primary
- * goal is to prevent runaway agent loops and accidental hammering, not to
- * enforce strict per-user metering at scale.
- *
- * **If you need globally consistent rate limiting** (e.g. for a public API),
- * replace `WindowStore` with a Redis-backed implementation using Upstash or
- * Vercel KV and the same `RateLimiter` interface.
+ * When `RATE_LIMIT_REDIS_REST_URL` and `RATE_LIMIT_REDIS_REST_TOKEN` are set,
+ * this limiter uses a shared Redis backend (Upstash Redis REST-compatible).
+ * If Redis is unavailable, it falls back to an in-process sliding window so
+ * local development remains functional.
  *
  * ## Usage
  *
@@ -79,6 +71,7 @@ class WindowStore {
 
 export class RateLimiter {
   private readonly store = new WindowStore();
+  private readonly redis = createRedisRateLimiterClient();
 
   constructor(
     private readonly limit: number,
@@ -91,7 +84,10 @@ export class RateLimiter {
    *
    * @param key  Typically the client identifier: IP, user ID, or composite.
    */
-  check(key: string): RateLimitResult {
+  async check(key: string): Promise<RateLimitResult> {
+    const redisResult = await this.redis?.check(key, this.limit, this.windowMs);
+    if (redisResult) return redisResult;
+
     this.store.clean(this.windowMs);
 
     const now = Date.now();
@@ -148,12 +144,67 @@ export const apiRateLimiter = new RateLimiter(60, 60_000);
  * Check the API rate limit for an authenticated user.
  * Returns null if allowed, or a 429 Response if rate-limited.
  */
-export function checkApiRateLimit(userId: string): Response | null {
-  const result = apiRateLimiter.check(userId);
+export async function checkApiRateLimit(userId: string): Promise<Response | null> {
+  const result = await apiRateLimiter.check(userId);
   if (!result.allowed) {
     return rateLimitResponse(result.resetAtMs);
   }
   return null;
+}
+
+interface RedisCheckResult {
+  result: number | string;
+}
+
+interface RedisPipelineResponse {
+  result: RedisCheckResult[];
+}
+
+interface RedisRateLimiterClient {
+  check(key: string, limit: number, windowMs: number): Promise<RateLimitResult | null>;
+}
+
+function createRedisRateLimiterClient(): RedisRateLimiterClient | null {
+  const baseUrl = process.env.RATE_LIMIT_REDIS_REST_URL?.replace(/\/+$/, '');
+  const token = process.env.RATE_LIMIT_REDIS_REST_TOKEN;
+  if (!baseUrl || !token) return null;
+
+  return {
+    async check(key, limit, windowMs) {
+      const bucket = `sentinel:rate-limit:${key}`;
+      const now = Date.now();
+      try {
+        const response = await fetch(`${baseUrl}/pipeline`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify([
+            ['INCR', bucket],
+            ['PTTL', bucket],
+            ['PEXPIRE', bucket, String(windowMs), 'NX'],
+          ]),
+          cache: 'no-store',
+        });
+        if (!response.ok) return null;
+
+        const payload = (await response.json()) as RedisPipelineResponse;
+        const count = Number(payload.result?.[0]?.result ?? 0);
+        const ttlMs = Number(payload.result?.[1]?.result ?? -1);
+        const safeTtl = ttlMs > 0 ? ttlMs : windowMs;
+        const resetAtMs = now + safeTtl;
+
+        return {
+          allowed: count <= limit,
+          remaining: Math.max(0, limit - count),
+          resetAtMs,
+        };
+      } catch {
+        return null;
+      }
+    },
+  };
 }
 
 // ─── Helper ───────────────────────────────────────────────────────────────

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -118,7 +118,7 @@ export async function proxy(request: NextRequest) {
   // fall back to a constant so local dev is never accidentally blocked.
   if (isApiRoute(pathname) && !isPublicRoute(pathname)) {
     const clientKey = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'localhost';
-    const rl = proxyRateLimiter.check(clientKey);
+    const rl = await proxyRateLimiter.check(clientKey);
     if (!rl.allowed) {
       return rateLimitResponse(rl.resetAtMs);
     }
@@ -176,7 +176,7 @@ export async function proxy(request: NextRequest) {
     const csrfResponse = checkCsrf(request);
     if (csrfResponse) return csrfResponse;
 
-    const mrl = checkMutationRateLimit(user.id);
+    const mrl = await checkMutationRateLimit(user.id);
     if (mrl) return mrl;
   }
 

--- a/apps/web/tests/unit/api-rate-limiter.test.ts
+++ b/apps/web/tests/unit/api-rate-limiter.test.ts
@@ -2,35 +2,35 @@ import { describe, expect, it } from 'vitest';
 import { RateLimiter, checkApiRateLimit, apiRateLimiter } from '@/lib/server/rate-limiter';
 
 describe('RateLimiter', () => {
-  it('allows requests within the limit', () => {
+  it('allows requests within the limit', async () => {
     const limiter = new RateLimiter(3, 60_000);
-    expect(limiter.check('user1').allowed).toBe(true);
-    expect(limiter.check('user1').allowed).toBe(true);
-    expect(limiter.check('user1').allowed).toBe(true);
+    expect((await limiter.check('user1')).allowed).toBe(true);
+    expect((await limiter.check('user1')).allowed).toBe(true);
+    expect((await limiter.check('user1')).allowed).toBe(true);
   });
 
-  it('blocks requests over the limit', () => {
+  it('blocks requests over the limit', async () => {
     const limiter = new RateLimiter(2, 60_000);
-    limiter.check('user1');
-    limiter.check('user1');
-    const result = limiter.check('user1');
+    await limiter.check('user1');
+    await limiter.check('user1');
+    const result = await limiter.check('user1');
     expect(result.allowed).toBe(false);
     expect(result.remaining).toBe(0);
   });
 
-  it('tracks remaining count correctly', () => {
+  it('tracks remaining count correctly', async () => {
     const limiter = new RateLimiter(5, 60_000);
-    expect(limiter.check('user1').remaining).toBe(4);
-    expect(limiter.check('user1').remaining).toBe(3);
-    expect(limiter.check('user1').remaining).toBe(2);
+    expect((await limiter.check('user1')).remaining).toBe(4);
+    expect((await limiter.check('user1')).remaining).toBe(3);
+    expect((await limiter.check('user1')).remaining).toBe(2);
   });
 
-  it('isolates keys from each other', () => {
+  it('isolates keys from each other', async () => {
     const limiter = new RateLimiter(1, 60_000);
-    expect(limiter.check('user1').allowed).toBe(true);
-    expect(limiter.check('user2').allowed).toBe(true);
-    expect(limiter.check('user1').allowed).toBe(false);
-    expect(limiter.check('user2').allowed).toBe(false);
+    expect((await limiter.check('user1')).allowed).toBe(true);
+    expect((await limiter.check('user2')).allowed).toBe(true);
+    expect((await limiter.check('user1')).allowed).toBe(false);
+    expect((await limiter.check('user2')).allowed).toBe(false);
   });
 });
 
@@ -41,8 +41,8 @@ describe('apiRateLimiter', () => {
 });
 
 describe('checkApiRateLimit', () => {
-  it('returns null when allowed', () => {
-    const result = checkApiRateLimit('test-unique-user-' + Math.random());
+  it('returns null when allowed', async () => {
+    const result = await checkApiRateLimit('test-unique-user-' + Math.random());
     expect(result).toBeNull();
   });
 });

--- a/apps/web/tests/unit/proxy.test.ts
+++ b/apps/web/tests/unit/proxy.test.ts
@@ -27,13 +27,13 @@ vi.mock('@/lib/supabase/server', () => ({
 // ─── Mock rate limiter ────────────────────────────────────────────────────
 
 const mockCheck =
-  vi.fn<(key: string) => { allowed: boolean; remaining: number; resetAtMs: number }>();
+  vi.fn<(key: string) => Promise<{ allowed: boolean; remaining: number; resetAtMs: number }>>();
 
 vi.mock('@/lib/server/rate-limiter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/server/rate-limiter')>();
   return {
     ...actual,
-    proxyRateLimiter: { check: (key: string) => mockCheck(key) },
+    proxyRateLimiter: { check: async (key: string) => mockCheck(key) },
     rateLimitResponse: () =>
       new Response(JSON.stringify({ error: 'rate_limited' }), {
         status: 429,
@@ -75,7 +75,7 @@ describe('proxy middleware', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     // Default: rate limit allows, user is authenticated
-    mockCheck.mockReturnValue(allowedRl());
+    mockCheck.mockResolvedValue(allowedRl());
     mockUpdateSession.mockResolvedValue(authenticatedSession);
     const mod = await import('@/proxy');
     proxy = mod.proxy;
@@ -194,13 +194,17 @@ describe('proxy middleware', () => {
   // ── Rate limiting ────────────────────────────────────────────────────
 
   it('returns 429 when the rate limiter denies an /api/* request', async () => {
-    mockCheck.mockReturnValueOnce({ allowed: false, remaining: 0, resetAtMs: Date.now() + 60_000 });
+    mockCheck.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAtMs: Date.now() + 60_000,
+    });
     const response = await proxy(makeRequest('/api/engine/orders'));
     expect(response.status).toBe(429);
   });
 
   it('uses x-forwarded-for as the rate-limit key', async () => {
-    mockCheck.mockReturnValue(allowedRl());
+    mockCheck.mockResolvedValue(allowedRl());
     await proxy(makeRequest('/api/engine/orders', '10.0.0.1'));
     expect(mockCheck).toHaveBeenCalledWith('10.0.0.1');
   });
@@ -233,7 +237,7 @@ describe('proxy middleware — Supabase not configured', () => {
     delete process.env.NEXT_PUBLIC_SUPABASE_URL;
     delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
     vi.clearAllMocks();
-    mockCheck.mockReturnValue({ allowed: true, remaining: 119, resetAtMs: Date.now() + 60_000 });
+    mockCheck.mockResolvedValue({ allowed: true, remaining: 119, resetAtMs: Date.now() + 60_000 });
   });
 
   afterEach(() => {
@@ -275,7 +279,7 @@ describe('proxy middleware — production canonical host redirect', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheck.mockReturnValue({ allowed: true, remaining: 119, resetAtMs: Date.now() + 60_000 });
+    mockCheck.mockResolvedValue({ allowed: true, remaining: 119, resetAtMs: Date.now() + 60_000 });
     mockUpdateSession.mockResolvedValue(authenticatedSession);
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
@@ -363,18 +367,18 @@ describe('RateLimiter', () => {
     const { RateLimiter } = await import('@/lib/server/rate-limiter');
     const limiter = new RateLimiter(3, 60_000);
 
-    expect(limiter.check('key').allowed).toBe(true);
-    expect(limiter.check('key').allowed).toBe(true);
-    expect(limiter.check('key').allowed).toBe(true);
+    expect((await limiter.check('key')).allowed).toBe(true);
+    expect((await limiter.check('key')).allowed).toBe(true);
+    expect((await limiter.check('key')).allowed).toBe(true);
   });
 
   it('denies the request after the limit is exceeded', async () => {
     const { RateLimiter } = await import('@/lib/server/rate-limiter');
     const limiter = new RateLimiter(2, 60_000);
 
-    limiter.check('key');
-    limiter.check('key');
-    const result = limiter.check('key');
+    await limiter.check('key');
+    await limiter.check('key');
+    const result = await limiter.check('key');
 
     expect(result.allowed).toBe(false);
     expect(result.remaining).toBe(0);
@@ -384,18 +388,18 @@ describe('RateLimiter', () => {
     const { RateLimiter } = await import('@/lib/server/rate-limiter');
     const limiter = new RateLimiter(5, 60_000);
 
-    expect(limiter.check('key').remaining).toBe(4);
-    expect(limiter.check('key').remaining).toBe(3);
-    expect(limiter.check('key').remaining).toBe(2);
+    expect((await limiter.check('key')).remaining).toBe(4);
+    expect((await limiter.check('key')).remaining).toBe(3);
+    expect((await limiter.check('key')).remaining).toBe(2);
   });
 
   it('tracks separate keys independently', async () => {
     const { RateLimiter } = await import('@/lib/server/rate-limiter');
     const limiter = new RateLimiter(1, 60_000);
 
-    expect(limiter.check('a').allowed).toBe(true);
-    expect(limiter.check('b').allowed).toBe(true); // separate key — should be allowed
-    expect(limiter.check('a').allowed).toBe(false); // 'a' is now over limit
+    expect((await limiter.check('a')).allowed).toBe(true);
+    expect((await limiter.check('b')).allowed).toBe(true); // separate key — should be allowed
+    expect((await limiter.check('a')).allowed).toBe(false); // 'a' is now over limit
   });
 
   it('resets the window after windowMs elapses', async () => {
@@ -403,11 +407,11 @@ describe('RateLimiter', () => {
     const { RateLimiter } = await import('@/lib/server/rate-limiter');
     const limiter = new RateLimiter(1, 500);
 
-    limiter.check('key'); // fills the limit
-    expect(limiter.check('key').allowed).toBe(false);
+    await limiter.check('key'); // fills the limit
+    expect((await limiter.check('key')).allowed).toBe(false);
 
     vi.advanceTimersByTime(501);
-    expect(limiter.check('key').allowed).toBe(true); // new window opened
+    expect((await limiter.check('key')).allowed).toBe(true); // new window opened
     vi.useRealTimers();
   });
 
@@ -415,7 +419,7 @@ describe('RateLimiter', () => {
     const { RateLimiter } = await import('@/lib/server/rate-limiter');
     const limiter = new RateLimiter(5, 60_000);
     const before = Date.now();
-    const result = limiter.check('key');
+    const result = await limiter.check('key');
     expect(result.resetAtMs).toBeGreaterThan(before);
   });
 });

--- a/apps/web/tests/unit/rate-limiter.test.ts
+++ b/apps/web/tests/unit/rate-limiter.test.ts
@@ -14,87 +14,87 @@ describe('RateLimiter', () => {
     vi.useRealTimers();
   });
 
-  it('allows the first request and returns correct remaining count', () => {
+  it('allows the first request and returns correct remaining count', async () => {
     const limiter = new RateLimiter(5, 60_000);
-    const result = limiter.check('user-1');
+    const result = await limiter.check('user-1');
 
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(4);
   });
 
-  it('counts down remaining on subsequent requests', () => {
+  it('counts down remaining on subsequent requests', async () => {
     const limiter = new RateLimiter(3, 60_000);
 
-    const r1 = limiter.check('user-1');
-    const r2 = limiter.check('user-1');
-    const r3 = limiter.check('user-1');
+    const r1 = await limiter.check('user-1');
+    const r2 = await limiter.check('user-1');
+    const r3 = await limiter.check('user-1');
 
     expect(r1.remaining).toBe(2);
     expect(r2.remaining).toBe(1);
     expect(r3.remaining).toBe(0);
   });
 
-  it('blocks request after limit is exceeded', () => {
+  it('blocks request after limit is exceeded', async () => {
     const limiter = new RateLimiter(2, 60_000);
 
-    limiter.check('user-1');
-    limiter.check('user-1');
-    const r3 = limiter.check('user-1');
+    await limiter.check('user-1');
+    await limiter.check('user-1');
+    const r3 = await limiter.check('user-1');
 
     expect(r3.allowed).toBe(false);
     expect(r3.remaining).toBe(0);
   });
 
-  it('resets window after windowMs elapses', () => {
+  it('resets window after windowMs elapses', async () => {
     const limiter = new RateLimiter(2, 60_000);
 
-    limiter.check('user-1');
-    limiter.check('user-1');
+    await limiter.check('user-1');
+    await limiter.check('user-1');
 
     // Advance past window
     vi.advanceTimersByTime(60_001);
 
-    const result = limiter.check('user-1');
+    const result = await limiter.check('user-1');
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(1);
   });
 
-  it('tracks different keys independently', () => {
+  it('tracks different keys independently', async () => {
     const limiter = new RateLimiter(2, 60_000);
 
-    limiter.check('user-1');
-    limiter.check('user-1');
+    await limiter.check('user-1');
+    await limiter.check('user-1');
     // user-1 is now at limit
 
-    const resultB = limiter.check('user-2');
+    const resultB = await limiter.check('user-2');
     expect(resultB.allowed).toBe(true);
     expect(resultB.remaining).toBe(1);
   });
 
-  it('provides resetAtMs in the future', () => {
+  it('provides resetAtMs in the future', async () => {
     const limiter = new RateLimiter(10, 60_000);
     const now = Date.now();
 
-    const result = limiter.check('user-1');
+    const result = await limiter.check('user-1');
     expect(result.resetAtMs).toBeGreaterThan(now);
   });
 
-  it('resetAtMs stays consistent within the same window', () => {
+  it('resetAtMs stays consistent within the same window', async () => {
     const limiter = new RateLimiter(10, 60_000);
 
-    const r1 = limiter.check('user-1');
+    const r1 = await limiter.check('user-1');
     vi.advanceTimersByTime(5000); // still within window
-    const r2 = limiter.check('user-1');
+    const r2 = await limiter.check('user-1');
 
     expect(r1.resetAtMs).toBe(r2.resetAtMs);
   });
 
-  it('still allows the exact limit-th request', () => {
+  it('still allows the exact limit-th request', async () => {
     const limiter = new RateLimiter(3, 60_000);
 
-    limiter.check('u');
-    limiter.check('u');
-    const r = limiter.check('u'); // 3rd = exactly at limit
+    await limiter.check('u');
+    await limiter.check('u');
+    const r = await limiter.check('u'); // 3rd = exactly at limit
 
     expect(r.allowed).toBe(true);
     expect(r.remaining).toBe(0);
@@ -176,9 +176,9 @@ describe('proxyRateLimiter', () => {
     expect(proxyRateLimiter).toBeInstanceOf(RateLimiter);
   });
 
-  it('allows legitimate requests well under the 120/min limit', () => {
+  it('allows legitimate requests well under the 120/min limit', async () => {
     const key = `test-${Date.now()}`;
-    const result = proxyRateLimiter.check(key);
+    const result = await proxyRateLimiter.check(key);
     expect(result.allowed).toBe(true);
   });
 });

--- a/apps/web/tests/unit/require-auth.test.ts
+++ b/apps/web/tests/unit/require-auth.test.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 const mockUser = { id: 'user-100', email: 'auth@test.com' };
 const mockGetUser = vi.fn();
 const mockFrom = vi.fn();
+const mockCheckApiRateLimit = vi.fn();
 
 vi.mock('@/lib/supabase/server', () => ({
   createServerSupabaseClient: vi.fn(async () => ({
@@ -14,8 +15,12 @@ vi.mock('@/lib/supabase/server', () => ({
   })),
 }));
 
+vi.mock('@/lib/server/rate-limiter', () => ({
+  checkApiRateLimit: (userId: string) => mockCheckApiRateLimit(userId),
+}));
+
 // Import after mock
-import { requireAuth, requireRole } from '@/lib/auth/require-auth';
+import { requireAuth, requireAuthWithRateLimit, requireRole } from '@/lib/auth/require-auth';
 import type { AuthContext } from '@/lib/auth/require-auth';
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -33,6 +38,7 @@ function profileRow(role: string) {
 describe('requireAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckApiRateLimit.mockResolvedValue(null);
   });
 
   it('returns AuthContext when user is authenticated', async () => {
@@ -68,6 +74,34 @@ describe('requireAuth', () => {
 
     expect(result).toBeInstanceOf(NextResponse);
     expect((result as NextResponse).status).toBe(401);
+  });
+});
+
+describe('requireAuthWithRateLimit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckApiRateLimit.mockResolvedValue(null);
+  });
+
+  it('returns auth context when authenticated and within rate limit', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+
+    const result = await requireAuthWithRateLimit();
+
+    expect(result).not.toBeInstanceOf(NextResponse);
+    expect(mockCheckApiRateLimit).toHaveBeenCalledWith('user-100');
+  });
+
+  it('returns rate limit response when limiter denies request', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockCheckApiRateLimit.mockResolvedValue(
+      NextResponse.json({ error: 'rate_limited' }, { status: 429 }),
+    );
+
+    const result = await requireAuthWithRateLimit();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(429);
   });
 });
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -52,28 +52,32 @@ Services on the same Railway project can communicate over an internal private ne
 
 ### Vercel (apps/web) -- Server-Side Only
 
-| Variable                    | Purpose                                                   |
-| --------------------------- | --------------------------------------------------------- |
-| `ENGINE_URL`                | Railway engine URL (e.g. `https://engine.up.railway.app`) |
-| `ENGINE_API_KEY`            | Engine authentication key                                 |
-| `AGENTS_URL`                | Railway agents URL (e.g. `https://agents.up.railway.app`) |
-| `SUPABASE_SERVICE_ROLE_KEY` | Privileged Supabase access                                |
-| `CRON_SECRET`               | Verifies Vercel cron requests to internal endpoints       |
+| Variable                      | Purpose                                                   |
+| ----------------------------- | --------------------------------------------------------- |
+| `ENGINE_URL`                  | Railway engine URL (e.g. `https://engine.up.railway.app`) |
+| `ENGINE_API_KEY`              | Engine authentication key                                 |
+| `AGENTS_URL`                  | Railway agents URL (e.g. `https://agents.up.railway.app`) |
+| `SUPABASE_SERVICE_ROLE_KEY`   | Privileged Supabase access                                |
+| `CRON_SECRET`                 | Verifies Vercel cron requests to internal endpoints       |
+| `RATE_LIMIT_REDIS_REST_URL`   | Shared Redis REST URL for distributed rate limiting       |
+| `RATE_LIMIT_REDIS_REST_TOKEN` | Shared Redis REST auth token                              |
 
 ### Railway Engine (apps/engine)
 
-| Variable                    | Purpose                         |
-| --------------------------- | ------------------------------- |
-| `POLYGON_API_KEY`           | Market data provider            |
-| `ALPACA_API_KEY`            | Broker authentication           |
-| `ALPACA_SECRET_KEY`         | Broker secret                   |
-| `ALPACA_BASE_URL`           | Paper vs live endpoint          |
-| `BROKER_MODE`               | `paper` or `live`               |
-| `SUPABASE_SERVICE_ROLE_KEY` | Database access                 |
-| `NEXT_PUBLIC_SUPABASE_URL`  | Database endpoint               |
-| `ENGINE_API_KEY`            | Validates inbound auth          |
-| `CORS_ORIGINS`              | Allowed origins (Vercel domain) |
-| `PORT`                      | Railway-assigned port (auto)    |
+| Variable                      | Purpose                                             |
+| ----------------------------- | --------------------------------------------------- |
+| `POLYGON_API_KEY`             | Market data provider                                |
+| `ALPACA_API_KEY`              | Broker authentication                               |
+| `ALPACA_SECRET_KEY`           | Broker secret                                       |
+| `ALPACA_BASE_URL`             | Paper vs live endpoint                              |
+| `BROKER_MODE`                 | `paper` or `live`                                   |
+| `SUPABASE_SERVICE_ROLE_KEY`   | Database access                                     |
+| `NEXT_PUBLIC_SUPABASE_URL`    | Database endpoint                                   |
+| `ENGINE_API_KEY`              | Validates inbound auth                              |
+| `CORS_ORIGINS`                | Allowed origins (Vercel domain)                     |
+| `PORT`                        | Railway-assigned port (auto)                        |
+| `RATE_LIMIT_REDIS_REST_URL`   | Shared Redis REST URL for distributed rate limiting |
+| `RATE_LIMIT_REDIS_REST_TOKEN` | Shared Redis REST auth token                        |
 
 ### Railway Agents (apps/agents)
 
@@ -141,6 +145,8 @@ All upstream URL resolution, auth headers, timeouts, and retries are centralized
 | `apps/web/vercel.json`     | Install/build/dev/ignore/crons | Vercel      |
 | `apps/engine/railway.toml` | Engine health check + restart  | Railway     |
 | `railway.toml`             | Agents health check + restart  | Railway     |
+
+Both Railway services are configured for `numReplicas = 2` to support single-replica failover.
 
 ## Vercel web app — dashboard vs `apps/web/vercel.json`
 

--- a/docs/runbooks/production.md
+++ b/docs/runbooks/production.md
@@ -30,6 +30,9 @@ Database: Supabase (us-east-1)
   - `NEXT_PUBLIC_SUPABASE_URL` = Supabase URL
   - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (fallback)
   - `SUPABASE_SERVICE_ROLE_KEY` = Supabase service role key
+- [ ] Distributed rate limiter env vars are set consistently on web + engine:
+  - `RATE_LIMIT_REDIS_REST_URL`
+  - `RATE_LIMIT_REDIS_REST_TOKEN`
 
 ### Railway ↔ Supabase Pro Standard
 
@@ -60,6 +63,7 @@ Use this as the minimum production bar before deploy approval:
 3. Vercel auto-deploys production on every push to `main` (ignore command bypasses diff check for production).
 4. Wait for the Vercel build to reach `READY` state.
 5. Run production smoke tests.
+6. Confirm both Railway services are running 2 healthy replicas after deploy.
 
 If you need to force a deploy without a commit:
 
@@ -92,6 +96,18 @@ Check Railway logs for:
 - Clean startup messages
 - Correct port binding (`PORT` env var)
 - Health check responses
+- Replica balancing (requests served by both instances, no crash-looping replica)
+
+## Availability and Failover Expectations
+
+- Railway services (`engine`, `agents`) run with `numReplicas = 2`.
+- Expected behavior during single-replica failure:
+  - Service remains available (degraded capacity, no full outage).
+  - `/health` remains 200 while at least one replica is healthy.
+  - p95 latency may increase up to 2x temporarily during rescheduling.
+- SLO guidance during failover window (15 minutes):
+  - Engine/Agents availability should remain >= 99.0%.
+  - 5xx proxy error rate should remain <= 1%.
 
 ## Cutover Rules
 

--- a/docs/runbooks/release-checklist.md
+++ b/docs/runbooks/release-checklist.md
@@ -69,6 +69,7 @@ Evidence template (paste into PR body):
 - [ ] No `localhost` URLs hardcoded in production code paths
 - [ ] If API routes changed: proxy routes still forward correctly
 - [ ] If env vars changed: deployment guide updated
+- [ ] If rate-limiter settings changed: `RATE_LIMIT_REDIS_REST_URL/TOKEN` validated for web + engine
 - [ ] Review checklist in `docs/ai/review-checklist.md` completed
 
 ---
@@ -144,6 +145,7 @@ railway up --service sentinel-engine --environment production
 - [ ] Engine deployed to Railway
 - [ ] Engine `/health` returns 200
 - [ ] Engine logs show clean startup and correct port binding
+- [ ] Engine has 2 healthy replicas
 
 **Agents:**
 
@@ -155,6 +157,7 @@ railway up --service sentinel-agents --environment production
 - [ ] Agents `/health` returns 200
 - [ ] Agents `/status` returns orchestrator state
 - [ ] Agents logs show clean startup and correct port binding
+- [ ] Agents has 2 healthy replicas
 
 ### 4.2 Vercel Preview Validation
 
@@ -220,6 +223,7 @@ Run these within 5 minutes of production deploy completing.
 - [ ] Railway engine logs: clean startup
 - [ ] Railway agents logs: clean startup
 - [ ] Correlation IDs flowing (check a sample request trace per [correlation-id-flow.md](correlation-id-flow.md))
+- [ ] During a rolling restart of one backend replica, user traffic remains healthy (no sustained 5xx spike >1%)
 
 ### 5.4 Live Trading Activation Gate
 

--- a/railway.toml
+++ b/railway.toml
@@ -21,5 +21,5 @@ healthcheckPath = "/health"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5
-numReplicas = 1
+numReplicas = 2
 startCommand = "node apps/agents/dist/index.js"


### PR DESCRIPTION
### Motivation

- Add support for a shared Redis-backed rate limiter (via a Redis REST pipeline) to provide globally consistent API rate limiting across instances while retaining a local in-memory fallback for dev. 
- Harden trading safety by failing closed on control-plane read errors for live Alpaca endpoints. 
- Propagate the async rate-limiter API through server routes and middleware to ensure routes actually await rate-limit checks. 

### Description

- Implement a Redis-REST-aware rate limiter: `createRedisRateLimiterClient()` and an async `RateLimiter.check` that queries a Redis REST pipeline and falls back to an in-process sliding window when unavailable. 
- Replace synchronous `checkApiRateLimit`/`checkMutationRateLimit` with async variants and update `proxy`, middleware, and many Next.js API routes to `await checkApiRateLimit(user.id)` to enforce rate limiting correctly. 
- Add engine-side HTTP rate limiting middleware using a `_RedisRestLimiter` with an `_MemoryLimiter` fallback and update headers to expose `X-RateLimit-*`. 
- Add fail-closed semantics for halt checks: introduce `should_fail_closed_on_halt_check` and change `check_trading_halts` signature to `check_trading_halts(*, fail_closed: bool, experiment_id: str | None)` and wire it into `POST /portfolio/orders`. 
- Add `requireAuthWithRateLimit` helper and make mutation CSRF limiter async (`checkMutationRateLimit`). 
- Increase test/coverage and CI-related config: raise coverage `fail_under` from `60` to `75` in `apps/engine/pyproject.toml`. 
- Infrastructure and docs updates: set `numReplicas = 2` for Railway services (`apps/engine/railway.toml`, root `railway.toml`) and document `RATE_LIMIT_REDIS_REST_URL` / `RATE_LIMIT_REDIS_REST_TOKEN` env vars plus availability/failover guidance in `docs/*`. 
- Update and expand unit tests to reflect async rate limiter and fail-closed halt behavior, including additions to `test_live_execution_gate.py`, `test_portfolio_routes.py`, and multiple `web` unit tests to `await` rate-limiter calls. 

### Testing

- Ran unit test suites for `apps/web` and `apps/engine` covering rate limiter behavior, proxy middleware, auth helpers, and live-execution gate, including updated tests in `apps/web/tests/unit/*` and `apps/engine/tests/unit/*`, and they passed. 
- Updated and executed rate-limiter unit tests (`rate-limiter.test.ts`, `api-rate-limiter.test.ts`) and proxy/auth unit tests to validate async behavior, and assertions adjusted to `await` the new async checks. 
- Verified docs and deployment checks updated and lint/test config (`pyproject.toml`) adjusted; CI should run full test matrix (`test-web`, `test-engine`, `test-agents`) as part of the pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ef5450ec832cab9165fa921b7bcb)