### PR TITLE
docs: reconcile proxy path, playwright path, and stale coordination refs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,8 @@ Describe the outcome in 2-5 lines.
 - [ ] No accidental shared contract drift
 - [ ] No accidental migration or env contract change
 - [ ] No secrets or credentials in the diff
+- [ ] Changed architectural boundary declared (proxy/auth/shared contracts/migrations)
+- [ ] Contract consumers checked (if `packages/shared`, proxy, or migrations touched)
 
 ## Reviewer Focus
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -7,7 +7,7 @@
 
 ## Active Context
 
-_Last updated: 2026-04-10_
+_Last updated: 2026-04-17_
 
 ### Current Architecture Decisions
 
@@ -37,12 +37,13 @@ _Last updated: 2026-04-10_
 
 > Record approaches that were tried and failed. Prevents agents from re-trying the same thing.
 
-| Date       | Agent    | What Was Tried                                     | Why It Failed                                            | Lesson                                              |
-| ---------- | -------- | -------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------- |
-| 2026-04-09 | Multiple | 8 overlapping PRs from 3 agents                    | No coordination — agents didn't check for in-flight work | Always check open PRs before starting work          |
-| 2026-04-09 | Codex    | PR #297 used `BrokerInterface` class name          | Hallucinated — actual class is `BrokerAdapter`           | Run `pnpm typecheck` before creating PR             |
-| 2026-04-09 | Codex    | PR #295 added `middleware.ts` alongside `proxy.ts` | Next.js rejects coexistence of middleware + proxy        | Check existing patterns before introducing new ones |
-| 2026-04-09 | Codex    | PR #297 touched 64 files across 5 subsystems       | Too broad — impossible to review safely                  | Keep PRs under 20 files, one concern per PR         |
+| Date       | Agent    | What Was Tried                                                | Why It Failed                                                           | Lesson                                                     |
+| ---------- | -------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
+| 2026-04-09 | Multiple | 8 overlapping PRs from 3 agents                               | No coordination — agents didn't check for in-flight work                | Always check open PRs before starting work                 |
+| 2026-04-09 | Codex    | PR #297 used `BrokerInterface` class name                     | Hallucinated — actual class is `BrokerAdapter`                          | Run `pnpm typecheck` before creating PR                    |
+| 2026-04-09 | Codex    | PR #295 added `middleware.ts` alongside `proxy.ts`            | Next.js rejects coexistence of middleware + proxy                       | Check existing patterns before introducing new ones        |
+| 2026-04-09 | Codex    | PR #297 touched 64 files across 5 subsystems                  | Too broad — impossible to review safely                                 | Keep PRs under 20 files, one concern per PR                |
+| 2026-04-17 | Audit    | Guardian/pre-PR scripts enforced `middleware.ts` as high-risk | `proxy.ts` replaced `middleware.ts`; coexistence is rejected by Next.js | Always check `proxy.ts` is the current request gating file |
 
 ---
 

--- a/docs/ai/code-standards.md
+++ b/docs/ai/code-standards.md
@@ -309,7 +309,7 @@ it('renders an error toast when the portfolio fetch fails', async () => {
 
 ### 6.5 End-to-End (Playwright)
 
-- Playwright tests live in `apps/web/e2e/`.
+- Playwright tests live in `apps/web/tests/e2e/` (configured via `playwright.config.ts` `testDir`). Note: `apps/web/e2e/smoke.spec.ts` also exists as a legacy smoke test; the canonical suite is `tests/e2e/`.
 - Run with `pnpm test:web:e2e`.
 - E2E tests cover critical user flows: login, portfolio view, trade execution, settings.
 - Do not use E2E tests for unit-level logic — keep them focused on integration.

--- a/scripts/pr-guardian.mjs
+++ b/scripts/pr-guardian.mjs
@@ -67,7 +67,7 @@ const CONFIG = {
     'supabase/migrations/',
     'apps/web/src/lib/engine-fetch.ts',
     'apps/web/src/lib/engine-client.ts',
-    'apps/web/src/middleware.ts',
+    'apps/web/src/proxy.ts',
     'apps/engine/src/api/main.py',
     'apps/engine/src/config.py',
     'apps/agents/src/server.ts',

--- a/scripts/pre-pr-check.mjs
+++ b/scripts/pre-pr-check.mjs
@@ -162,7 +162,7 @@ async function main() {
 
   const riskPaths = [
     '.github/workflows/', 'packages/shared/src/', 'supabase/migrations/',
-    'apps/web/src/lib/engine-fetch.ts', 'apps/web/src/middleware.ts',
+    'apps/web/src/lib/engine-fetch.ts', 'apps/web/src/proxy.ts',
     'apps/engine/src/api/main.py', 'apps/engine/src/config.py',
   ];
   const riskHits = changedFiles.filter((f) =>


### PR DESCRIPTION
## Summary

Phase 1 of 4-phase AI-workflow drift cleanup.

- Update `pr-guardian.mjs` and `pre-pr-check.mjs` highRiskPaths to reference `apps/web/src/proxy.ts` (was stale `middleware.ts` — the app migrated to Next.js proxy; coexistence is rejected).
- Fix `docs/ai/code-standards.md` Playwright path to `apps/web/tests/e2e/` matching the actual `playwright.config.ts` testDir.
- Refresh `WORKLOG.md` Active Context timestamp; log the guardian-drift discovery under Failed Approaches.
- Add two contract-risk fields to the PR template.

## Validation

| Command | Result |
|---------|--------|
| `git diff --check` | ✅ PASS |
| Manual verification of edits | ✅ PASS |

Docs/config-only; no build/test suite required.

## Phase order

This is Phase 1. Phases 2–4 are separate PRs, intended to merge in order.