### PR TITLE
chore(ai): add contract-guardian subagent and PostToolUse validation hooks

### DIFF
--- a/.claude/agents/contract-guardian.md
+++ b/.claude/agents/contract-guardian.md
@@ -1,0 +1,41 @@
+# Contract Guardian
+
+Specialized subagent for reviewing changes that touch shared contracts,
+proxy/auth boundaries, or database migrations.
+
+## When to invoke
+
+Invoke this subagent proactively when ANY of the following paths are in scope:
+
+- `packages/shared/src/*`
+- `apps/web/src/proxy.ts`
+- `apps/web/src/lib/engine-fetch.ts`
+- `apps/web/src/lib/engine-client.ts`
+- `apps/engine/src/config.py`
+- `supabase/migrations/*`
+
+## Role
+
+You are a contract-safety reviewer. Do not write code. Your job is to:
+
+1. Enumerate every downstream consumer of the changed contract or boundary.
+2. Verify each consumer has been accounted for in the task scope.
+3. Identify validation gaps (tests that don't cover the changed shape).
+4. Flag rollback risk (migrations are irreversible; proxy changes affect all routes).
+5. Produce a short review table:
+
+| Consumer | Accounted For | Risk Level   | Notes |
+| -------- | ------------- | ------------ | ----- |
+| ...      | ✅ / ❌       | LOW/MED/HIGH | ...   |
+
+## Allowed tools
+
+Read, Grep, Glob — no edits.
+
+## Output format
+
+End with one of:
+
+- `APPROVED` — all consumers accounted for, low risk
+- `REVIEW NEEDED` — gaps found
+- `BLOCKED` — migration or proxy change with no downstream validation

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,5 +75,28 @@
       "Bash(python3 -m pytest:*)",
       "Bash(python -m pytest:*)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/validate-changed-scope.mjs --dry-run 2>/dev/null | grep -E 'migrations|packages/shared|proxy\\.ts|engine-fetch' && echo 'HIGH-RISK PATH TOUCHED — run pnpm validate:changed before continuing' || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/validate-changed-scope.mjs 2>/dev/null; echo 'Session end: validate:changed complete'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ apps/agents/.tmp/
 
 # Claude Code local settings
 .claude/settings.local.json
-.claude/agents/
+.claude/agents/*
+!.claude/agents/contract-guardian.md
 .claude/worktrees/
 .claude/agent-memory/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,18 @@
 - Reusable project skills live in `.claude/skills/`. Check for an existing Sentinel skill before inventing a new workflow.
 - Permissions live in `.claude/settings.json`. Keep permissions narrow and project-specific.
 
+## Hooks and Subagents
+
+- **PostToolUse hook**: After any file edit, a fast check scans for high-risk path touches and
+  warns to run `pnpm validate:changed`. This is a warning, not a blocker.
+- **Stop hook**: At session end, `validate:changed` runs automatically to surface any
+  unvalidated changes before handoff.
+- **contract-guardian subagent** (`.claude/agents/contract-guardian.md`): Invoke this
+  subagent before proposing edits that touch shared types, proxy code, auth utilities,
+  or migrations. It enumerates consumers and flags rollback risk.
+
+Invoke contract-guardian explicitly: `Use the contract-guardian subagent to review this change.`
+
 ## Commands (Quick Reference)
 
 See `docs/ai/commands.md` for the full matrix. Most common:


### PR DESCRIPTION
/settings.json\))'` | ✅ PASS |
| `git diff --check` | ✅ PASS |

## Phase order

Depends on Phase 2 (#350) for `scripts/validate-changed-scope.mjs`. Merge Phase 2 first.