### PR TITLE
docs(ai): shift live task coordination from markdown claims to GitHub artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ and a Python engine that is validated separately from the Node workspaces.
 3. `docs/ai/architecture.md`
 4. `docs/ai/commands.md`
 5. `docs/ai/review-checklist.md`
-6. `docs/ai/state/project-state.md`
+6. `docs/ai/state/project-state.md` _(secondary view — check GitHub issues for live status)_
 7. `docs/ai/agent-ops.md`
 8. `CLAUDE.md` when using Claude Code
 
@@ -120,9 +120,10 @@ gh pr list --state open                 # must have <2 of your PRs
 
 ## Execution State
 
-- Before editing files, read `docs/ai/state/project-state.md` and claim one ticket or explicitly note you are performing an untracked audit.
-- Use `docs/ai/agent-ops.md` for the startup checklist, claim protocol, handoff format, and session priority order.
-- Treat `docs/ai/state/project-state.md` as the live source of truth for task status. Do not create a competing status tracker in another file.
+- Before editing files, check open GitHub issues for the task you are claiming. Assign the issue to yourself (or note "untracked audit") before starting.
+- Use `docs/ai/agent-ops.md` for the startup checklist, handoff format, and session priority order.
+- GitHub issue assignment + PR linkage is the authoritative coordination surface. `docs/ai/state/project-state.md` is a secondary summary view only — do not treat it as live truth and do not block on it being current.
+- If no issue exists for your task, note "untracked audit" in the PR description.
 
 ## Collaboration Defaults
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -14,7 +14,7 @@ _Last updated: 2026-04-10_
 - **Web → Engine**: All calls go through `apps/web/src/lib/engine-fetch.ts` (same-origin proxy)
 - **Web → Agents**: All calls go through `apps/web/src/lib/agents-client.ts`
 - **Deployment**: Vercel (web) + Railway (engine + agents) + Supabase (database)
-- **Agent coordination**: `docs/ai/state/project-state.md` is the single source of truth for task status
+- **Task coordination**: GitHub issue assignment + PR linkage (primary). `docs/ai/state/project-state.md` is secondary/generated — do not treat as live truth.
 
 ### Known Working Patterns
 

--- a/docs/ai/working-agreement.md
+++ b/docs/ai/working-agreement.md
@@ -129,7 +129,7 @@ When multiple AI agents (Claude, Codex, Copilot) are active in the same repo:
 1. Read `WORKLOG.md` to check for active context and failed approaches
 2. Run `gh pr list --state open` to check for in-flight work
 3. Run `bash scripts/agent-worktree.sh list` to see active worktrees
-4. Claim your ticket in `project-state.md` before editing any files
+4. Assign the GitHub issue to yourself before editing any files. If no issue exists, create one or note "untracked audit" in your first commit message. Do not rely on `project-state.md` as a real-time claim registry — it is a summary artifact, not a lock file.
 5. If another agent is active on overlapping files, STOP and wait
 
 ### During work
@@ -149,7 +149,7 @@ When multiple AI agents (Claude, Codex, Copilot) are active in the same repo:
 ### After finishing
 
 1. Update `WORKLOG.md` with session entry
-2. Update `project-state.md` with task status
+2. Update the GitHub issue status (close on merge or comment with the PR link). `project-state.md` is a secondary summary — not required to update in real time.
 3. Remove your worktree: `bash scripts/agent-worktree.sh remove <branch>`
 4. If your PR is merged, clean up: `bash scripts/agent-worktree.sh clean`
 


### PR DESCRIPTION
## Summary

Phase 4 of 4. Moves live task coordination from mutable markdown claims to GitHub issue/PR assignment.

- `AGENTS.md` Execution State: replace 'claim in project-state.md' language with 'assign GitHub issue to yourself'. Read-order item 6 tagged as secondary view.
- `docs/ai/working-agreement.md`: startup + finish claim protocol points at GitHub issues, not markdown editing.
- `WORKLOG.md`: record the coordination shift under Current Architecture Decisions.

Rationale: `project-state.md` drifts (confirmed during audit — chronology artifacts present). GitHub issues + PR linkage is the trustworthy coordination surface for multi-agent work.

## Validation

| Command | Result |
|---------|--------|
| `git diff --check` | ✅ PASS |
| grep verification (no remaining 'live source of truth' refs) | ✅ PASS |

## Phase order

Final phase. Safe to merge after Phase 1 (#349).