### PR TITLE
fix(engine): capture rate-limit remaining count inside async lock

### DIFF
--- a/apps/engine/src/middleware/rate_limit.py
+++ b/apps/engine/src/middleware/rate_limit.py
@@ -55,10 +55,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 )
 
             self.request_counts[client_ip].append(now)
+            remaining = self.requests_per_minute - len(self.request_counts[client_ip])
 
         response = await call_next(request)
         response.headers["X-RateLimit-Limit"] = str(self.requests_per_minute)
-        response.headers["X-RateLimit-Remaining"] = str(
-            self.requests_per_minute - len(self.request_counts[client_ip])
-        )
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
         return response


### PR DESCRIPTION
Single small fix: move the read of rate-limit remaining count inside the async lock to prevent a race window.

**Scope**: 1 file, ~5 lines (apps/engine/src/middleware/rate_limit.py).

**Validation**: pnpm test:engine should still pass.

Auto-opened during repo cleanup on 2026-04-17.