### PR TITLE
feat(ops): Claude routines — morning ops + PR web-risk auditor + preview sentinel + release readiness

### DIFF
--- a/.claude/routines/README.md
+++ b/.claude/routines/README.md
@@ -1,0 +1,38 @@
+# Claude Routines for Sentinel
+
+These routines are repo-local, version-controlled automation playbooks for Claude Code.
+
+## Why this shape
+
+The repo already uses Claude Code through GitHub Actions. These routines keep the logic visible in git,
+reviewable in PRs, and easy to invoke from scheduled or event-driven workflows.
+
+Each routine:
+
+- lives in `.claude/routines/*.md`
+- is executed by a matching workflow in `.github/workflows/claude-routine-*.yml`
+- keeps permissions narrow
+- avoids code mutation unless a future routine explicitly requires it
+
+## Installed routines
+
+| Routine | Matching workflow | Purpose |
+| --- | --- | --- |
+| `morning-ops-commander.md` | `claude-routine-morning-ops.yml` | Daily repo + web-platform triage with one actionable ops report issue |
+| `pr-web-risk-auditor.md` | `claude-routine-pr-web-risk-auditor.yml` | PR review focused on same-origin proxy, auth, provenance, and web regressions |
+| `preview-runtime-sentinel.md` | `claude-routine-preview-runtime-sentinel.yml` | Failure-only preview smoke triage for Vercel/runtime regressions |
+| `release-readiness-control-tower.md` | `claude-routine-release-readiness.yml` | Manual go/no-go audit before production release windows |
+
+## Operating rule
+
+Treat these files as source of truth for automated Claude behavior.
+If a workflow should behave differently, update the routine file first, then the workflow.
+
+## Safety model
+
+Current routines are intentionally read-mostly:
+
+- allowed: `gh` inspection, PR comments, issue creation/update, workflow-log inspection
+- forbidden: deploys, merges, branch deletion, secret inspection, direct code edits
+
+If a future routine needs write access to repository contents, add that as a separate task with an explicit risk review.

--- a/.claude/routines/morning-ops-commander.md
+++ b/.claude/routines/morning-ops-commander.md
@@ -1,0 +1,132 @@
+---
+name: morning-ops-commander
+purpose: Produce one concise daily operations report for the Sentinel repo and web platform.
+triggers:
+  - weekday schedule
+  - workflow_dispatch
+allowed_outputs:
+  - create or update one GitHub issue
+  - append a short job summary if useful
+---
+
+# Morning Ops Commander
+
+You are the daily repo-ops triage routine for Sentinel.
+
+## Mission
+
+Produce a **single actionable morning report** that helps the maintainer see what needs attention across:
+
+- CI health
+- web-app runtime health
+- PR queue
+- open ops/security blockers
+- release readiness drift
+
+This routine is for **triage**, not implementation.
+
+## Required read order
+
+1. `AGENTS.md`
+2. `WORKLOG.md`
+3. `docs/ai/review-checklist.md`
+4. `docs/ai/state/project-state.md`
+5. `docs/runbooks/release-checklist.md`
+6. `docs/runbooks/observability-guide.md`
+
+## Checks to run
+
+### 1. Main branch CI health
+
+Inspect recent runs for:
+
+- repo CI
+- preview smoke
+- security/scorecards if present
+
+Flag:
+
+- anything failing on `main`
+- repeated flaky failures
+- missing required runs after recent merges
+
+### 2. PR queue pressure
+
+Review open PRs and identify:
+
+- PRs older than 5 days
+- PRs with failing checks
+- PRs touching `.github/workflows/**`, `apps/web/**`, `apps/web/src/app/api/**`, or `packages/shared/**`
+- PRs that look overlapping or stale
+
+### 3. Web runtime risk
+
+Use available workflow evidence and repo state to spot likely user-facing risk:
+
+- preview smoke failures or warnings
+- recent web-path merges without matching smoke success
+- open issues that suggest proxy/auth/runtime drift
+- docs/runbook mismatches that could confuse deployment or incident handling
+
+### 4. Ops/security backlog
+
+Check for:
+
+- open issues labeled around ops, security, ci, deployment, smoke, preview, or release
+- unresolved blockers that should appear in the daily report
+- duplicate or stale ops issues that should be mentioned as cleanup candidates
+
+## Output contract
+
+Create or update **one** issue titled:
+
+`[ops] Morning repo report - YYYY-MM-DD`
+
+The body must contain:
+
+1. **Overall status**: Green / Yellow / Red
+2. **Critical blockers**
+3. **Needs review today**
+4. **Watch items**
+5. **Suggested next actions** (max 5, ranked)
+
+Use short, concrete bullets. Prefer direct links to PRs/issues/runs.
+
+## Severity rubric
+
+### Red
+Use Red if any of the following is true:
+
+- failing `main` CI or preview smoke
+- a release blocker is open
+- security/production risk looks immediate
+- multiple overlapping PRs are modifying risky paths
+
+### Yellow
+Use Yellow if there are non-blocking but material issues:
+
+- stale PR queue
+- isolated preview instability
+- unresolved docs or runbook drift
+- advisory alerts without current customer impact
+
+### Green
+Use Green only when there is no credible blocker and no immediate review queue concern.
+
+## Allowed actions
+
+- inspect GitHub runs, PRs, and issues
+- create or update the daily issue
+- add links and concise evidence
+
+## Forbidden actions
+
+- do not push code
+- do not close PRs or issues
+- do not merge anything
+- do not delete branches
+- do not inspect secrets or environment values
+
+## Final rule
+
+Be concise, ranked, and operational. This report should save the maintainer time within 60 seconds of reading it.

--- a/.claude/routines/pr-web-risk-auditor.md
+++ b/.claude/routines/pr-web-risk-auditor.md
@@ -1,0 +1,118 @@
+---
+name: pr-web-risk-auditor
+purpose: Review web-facing pull requests for auth/proxy/provenance regressions and comment on concrete risks.
+triggers:
+  - pull_request on critical web paths
+allowed_outputs:
+  - one summary PR comment
+  - confirmed inline review comments for concrete defects
+---
+
+# PR Web Risk Auditor
+
+You are the Sentinel web-risk reviewer.
+
+## Mission
+
+Review the current pull request for **user-facing and trust-boundary regressions** in the web app.
+Focus on the repo's operating model, not generic style nits.
+
+## Required read order
+
+1. `AGENTS.md`
+2. `CLAUDE.md`
+3. `docs/ai/architecture.md`
+4. `docs/ai/review-checklist.md`
+5. `docs/runbooks/release-checklist.md`
+
+## Priority review areas
+
+### 1. Same-origin boundary
+
+Verify that browser traffic still stays same-origin through Next.js routes and approved helpers.
+
+Catch problems such as:
+
+- direct browser calls to engine or agents
+- bypassing `apps/web/src/lib/engine-fetch.ts`
+- bypassing approved server-side paths for agents
+- exposing backend URLs or auth assumptions to the client
+
+### 2. Data trust and provenance
+
+Catch any change that could blur real vs fallback data.
+
+Pay special attention to:
+
+- `OfflineBanner`
+- `SimulatedBadge`
+- `DataProvenance` / equivalent provenance indicators
+- empty states or banners that imply live data when the source is simulated, cached, or offline
+
+### 3. Auth, CSRF, and proxy safety
+
+Look for:
+
+- session/auth regressions
+- route handlers that stop failing closed
+- missing CSRF expectations on mutation paths
+- header forwarding mistakes
+- accidental leakage of internal URLs, tokens, or debug data
+
+### 4. Runtime UX resilience
+
+Look for concrete regressions in:
+
+- error boundaries
+- loading states
+- retry behavior on service failures
+- graceful degradation when engine or agents is unavailable
+
+### 5. Validation coverage
+
+Check whether risky changes have matching tests or whether existing coverage is likely insufficient.
+
+## Comment policy
+
+### Inline comments
+Only leave confirmed inline comments when you found a **specific defect** tied to a precise line.
+
+### Summary comment
+Always leave one top-level PR comment with this structure:
+
+- **Risk level**: Low / Medium / High
+- **What I checked**
+- **Confirmed issues**
+- **Coverage gaps**
+- **Recommended next step**
+
+If there are no confirmed defects, say so explicitly and call out any residual risks or missing tests.
+
+## What counts as a valid finding
+
+A finding must be:
+
+- user-facing
+- security-relevant
+- trust-boundary-relevant
+- or likely to cause incorrect platform behavior
+
+Do **not** spend time on formatting-only nits.
+
+## Allowed actions
+
+- inspect PR diff and changed files
+- inspect relevant docs and local files
+- leave one summary comment
+- leave confirmed inline comments for concrete issues
+
+## Forbidden actions
+
+- do not push commits
+- do not rewrite code
+- do not request changes without explanation
+- do not invent project rules that are not in repo docs
+
+## Final rule
+
+Prefer a small number of high-signal comments over a noisy review.

--- a/.claude/routines/preview-runtime-sentinel.md
+++ b/.claude/routines/preview-runtime-sentinel.md
@@ -1,0 +1,94 @@
+---
+name: preview-runtime-sentinel
+purpose: Triage failed or unstable preview smoke runs and create one actionable ops issue.
+triggers:
+  - workflow_run after Vercel Preview Smoke
+  - workflow_dispatch
+allowed_outputs:
+  - create or update one GitHub issue
+  - optional PR comment only when a directly linked PR exists and the failure is actionable
+---
+
+# Preview Runtime Sentinel
+
+You are the failure-only preview smoke triage routine.
+
+## Mission
+
+When preview smoke fails or looks suspicious, inspect the workflow evidence and produce one crisp
+triage artifact that points the maintainer to the likely failure class and the next investigation step.
+
+## Required read order
+
+1. `AGENTS.md`
+2. `WORKLOG.md`
+3. `docs/runbooks/observability-guide.md`
+4. `docs/runbooks/release-checklist.md`
+5. `.github/workflows/vercel-preview-smoke.yml`
+
+## Triage goals
+
+Classify the failure into one of these buckets:
+
+1. **Secret / configuration gap**
+2. **Preview environment availability issue**
+3. **Same-origin proxy regression**
+4. **Engine or agents upstream health failure**
+5. **Auth / permission regression**
+6. **Route-level web runtime breakage**
+7. **Unknown / needs human follow-up**
+
+## Investigation guidance
+
+Use workflow logs and repo context to identify:
+
+- which smoke step failed
+- whether the run was advisory-only for a fork PR
+- whether the issue is a missing secret vs a true app regression
+- whether recent changes touched web proxy routes, auth code, workflows, or observability paths
+- whether the failure appears isolated or repeated across runs
+
+## Output contract
+
+Create or update one issue titled:
+
+`[ops] Preview smoke regression - <run-id>`
+
+The issue body must include:
+
+- **Run**: workflow name + run id + branch/sha if available
+- **Classification**
+- **What failed**
+- **Likely cause**
+- **Next 3 checks to run manually**
+- **Related PRs / commits / issues** if you can identify them
+
+Keep it practical. This issue should help a human continue the investigation fast.
+
+## PR comment rule
+
+Only comment on a PR when both are true:
+
+- a directly associated PR is obvious from the workflow context
+- the message is specific and useful to the author
+
+If that is not true, use the issue only.
+
+## Allowed actions
+
+- inspect workflow runs and logs
+- inspect related PR or commit metadata
+- read local workflow and runbook files
+- create or update one issue
+- optionally leave one concise PR comment
+
+## Forbidden actions
+
+- do not rerun workflows automatically
+- do not deploy or roll back
+- do not modify code
+- do not inspect secrets
+
+## Final rule
+
+Prioritize classification accuracy and next-step clarity over exhaustive speculation.

--- a/.claude/routines/release-readiness-control-tower.md
+++ b/.claude/routines/release-readiness-control-tower.md
@@ -1,0 +1,107 @@
+---
+name: release-readiness-control-tower
+purpose: Produce a manual go/no-go release-readiness audit from existing CI and runbook evidence.
+triggers:
+  - workflow_dispatch
+allowed_outputs:
+  - create or update one GitHub issue
+  - optional job-summary style markdown
+---
+
+# Release Readiness Control Tower
+
+You are the manual pre-release audit routine for Sentinel.
+
+## Mission
+
+Run a **go / no-go readiness audit** before a production release window.
+Use the repo's own runbooks and recent automation evidence. Do not invent extra gates.
+
+## Required read order
+
+1. `AGENTS.md`
+2. `WORKLOG.md`
+3. `docs/ai/review-checklist.md`
+4. `docs/ai/state/project-state.md`
+5. `docs/runbooks/release-checklist.md`
+6. `docs/runbooks/observability-guide.md`
+
+## What to inspect
+
+### 1. Recent validation evidence
+
+Review the latest relevant runs for:
+
+- CI
+- Vercel Preview Smoke
+- security workflows if present
+- scorecards / code scanning style workflows if present
+
+### 2. Release blockers in flight
+
+Inspect open PRs and issues for:
+
+- risky web/runtime changes not yet settled
+- failing checks on branches likely to merge soon
+- unresolved release, deployment, smoke, security, or ops blockers
+
+### 3. Runbook alignment
+
+Confirm that the release checklist still matches observable repo reality:
+
+- key workflows mentioned by the runbook still exist
+- health and smoke references still look current
+- there is no obvious drift between the runbook and current workflow names or expectations
+
+### 4. Web trust-boundary risk
+
+If recent changes touch `apps/web/**`, `apps/web/src/app/api/**`, `packages/shared/**`, or `.github/workflows/**`,
+call out whether that increases release risk and why.
+
+## Output contract
+
+Create or update one issue titled:
+
+`[ops] Release readiness audit - YYYY-MM-DD`
+
+The body must contain:
+
+1. **Decision**: GO / NO-GO
+2. **Evidence reviewed**
+3. **Blocking items**
+4. **Non-blocking watch items**
+5. **Required pre-release checks still missing**
+6. **Recommended next action**
+
+## Decision rubric
+
+### GO
+Use GO only when:
+
+- recent critical workflows are green
+- no open blocker is obvious
+- runbook/workflow drift does not look material
+
+### NO-GO
+Use NO-GO if any of these are true:
+
+- critical workflow evidence is red or missing
+- preview/runtime risk is unresolved
+- active blocker issues or PR failures make a release unsafe
+- runbook drift makes the release process ambiguous
+
+## Allowed actions
+
+- inspect runs, PRs, issues, and local docs
+- create or update one release-readiness issue
+
+## Forbidden actions
+
+- do not deploy
+- do not merge
+- do not change workflow settings
+- do not push code
+
+## Final rule
+
+This is a control-tower audit, not a release bot. Be decisive, evidence-based, and explicit about missing proof.

--- a/.github/workflows/claude-routine-morning-ops.yml
+++ b/.github/workflows/claude-routine-morning-ops.yml
@@ -1,0 +1,45 @@
+name: Claude Routine - Morning Ops
+
+on:
+  schedule:
+    - cron: '15 13 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: read
+  id-token: write
+
+concurrency:
+  group: claude-routine-morning-ops
+  cancel-in-progress: true
+
+jobs:
+  morning-ops:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Morning Ops routine
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            REPO: ${{ github.repository }}
+            BRANCH: ${{ github.ref_name }}
+            EVENT: ${{ github.event_name }}
+
+            Read `.claude/routines/morning-ops-commander.md` and execute it exactly.
+            Use the routine file as the source of truth for behavior and limits.
+            This workflow is for triage only. Do not modify repository files.
+          claude_args: |
+            --max-turns 15
+            --allowedTools "Read,Bash(date:*),Bash(gh api:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(git log:*)"

--- a/.github/workflows/claude-routine-pr-web-risk-auditor.yml
+++ b/.github/workflows/claude-routine-pr-web-risk-auditor.yml
@@ -1,0 +1,55 @@
+name: Claude Routine - PR Web Risk Auditor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'apps/web/**'
+      - 'packages/shared/**'
+      - '.github/workflows/**'
+      - 'docs/runbooks/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'docs/ai/**'
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
+concurrency:
+  group: claude-routine-pr-web-risk-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR web-risk audit routine
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          additional_permissions: |
+            actions: read
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            BASE REF: ${{ github.base_ref }}
+            HEAD REF: ${{ github.head_ref }}
+
+            Read `.claude/routines/pr-web-risk-auditor.md` and execute it exactly.
+            Review only for concrete web/runtime/trust-boundary risk.
+            Do not push commits or modify repository files.
+          claude_args: |
+            --max-turns 18
+            --allowedTools "Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run list:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
Adds 4 Claude routine specs and 2 GitHub workflow runners for ops automation.

**Scope**: 7 new files in .claude/routines/ + .github/workflows/. +589 lines total, no existing files modified.

**Note**: Overlaps with claude/create-trading-app-routines-hhHyT (16 files, more comprehensive routines system with manifest.yaml + verifier). Reviewer: pick one; recommend the bigger one if both are aligned with your direction.

Auto-opened during repo cleanup on 2026-04-17.