### PR TITLE
fix(smoke): follow redirects in health-check.sh so canonical-host 308 resolves to 200

### DIFF
--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -65,9 +65,13 @@ check_service() {
 
     log_verbose "Checking ${url} (timeout ${TIMEOUT}s)..."
 
-    # Capture both status code and body; allow curl to fail without killing the script
+    # Capture both status code and body; allow curl to fail without killing the script.
+    # --location (-L) follows up to --max-redirs hops so we evaluate the FINAL response,
+    # which lets the canonical-host 308 redirect from proxy.ts (raw *.vercel.app → canonical
+    # host) and other safe redirects resolve to their real 200 destination instead of
+    # being treated as failures.
     local http_response
-    http_response=$(curl --silent --max-time "$TIMEOUT" "${BYPASS_ARGS[@]+"${BYPASS_ARGS[@]}"}" --write-out "\n%{http_code}" "$url" 2>&1) || true
+    http_response=$(curl --silent --location --max-redirs 5 --max-time "$TIMEOUT" "${BYPASS_ARGS[@]+"${BYPASS_ARGS[@]}"}" --write-out "\n%{http_code}" "$url" 2>&1) || true
 
     status_code=$(echo "$http_response" | tail -n1)
     body=$(echo "$http_response" | sed '$d')


### PR DESCRIPTION
## Problem

The Vercel Preview Smoke workflow has been failing on every push to main since the canonical-host redirect was added to apps/web/src/proxy.ts. Frontend root returns 308; engine/agents endpoints (proxied through Vercel) return 200, confirming bypass header works.

The 308 is the app's own canonical-host redirect at apps/web/src/proxy.ts:112. The smoke script issued curl without --location, so the 308 was treated as a failure.

## Fix

Add --location --max-redirs 5 to the curl call in check_service. Following redirects is the correct semantic for a synthetic uptime check.

## Why now

Surfaced during 2026-04-17 cleanup. The broken gate forced 2 admin-overrides (#355, #356). Restoring it removes that drift.