### PR TITLE
fix(deploy): make husky prepare script resilient for prod installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pre-pr:quick": "node scripts/pre-pr-check.mjs --quick",
     "validate:changed": "node scripts/validate-changed-scope.mjs",
     "worktree": "bash scripts/agent-worktree.sh",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",


### PR DESCRIPTION
## Root cause
Railway `sentinel-agents` deploys have been failing on every push that touches `apps/agents/` or `packages/shared/`. Build logs from failed deploy `fcc3fe89-4fd0-4f23-bdca-23a48853cfdc` (commit 062bc3a, PR #355) show:

```
info . prepare\$ husky
info . prepare: sh: husky: not found
info ELIFECYCLE Command failed.
error [prod-deps 6/6] RUN pnpm install --frozen-lockfile --prod --ignore-scripts && pnpm rebuild
```

The Dockerfile's prod-deps stage runs `pnpm install --prod` which strips devDependencies (including husky), but the root `prepare` script still fires and tries to invoke the missing husky binary.

## Fix
Change root `package.json` prepare from `"husky"` to `"husky || true"` — battle-tested pattern that no-ops when husky is unavailable (Docker/Railway/CI prod installs) while preserving normal local hook installation.

## Scope
1 file, +1/-1 line. Touches a protected file (`package.json`) — explicit user authorization to fix Railway deploy failures.

## Validation
- Build logs from Railway confirm the failure mode
- Pattern is the documented husky workaround for prod installs (https://typicode.github.io/husky/how-to.html#with-pinst-optional)
- After merge, next push to main that touches `apps/agents/` should redeploy clean
