### PR TITLE
fix(agents): move @opentelemetry/* to dependencies so prod containers can start

### DIFF
--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -16,6 +16,11 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.72.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+    "@opentelemetry/sdk-node": "^0.214.0",
+    "@opentelemetry/sdk-trace-node": "^2.6.1",
     "@sentinel/shared": "workspace:*",
     "@supabase/supabase-js": "^2.103.0",
     "cors": "^2.8.5",
@@ -26,11 +31,6 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.72.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
-    "@opentelemetry/sdk-node": "^0.214.0",
-    "@opentelemetry/sdk-trace-node": "^2.6.1",
     "@types/cors": "^2.8.17",
     "@types/express": "^5",
     "@types/node": "^25.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,21 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.88.0
         version: 0.88.0(zod@4.3.6)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/auto-instrumentations-node':
+        specifier: ^0.72.0
+        version: 0.72.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.214.0
+        version: 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.214.0
+        version: 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@sentinel/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -65,21 +80,6 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.1
-      '@opentelemetry/auto-instrumentations-node':
-        specifier: ^0.72.0
-        version: 0.72.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))
-      '@opentelemetry/exporter-trace-otlp-http':
-        specifier: ^0.214.0
-        version: 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-node':
-        specifier: ^0.214.0
-        version: 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node':
-        specifier: ^2.6.1
-        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -8677,7 +8677,7 @@ snapshots:
       eslint: 10.2.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.2.0(jiti@2.6.1))
@@ -8710,7 +8710,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8724,7 +8724,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Root cause
After PR #363 fixed the husky build error, Railway sentinel-agents builds **succeed** but containers crash on startup with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@opentelemetry/sdk-node' imported from /app/apps/agents/dist/telemetry.js
```

`apps/agents/src/index.ts:26` does `import { initTelemetry } from './telemetry.js'` at top level. `telemetry.js` statically imports four `@opentelemetry/*` packages, all of which were misclassified as devDependencies. The Dockerfile's `pnpm install --prod` strips them, so the import fails before `initTelemetry()` can check the `OTEL_ENABLED` env flag.

Verified across 4 consecutive failed deploys (b833a1f5, fcc3fe89, 01a949ec, 8934205d), all with the same ESM resolution trace.

## Fix
Move runtime OTel packages from devDependencies to dependencies:
- @opentelemetry/api
- @opentelemetry/auto-instrumentations-node
- @opentelemetry/exporter-trace-otlp-http
- @opentelemetry/sdk-node
- @opentelemetry/sdk-trace-node

@types/* and tooling stay in devDependencies.

## Scope
2 files (apps/agents/package.json + pnpm-lock.yaml). Touches a protected file (lockfile) — explicit user authorization to fix Railway runtime failures. Lockfile churn is mechanical (just relocates the entries).

## Validation
- Local `pnpm install --lockfile-only` succeeds (warnings are pre-existing peer mismatches)
- Once merged, Railway prod deploy will validate end-to-end
