### PR TITLE
[codex] Add deploy/runtime regression guards

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -51,24 +51,26 @@ _Last updated: 2026-04-18_
 
 > Brief entry per agent session. Most recent first.
 
-### 2026-05-15 — Codex (test gap detection: deploy/runtime package guards)
+### 2026-05-15 — Codex (test gap detection: deploy/runtime guards)
 
-**Goal**: Add a focused regression test for recent deploy/runtime fixes that landed without automated coverage.
+**Goal**: Add focused regression tests for recent deploy/runtime fixes that landed without automated coverage.
 
 **What changed**:
 
 - Added `scripts/runtime-package-contract.test.mjs` to lock two recent fixes in place:
   - root `prepare` stays `husky || true` for prod installs without Husky
   - agents OpenTelemetry imports remain in `dependencies`, not `devDependencies`
+- Added `scripts/health-check-redirect.test.mjs` to execute the real `scripts/health-check.sh` against a local 308 redirect and confirm it follows through to the final 200 response instead of failing early on the redirect status.
 
 **Validation**:
 
 - `node --test scripts/runtime-package-contract.test.mjs` ✅
+- `node --test scripts/health-check-redirect.test.mjs` ✅
 - `git diff --check` ✅
 - `pnpm --filter @sentinel/agents test -- runtime-package-contract.test.ts` could not run because this worktree does not have package-local `node_modules`
 - `pnpm --filter @sentinel/agents lint` is currently failing from the same missing-dependencies state plus pre-existing TypeScript issues in the worktree environment
 
-**Decisions**: Kept the test dependency-free under `node:test` instead of Vitest so it can run in this worktree without broad install/setup changes.
+**Decisions**: Kept the tests dependency-free under `node:test` instead of Vitest so they can run in this worktree without broad install/setup changes.
 
 ### 2026-04-18 — Claude (AI workflow playbooks)
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -51,6 +51,25 @@ _Last updated: 2026-04-18_
 
 > Brief entry per agent session. Most recent first.
 
+### 2026-05-15 — Codex (test gap detection: deploy/runtime package guards)
+
+**Goal**: Add a focused regression test for recent deploy/runtime fixes that landed without automated coverage.
+
+**What changed**:
+
+- Added `scripts/runtime-package-contract.test.mjs` to lock two recent fixes in place:
+  - root `prepare` stays `husky || true` for prod installs without Husky
+  - agents OpenTelemetry imports remain in `dependencies`, not `devDependencies`
+
+**Validation**:
+
+- `node --test scripts/runtime-package-contract.test.mjs` ✅
+- `git diff --check` ✅
+- `pnpm --filter @sentinel/agents test -- runtime-package-contract.test.ts` could not run because this worktree does not have package-local `node_modules`
+- `pnpm --filter @sentinel/agents lint` is currently failing from the same missing-dependencies state plus pre-existing TypeScript issues in the worktree environment
+
+**Decisions**: Kept the test dependency-free under `node:test` instead of Vitest so it can run in this worktree without broad install/setup changes.
+
 ### 2026-04-18 — Claude (AI workflow playbooks)
 
 **Goal**: Land the three "adopt now" doc deliverables from the April 2026 deep-research audit that Phases 1–4 (PRs #349–#352) did not cover.

--- a/scripts/health-check-redirect.test.mjs
+++ b/scripts/health-check-redirect.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+
+function startTestServer() {
+  const server = http.createServer((request, response) => {
+    switch (request.url) {
+      case '/redirect':
+        response.writeHead(308, { Location: '/ok' });
+        response.end('redirecting');
+        break;
+      case '/ok':
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ status: 'ok' }));
+        break;
+      default:
+        response.writeHead(404, { 'Content-Type': 'text/plain' });
+        response.end('not found');
+        break;
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Expected server to bind to a TCP port'));
+        return;
+      }
+
+      resolve({
+        close: () => new Promise((closeResolve, closeReject) => {
+          server.close((error) => {
+            if (error) {
+              closeReject(error);
+              return;
+            }
+            closeResolve();
+          });
+        }),
+        origin: `http://127.0.0.1:${address.port}`,
+      });
+    });
+  });
+}
+
+function runHealthCheck(env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', ['scripts/health-check.sh'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        ...env,
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once('error', reject);
+    child.once('close', (code) => {
+      resolve({ code, stderr, stdout });
+    });
+  });
+}
+
+test('health check follows canonical-host redirects before evaluating status', async () => {
+  const server = await startTestServer();
+
+  try {
+    const result = await runHealthCheck({
+      AGENTS_URL: `${server.origin}/ok`,
+      ENGINE_URL: `${server.origin}/ok`,
+      VERCEL_URL: `${server.origin}/redirect`,
+    });
+
+    assert.equal(result.code, 0, `Expected health check to pass.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+    assert.match(result.stdout, /Vercel Frontend\.\.\.\s+✓ UP/);
+    assert.match(result.stdout, /All services healthy/);
+  } finally {
+    await server.close();
+  }
+});

--- a/scripts/runtime-package-contract.test.mjs
+++ b/scripts/runtime-package-contract.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = process.cwd();
+
+function readJson(relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('root prepare script no-ops cleanly when husky is unavailable', () => {
+  const rootPackage = readJson('package.json');
+
+  assert.equal(rootPackage.scripts.prepare, 'husky || true');
+});
+
+test('agents telemetry runtime imports stay in dependencies', () => {
+  const telemetrySource = fs.readFileSync(
+    path.join(repoRoot, 'apps/agents/src/telemetry.ts'),
+    'utf8',
+  );
+  const agentsPackage = readJson('apps/agents/package.json');
+
+  const runtimeImports = [...telemetrySource.matchAll(/from '(@opentelemetry\/[^']+)'/g)].map(
+    ([, packageName]) => packageName,
+  );
+
+  assert.ok(runtimeImports.length > 0, 'Expected telemetry.ts to declare OpenTelemetry imports');
+
+  for (const packageName of runtimeImports) {
+    assert.ok(
+      agentsPackage.dependencies?.[packageName],
+      `${packageName} must remain in dependencies for prod installs`,
+    );
+    assert.equal(
+      packageName in (agentsPackage.devDependencies ?? {}),
+      false,
+      `${packageName} must not move back to devDependencies`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add dependency-free regression tests for recent deploy/runtime fixes
- assert the root `prepare` script stays `husky || true`
- assert OpenTelemetry imports used by `apps/agents/src/telemetry.ts` remain in `dependencies`
- execute the real `scripts/health-check.sh` against a local 308 redirect and verify it resolves to the final 200

## Why
Recent deploy fixes stopped production install and preview-smoke failures, but the changed paths still lacked narrow regression coverage. These tests lock those contracts without pulling broader app suites into scope.

## Scope
- `scripts/runtime-package-contract.test.mjs`
- `scripts/health-check-redirect.test.mjs`
- `WORKLOG.md`

## Validation
- `node --test scripts/runtime-package-contract.test.mjs` ✅
- `node --test scripts/health-check-redirect.test.mjs` ✅
- `git diff --check` ✅

## Coordination
- untracked audit
